### PR TITLE
feat: agent mode, extract/mount resources, mTLS support

### DIFF
--- a/src/apply.zig
+++ b/src/apply.zig
@@ -190,7 +190,8 @@ fn runWithBootstrap(comptime Impl: type, allocator: std.mem.Allocator, opts: App
 
     std.debug.print("\n", .{});
     // provision.run() will use its own ModernProvisionDisplay with spinner and will show section
-    try provision.run(allocator, .{ .script_path = script_path });
+    var prov_result = try provision.run(allocator, .{ .script_path = script_path });
+    defer prov_result.deinit(allocator);
 
     // Show log file location
     if (logger.getLogPath()) |log_file| {

--- a/src/base_resource.zig
+++ b/src/base_resource.zig
@@ -8,6 +8,7 @@ pub const ApplyResult = struct {
     was_updated: bool,
     action: []const u8,
     skip_reason: ?[]const u8 = null, // null means "up to date", non-null means skipped with reason
+    output: ?[]const u8 = null, // resource output: execute stdout/stderr, file/template diff, etc.
 };
 
 /// Common properties shared by all resources

--- a/src/commands.zig
+++ b/src/commands.zig
@@ -5,5 +5,6 @@ pub const link = @import("commands/link.zig");
 pub const apply = @import("commands/apply.zig");
 pub const provision = @import("commands/provision.zig");
 pub const node_info = @import("commands/node_info.zig");
+pub const agent = @import("commands/agent.zig");
 pub const applescript = if (builtin.os.tag == .macos) @import("commands/applescript.zig") else struct {};
 pub const dock = if (builtin.os.tag == .macos) @import("commands/dock.zig") else struct {};

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -1,0 +1,427 @@
+const std = @import("std");
+const clap = @import("clap");
+const http = @import("../http.zig");
+const sse = @import("../sse.zig");
+const provision_cmd = @import("provision.zig");
+const node_info = @import("../node_info.zig");
+
+const params = clap.parseParamsComptime(
+    \\-h, --help                 Show help for agent
+    \\-n, --node-name <NAME>     Node name (default: hostname)
+    \\-m, --mode <MODE>          Mode: sse (default) or watch
+    \\-i, --interval <SECONDS>   Watch polling interval in seconds (default: 10)
+    \\-c, --callback <URL>       Default callback URL (overridden by event)
+    \\<endpoint>                  Endpoint URL
+    \\
+);
+
+const parsers = .{
+    .endpoint = clap.parsers.string,
+    .URL = clap.parsers.string,
+    .NAME = clap.parsers.string,
+    .MODE = clap.parsers.string,
+    .SECONDS = clap.parsers.int(u32, 10),
+};
+
+const INITIAL_BACKOFF_MS: u64 = 1000;
+const MAX_BACKOFF_MS: u64 = 30_000;
+const DEFAULT_WATCH_INTERVAL: u32 = 10;
+
+// -- Shared task handling --
+
+/// Parse ISO 8601 UTC timestamp (e.g. "2026-03-11T12:00:00Z") to epoch seconds.
+fn parseIso8601(s: []const u8) !i64 {
+    if (s.len < 20) return error.InvalidFormat;
+    if (s[4] != '-' or s[7] != '-' or (s[10] != 'T' and s[10] != 't') or s[13] != ':' or s[16] != ':')
+        return error.InvalidFormat;
+
+    const year = std.fmt.parseInt(i32, s[0..4], 10) catch return error.InvalidFormat;
+    const month = std.fmt.parseInt(u8, s[5..7], 10) catch return error.InvalidFormat;
+    const day = std.fmt.parseInt(u8, s[8..10], 10) catch return error.InvalidFormat;
+    const hour = std.fmt.parseInt(u8, s[11..13], 10) catch return error.InvalidFormat;
+    const min = std.fmt.parseInt(u8, s[14..16], 10) catch return error.InvalidFormat;
+    const sec = std.fmt.parseInt(u8, s[17..19], 10) catch return error.InvalidFormat;
+
+    if (month < 1 or month > 12 or day < 1 or day > 31) return error.InvalidFormat;
+    if (hour > 23 or min > 59 or sec > 59) return error.InvalidFormat;
+
+    // Days from year 1970 to start of given year
+    var days: i64 = 0;
+    var y: i32 = 1970;
+    while (y < year) : (y += 1) {
+        days += if (@mod(y, 4) == 0 and (@mod(y, 100) != 0 or @mod(y, 400) == 0)) @as(i64, 366) else 365;
+    }
+
+    // Days from start of year to start of given month
+    const month_days = [_]u8{ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+    const leap: bool = @mod(year, 4) == 0 and (@mod(year, 100) != 0 or @mod(year, 400) == 0);
+    var m: u8 = 1;
+    while (m < month) : (m += 1) {
+        days += month_days[m - 1];
+        if (m == 2 and leap) days += 1;
+    }
+    days += day - 1;
+
+    return days * 86400 + @as(i64, hour) * 3600 + @as(i64, min) * 60 + sec;
+}
+
+fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callback: ?[]const u8) void {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch |err| {
+        std.debug.print("[agent] failed to parse task: {}\n", .{err});
+        return;
+    };
+    defer parsed.deinit();
+
+    if (parsed.value != .object) {
+        std.debug.print("[agent] task is not a JSON object\n", .{});
+        return;
+    }
+    const obj = parsed.value.object;
+
+    // Check expiration
+    if (obj.get("expires_at")) |ea| {
+        if (ea == .string) {
+            const now = std.time.timestamp();
+            const expires = parseIso8601(ea.string) catch |err| {
+                std.debug.print("[agent] invalid expires_at: {s} ({})\n", .{ ea.string, err });
+                return;
+            };
+            if (now > expires) {
+                std.debug.print("[agent] task expired (expires_at={s}), skipping\n", .{ea.string});
+                return;
+            }
+        }
+    }
+
+    const url_val = obj.get("url") orelse {
+        std.debug.print("[agent] task missing 'url' field\n", .{});
+        return;
+    };
+    if (url_val != .string) {
+        std.debug.print("[agent] 'url' field is not a string\n", .{});
+        return;
+    }
+    const url = url_val.string;
+
+    const callback_url = blk: {
+        if (obj.get("callback")) |v| {
+            if (v == .string) break :blk @as(?[]const u8, v.string);
+        }
+        break :blk default_callback;
+    };
+
+    std.debug.print("[agent] provisioning: {s}\n", .{url});
+
+    provision_cmd.runScript(allocator, url, false) catch |err| {
+        std.debug.print("[agent] provision failed: {}\n", .{err});
+        if (callback_url) |cb| {
+            sendCallback(allocator, cb, data, "error", @errorName(err));
+        }
+        return;
+    };
+
+    std.debug.print("[agent] provision complete\n", .{});
+    if (callback_url) |cb| {
+        sendCallback(allocator, cb, data, "ok", null);
+    }
+}
+
+fn buildCallbackBody(allocator: std.mem.Allocator, event_data: []const u8, status: []const u8, err_msg: ?[]const u8) ![]const u8 {
+    // Use arena for all intermediate JSON allocations; only the final string is duped to caller's allocator.
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, aa, event_data, .{});
+
+    var obj = parsed.value.object;
+
+    _ = obj.fetchSwapRemove("url");
+    _ = obj.fetchSwapRemove("callback");
+
+    var result = std.json.ObjectMap.init(aa);
+    try result.put("status", .{ .string = status });
+    if (err_msg) |msg| {
+        try result.put("error", .{ .string = msg });
+    }
+    try obj.put("result", .{ .object = result });
+
+    const node = node_info.getNodeInfo(aa) catch null;
+    if (node) |n| {
+        const node_json = try std.fmt.allocPrint(aa, "{f}", .{std.json.fmt(n, .{})});
+        const node_parsed = try std.json.parseFromSlice(std.json.Value, aa, node_json, .{});
+        const node_clone = try cloneJsonValue(aa, node_parsed.value);
+        try obj.put("node", node_clone);
+    }
+
+    const body = try std.fmt.allocPrint(aa, "{f}", .{std.json.fmt(std.json.Value{ .object = obj }, .{})});
+    return try allocator.dupe(u8, body);
+}
+
+fn cloneJsonValue(allocator: std.mem.Allocator, value: std.json.Value) !std.json.Value {
+    return switch (value) {
+        .null => .null,
+        .bool => |b| .{ .bool = b },
+        .integer => |i| .{ .integer = i },
+        .float => |f| .{ .float = f },
+        .number_string => |s| .{ .number_string = try allocator.dupe(u8, s) },
+        .string => |s| .{ .string = try allocator.dupe(u8, s) },
+        .array => |arr| blk: {
+            var new_arr = std.json.Array.init(allocator);
+            try new_arr.ensureTotalCapacity(arr.items.len);
+            for (arr.items) |item| {
+                try new_arr.append(try cloneJsonValue(allocator, item));
+            }
+            break :blk .{ .array = new_arr };
+        },
+        .object => |obj| blk: {
+            var new_obj = std.json.ObjectMap.init(allocator);
+            var it = obj.iterator();
+            while (it.next()) |entry| {
+                const key = try allocator.dupe(u8, entry.key_ptr.*);
+                const val = try cloneJsonValue(allocator, entry.value_ptr.*);
+                try new_obj.put(key, val);
+            }
+            break :blk .{ .object = new_obj };
+        },
+    };
+}
+
+fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_data: []const u8, status: []const u8, err_msg: ?[]const u8) void {
+    const body = buildCallbackBody(allocator, event_data, status, err_msg) catch |err| {
+        std.debug.print("[agent] failed to build callback body: {}\n", .{err});
+        return;
+    };
+    defer allocator.free(body);
+
+    std.debug.print("[agent] callback POST {s}\n", .{callback_url});
+
+    var resp = http.post(allocator, callback_url, .{
+        .body = body,
+        .headers = .{ .@"Content-Type" = "application/json" },
+    }) catch |err| {
+        std.debug.print("[agent] callback POST failed: {}\n", .{err});
+        return;
+    };
+    defer resp.deinit();
+
+    std.debug.print("[agent] callback response: {d}\n", .{resp.status});
+}
+
+// -- SSE mode --
+
+const SseContext = struct {
+    parser: *sse.Parser,
+    allocator: std.mem.Allocator,
+    default_callback: ?[]const u8,
+};
+
+fn sseStreamCallback(data: []const u8, context: *anyopaque) anyerror!usize {
+    const ctx: *SseContext = @ptrCast(@alignCast(context));
+    try ctx.parser.feed(data);
+    while (ctx.parser.next()) |ev| {
+        var event = ev;
+        defer event.deinit(ctx.allocator);
+        if (event.data) |event_data| {
+            handleTaskJson(ctx.allocator, event_data, ctx.default_callback);
+        }
+    }
+    return data.len;
+}
+
+fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8) void {
+    std.debug.print("[agent] SSE mode, node={s}, connecting to {s}\n", .{ node_name, endpoint });
+
+    var backoff_ms: u64 = INITIAL_BACKOFF_MS;
+    while (true) {
+        sseConnect(allocator, endpoint, node_name, default_callback) catch {
+            std.debug.print("[agent] reconnecting in {d}ms...\n", .{backoff_ms});
+            std.Thread.sleep(backoff_ms * std.time.ns_per_ms);
+            backoff_ms = @min(backoff_ms * 2, MAX_BACKOFF_MS);
+            continue;
+        };
+
+        backoff_ms = INITIAL_BACKOFF_MS;
+        std.debug.print("[agent] connection closed, reconnecting...\n", .{});
+    }
+}
+
+fn sseConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8) !void {
+    var parser = sse.Parser.init(allocator);
+    defer parser.deinit();
+
+    var ctx = SseContext{
+        .parser = &parser,
+        .allocator = allocator,
+        .default_callback = default_callback,
+    };
+
+    const cfg = http.Config{
+        .timeout_ms = 0,
+        .low_speed_limit = 0,
+        .low_speed_time = 0,
+    };
+    var client = try http.Client.init(allocator, cfg);
+    defer client.deinit();
+
+    var req = try http.Request.build(allocator, .GET, endpoint, .{
+        .headers = .{
+            .Accept = "text/event-stream",
+            .@"Cache-Control" = "no-cache",
+            .@"X-Hola-Node" = node_name,
+            .@"X-Hola-Platform" = node_info.getOs(),
+            .@"X-Hola-Arch" = node_info.getCpuArch(),
+        },
+    });
+    defer req.deinit();
+
+    var result = client.stream(req, sseStreamCallback, @ptrCast(&ctx), null, null) catch |err| {
+        std.debug.print("[agent] SSE connection error: {}\n", .{err});
+        return err;
+    };
+    // Free headers owned by StreamResult
+    var it = result.headers.iterator();
+    while (it.next()) |entry| {
+        allocator.free(entry.key_ptr.*);
+        allocator.free(entry.value_ptr.*);
+    }
+    result.headers.deinit();
+
+    if (result.status < 200 or result.status >= 300) {
+        std.debug.print("[agent] SSE server returned HTTP {d}\n", .{result.status});
+        return error.ConnectionFailed;
+    }
+}
+
+// -- Watch (polling) mode --
+
+fn runWatchMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, interval_s: u32, default_callback: ?[]const u8) void {
+    std.debug.print("[agent] watch mode, node={s}, polling {s} every {d}s\n", .{ node_name, endpoint, interval_s });
+
+    while (true) {
+        pollOnce(allocator, endpoint, node_name, default_callback);
+        std.Thread.sleep(@as(u64, interval_s) * std.time.ns_per_s);
+    }
+}
+
+fn pollOnce(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8) void {
+    var resp = http.request(allocator, .GET, endpoint, .{
+        .headers = .{
+            .@"X-Hola-Node" = node_name,
+            .@"X-Hola-Platform" = node_info.getOs(),
+            .@"X-Hola-Arch" = node_info.getCpuArch(),
+        },
+    }) catch |err| {
+        std.debug.print("[agent] poll failed: {}\n", .{err});
+        return;
+    };
+    defer resp.deinit();
+
+    if (resp.status < 200 or resp.status >= 300) {
+        std.debug.print("[agent] poll returned HTTP {d}\n", .{resp.status});
+        return;
+    }
+
+    if (resp.body.len == 0) return;
+
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, resp.body, .{}) catch |err| {
+        std.debug.print("[agent] failed to parse poll response: {}\n", .{err});
+        return;
+    };
+    defer parsed.deinit();
+
+    switch (parsed.value) {
+        .array => |arr| {
+            for (arr.items) |item| {
+                if (item != .object) continue;
+                const task_json = std.fmt.allocPrint(allocator, "{f}", .{std.json.fmt(item, .{})}) catch continue;
+                defer allocator.free(task_json);
+                handleTaskJson(allocator, task_json, default_callback);
+            }
+        },
+        .object => {
+            handleTaskJson(allocator, resp.body, default_callback);
+        },
+        else => {
+            std.debug.print("[agent] poll response is not a JSON object or array\n", .{});
+        },
+    }
+}
+
+// -- Entry point --
+
+fn getDefaultNodeName(allocator: std.mem.Allocator) []const u8 {
+    return node_info.getHostname(allocator) catch "unknown";
+}
+
+pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
+    var diag = clap.Diagnostic{};
+    var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
+        .allocator = allocator,
+        .diagnostic = &diag,
+    }) catch |err| {
+        try diag.reportToFile(std.fs.File.stderr(), err);
+        return;
+    };
+    defer res.deinit();
+
+    if (res.args.help != 0) return printHelp(null);
+
+    const endpoint = res.positionals[0] orelse return printHelp("Missing endpoint URL.");
+
+    const node_name = res.args.@"node-name" orelse getDefaultNodeName(allocator);
+    const default_callback = res.args.callback;
+    const interval = res.args.interval orelse DEFAULT_WATCH_INTERVAL;
+
+    const agent_mode = res.args.mode orelse "sse";
+    if (std.mem.eql(u8, agent_mode, "sse")) {
+        runSseMode(allocator, endpoint, node_name, default_callback);
+    } else if (std.mem.eql(u8, agent_mode, "watch")) {
+        runWatchMode(allocator, endpoint, node_name, interval, default_callback);
+    } else {
+        std.debug.print("Invalid mode: {s}\n", .{agent_mode});
+        std.debug.print("Valid modes: sse, watch\n", .{});
+        return error.InvalidMode;
+    }
+}
+
+fn printHelp(reason: ?[]const u8) !void {
+    const out = std.fs.File.stdout();
+    if (reason) |msg| {
+        try out.writeAll(msg);
+        try out.writeAll("\n\n");
+    }
+    try out.writeAll(
+        \\agent
+        \\  hola agent [OPTIONS] <endpoint>
+        \\
+        \\Connect to an endpoint and execute provision scripts as tasks arrive.
+        \\Supports SSE (streaming) and watch (polling) modes.
+        \\
+        \\Options:
+        \\  -n, --node-name NAME   Node name sent as X-Hola-Node header (default: hostname)
+        \\  -m, --mode MODE        Mode: sse (default) or watch
+        \\  -i, --interval SECS    Watch polling interval in seconds (default: 10)
+        \\  -c, --callback URL     Default callback URL (overridden by event payload)
+        \\
+        \\Task JSON Format:
+        \\  {"url": "https://r2.example.com/task.rb", "callback": "https://example.com/done", ...}
+        \\
+        \\  - url       (required) Provision script URL
+        \\  - callback  (optional) Callback URL for this task (overrides --callback)
+        \\  - ...       All other fields are passed through to callback
+        \\
+        \\Callback POST Body:
+        \\  Original fields (minus url/callback) + result + node info
+        \\  {"task_id": "abc", "result": {"status": "ok"}, "node": {"hostname": "...", ...}}
+        \\
+        \\SSE Mode (default):
+        \\  hola agent https://worker.example.com/events
+        \\  hola agent --node-name web-01 https://worker.example.com/events
+        \\
+        \\Watch Mode:
+        \\  hola agent --mode watch https://worker.example.com/pending
+        \\  hola agent --mode watch --interval 30 --node-name db-01 https://worker.example.com/pending
+        \\
+    );
+}

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -211,6 +211,9 @@ fn buildCallbackBody(allocator: std.mem.Allocator, event_data: []const u8, statu
             if (rr.error_name) |en| {
                 try res_obj.put("error", .{ .string = en });
             }
+            if (rr.output) |o| {
+                try res_obj.put("output", .{ .string = o });
+            }
             try resources_arr.append(.{ .object = res_obj });
         }
         try result.put("resources", .{ .array = resources_arr });

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const clap = @import("clap");
 const http = @import("../http.zig");
-const sse = @import("../sse.zig");
 const provision_cmd = @import("provision.zig");
 const provision = @import("../provision.zig");
 const node_info = @import("../node_info.zig");
@@ -283,35 +282,27 @@ fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_da
     std.debug.print("[agent] callback response: {d}\n", .{resp.status});
 }
 
-// -- SSE mode --
-
-const SseContext = struct {
-    parser: *sse.Parser,
-    allocator: std.mem.Allocator,
-    default_callback: ?[]const u8,
-};
-
-fn sseStreamCallback(data: []const u8, context: *anyopaque) anyerror!usize {
-    const ctx: *SseContext = @ptrCast(@alignCast(context));
-    try ctx.parser.feed(data);
-    while (ctx.parser.next()) |ev| {
-        var event = ev;
-        defer event.deinit(ctx.allocator);
-        if (event.data) |event_data| {
-            handleTaskJson(ctx.allocator, event_data, ctx.default_callback);
-        }
-    }
-    return data.len;
-}
+// -- WebSocket mode --
 
 fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8) void {
-    const display_endpoint = maskUrlPassword(allocator, endpoint);
-    defer if (display_endpoint.ptr != endpoint.ptr) allocator.free(display_endpoint);
-    std.debug.print("[agent] SSE mode, node={s}, connecting to {s}\n", .{ node_name, display_endpoint });
+    // Convert http(s) URL to ws(s) URL
+    const ws_endpoint = blk: {
+        if (std.mem.startsWith(u8, endpoint, "https://")) {
+            break :blk std.fmt.allocPrint(allocator, "wss://{s}", .{endpoint["https://".len..]}) catch endpoint;
+        } else if (std.mem.startsWith(u8, endpoint, "http://")) {
+            break :blk std.fmt.allocPrint(allocator, "ws://{s}", .{endpoint["http://".len..]}) catch endpoint;
+        }
+        break :blk endpoint;
+    };
+    defer if (ws_endpoint.ptr != endpoint.ptr) allocator.free(ws_endpoint);
+
+    const display_endpoint = maskUrlPassword(allocator, ws_endpoint);
+    defer if (display_endpoint.ptr != ws_endpoint.ptr) allocator.free(display_endpoint);
+    std.debug.print("[agent] node={s}, connecting to {s}\n", .{ node_name, display_endpoint });
 
     var backoff_ms: u64 = INITIAL_BACKOFF_MS;
     while (true) {
-        sseConnect(allocator, endpoint, node_name, default_callback) catch {
+        wsConnect(allocator, ws_endpoint, node_name, default_callback) catch {
             std.debug.print("[agent] reconnecting in {d}ms...\n", .{backoff_ms});
             std.Thread.sleep(backoff_ms * std.time.ns_per_ms);
             backoff_ms = @min(backoff_ms * 2, MAX_BACKOFF_MS);
@@ -323,50 +314,82 @@ fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []c
     }
 }
 
-fn sseConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8) !void {
-    var parser = sse.Parser.init(allocator);
-    defer parser.deinit();
+const WsContext = struct {
+    allocator: std.mem.Allocator,
+    default_callback: ?[]const u8,
+};
 
-    var ctx = SseContext{
-        .parser = &parser,
-        .allocator = allocator,
-        .default_callback = default_callback,
-    };
+fn wsWriteCallback(ptr: [*]const u8, size: usize, nmemb: usize, userdata: *anyopaque) callconv(.c) usize {
+    const ctx: *WsContext = @ptrCast(@alignCast(userdata));
+    const total = size * nmemb;
+    if (total == 0) return 0;
+    handleWsMessage(ctx.allocator, ptr[0..total], ctx.default_callback);
+    return total;
+}
 
-    const cfg = http.Config{
-        .timeout_ms = 0,
-        .low_speed_limit = 0,
-        .low_speed_time = 0,
-    };
-    var client = try http.Client.init(allocator, cfg);
-    defer client.deinit();
+fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8) !void {
+    const curl = @import("../curl.zig");
+    const handle = curl.curl_easy_init() orelse return error.ConnectionFailed;
+    defer curl.curl_easy_cleanup(handle);
 
-    var req = try http.Request.build(allocator, .GET, endpoint, .{
-        .headers = .{
-            .Accept = "text/event-stream",
-            .@"Cache-Control" = "no-cache",
-            .@"X-Hola-Node" = node_name,
-            .@"X-Hola-Platform" = node_info.getOs(),
-            .@"X-Hola-Arch" = node_info.getCpuArch(),
-        },
-    });
-    defer req.deinit();
+    const url_z = try allocator.dupeZ(u8, endpoint);
+    defer allocator.free(url_z);
+    _ = curl.curl_easy_setopt(handle, .CURLOPT_URL, url_z.ptr);
 
-    var result = client.stream(req, sseStreamCallback, @ptrCast(&ctx), null, null) catch |err| {
-        std.debug.print("[agent] SSE connection error: {}\n", .{err});
-        return err;
-    };
-    // Free headers owned by StreamResult
-    var it = result.headers.iterator();
-    while (it.next()) |entry| {
-        allocator.free(entry.key_ptr.*);
-        allocator.free(entry.value_ptr.*);
+    // Custom headers
+    var headers: ?*curl.curl_slist = null;
+    const node_header = try std.fmt.allocPrint(allocator, "X-Hola-Node: {s}\x00", .{node_name});
+    defer allocator.free(node_header);
+    headers = curl.curl_slist_append(headers, @ptrCast(node_header.ptr));
+    const platform_header = try std.fmt.allocPrint(allocator, "X-Hola-Platform: {s}\x00", .{node_info.getOs()});
+    defer allocator.free(platform_header);
+    headers = curl.curl_slist_append(headers, @ptrCast(platform_header.ptr));
+    const arch_header = try std.fmt.allocPrint(allocator, "X-Hola-Arch: {s}\x00", .{node_info.getCpuArch()});
+    defer allocator.free(arch_header);
+    headers = curl.curl_slist_append(headers, @ptrCast(arch_header.ptr));
+    if (headers) |h| {
+        _ = curl.curl_easy_setopt(handle, .CURLOPT_HTTPHEADER, h);
     }
-    result.headers.deinit();
+    defer if (headers) |h| curl.curl_slist_free_all(h);
 
-    if (result.status < 200 or result.status >= 300) {
-        std.debug.print("[agent] SSE server returned HTTP {d}\n", .{result.status});
+    // Write callback receives WebSocket text frame payloads
+    var ctx = WsContext{ .allocator = allocator, .default_callback = default_callback };
+    _ = curl.curl_easy_setopt(handle, .CURLOPT_WRITEFUNCTION, @as(curl.WriteCallback, @ptrCast(&wsWriteCallback)));
+    _ = curl.curl_easy_setopt(handle, .CURLOPT_WRITEDATA, @as(*anyopaque, @ptrCast(&ctx)));
+
+    // Perform WebSocket connection (blocks until closed)
+    const rc = curl.curl_easy_perform(handle);
+    if (rc != .CURLE_OK) {
+        const err_msg = curl.curl_easy_strerror(rc);
+        std.debug.print("[agent] WebSocket error: {s}\n", .{std.mem.span(err_msg)});
         return error.ConnectionFailed;
+    }
+}
+
+fn handleWsMessage(allocator: std.mem.Allocator, msg: []const u8, default_callback: ?[]const u8) void {
+    // Parse {"type": "task"|"snapshot-task", "data": {...}}
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, msg, .{}) catch |err| {
+        std.debug.print("[agent] failed to parse WS message: {}\n", .{err});
+        return;
+    };
+    defer parsed.deinit();
+
+    if (parsed.value != .object) return;
+    const obj = parsed.value.object;
+
+    const msg_type = blk: {
+        if (obj.get("type")) |v| {
+            if (v == .string) break :blk v.string;
+        }
+        break :blk "";
+    };
+
+    if (std.mem.eql(u8, msg_type, "task") or std.mem.eql(u8, msg_type, "snapshot-task")) {
+        if (obj.get("data")) |data_val| {
+            const task_json = std.fmt.allocPrint(allocator, "{f}", .{std.json.fmt(data_val, .{})}) catch return;
+            defer allocator.free(task_json);
+            handleTaskJson(allocator, task_json, default_callback);
+        }
     }
 }
 
@@ -452,14 +475,14 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
     const default_callback = res.args.callback;
     const interval = res.args.interval orelse DEFAULT_WATCH_INTERVAL;
 
-    const agent_mode = res.args.mode orelse "sse";
-    if (std.mem.eql(u8, agent_mode, "sse")) {
+    const agent_mode = res.args.mode orelse "ws";
+    if (std.mem.eql(u8, agent_mode, "ws") or std.mem.eql(u8, agent_mode, "sse")) {
         runSseMode(allocator, endpoint, node_name, default_callback);
     } else if (std.mem.eql(u8, agent_mode, "watch")) {
         runWatchMode(allocator, endpoint, node_name, interval, default_callback);
     } else {
         std.debug.print("Invalid mode: {s}\n", .{agent_mode});
-        std.debug.print("Valid modes: sse, watch\n", .{});
+        std.debug.print("Valid modes: ws, watch\n", .{});
         return error.InvalidMode;
     }
 }
@@ -475,11 +498,11 @@ fn printHelp(reason: ?[]const u8) !void {
         \\  hola agent [OPTIONS] <endpoint>
         \\
         \\Connect to an endpoint and execute provision scripts as tasks arrive.
-        \\Supports SSE (streaming) and watch (polling) modes.
+        \\Supports WebSocket (streaming) and watch (polling) modes.
         \\
         \\Options:
         \\  -n, --node-name NAME   Node name sent as X-Hola-Node header (default: hostname)
-        \\  -m, --mode MODE        Mode: sse (default) or watch
+        \\  -m, --mode MODE        Mode: ws (default) or watch
         \\  -i, --interval SECS    Watch polling interval in seconds (default: 10)
         \\  -c, --callback URL     Default callback URL (overridden by event payload)
         \\
@@ -494,9 +517,9 @@ fn printHelp(reason: ?[]const u8) !void {
         \\  Original fields (minus url/callback) + result + node info
         \\  {"task_id": "abc", "result": {"status": "ok"}, "node": {"hostname": "...", ...}}
         \\
-        \\SSE Mode (default):
-        \\  hola agent https://worker.example.com/events
-        \\  hola agent --node-name web-01 https://worker.example.com/events
+        \\WebSocket Mode (default):
+        \\  hola agent https://hub.example.com/nodes/mynode/events
+        \\  hola agent --node-name web-01 https://hub.example.com/nodes/web-01/events
         \\
         \\Watch Mode:
         \\  hola agent --mode watch https://worker.example.com/pending

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -3,6 +3,7 @@ const clap = @import("clap");
 const http = @import("../http.zig");
 const sse = @import("../sse.zig");
 const provision_cmd = @import("provision.zig");
+const provision = @import("../provision.zig");
 const node_info = @import("../node_info.zig");
 
 const params = clap.parseParamsComptime(
@@ -136,21 +137,22 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
 
     std.debug.print("[agent] task={s} action={s} provisioning: {s}\n", .{ task_id, action_name, url });
 
-    provision_cmd.runScript(allocator, url, false, params_json) catch |err| {
+    var prov_result = provision_cmd.runScript(allocator, url, false, params_json) catch |err| {
         std.debug.print("[agent] provision failed: {}\n", .{err});
         if (callback_url) |cb| {
-            sendCallback(allocator, cb, data, "error", @errorName(err));
+            sendCallback(allocator, cb, data, "error", @errorName(err), null);
         }
         return;
     };
+    defer prov_result.deinit(allocator);
 
     std.debug.print("[agent] provision complete\n", .{});
     if (callback_url) |cb| {
-        sendCallback(allocator, cb, data, "ok", null);
+        sendCallback(allocator, cb, data, "ok", null, &prov_result);
     }
 }
 
-fn buildCallbackBody(allocator: std.mem.Allocator, event_data: []const u8, status: []const u8, err_msg: ?[]const u8) ![]const u8 {
+fn buildCallbackBody(allocator: std.mem.Allocator, event_data: []const u8, status: []const u8, err_msg: ?[]const u8, prov_result: ?*const provision.ProvisionResult) ![]const u8 {
     // Use arena for all intermediate JSON allocations; only the final string is duped to caller's allocator.
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
@@ -168,6 +170,35 @@ fn buildCallbackBody(allocator: std.mem.Allocator, event_data: []const u8, statu
     if (err_msg) |msg| {
         try result.put("error", .{ .string = msg });
     }
+
+    if (prov_result) |pr| {
+        try result.put("executed", .{ .integer = @intCast(pr.executed_count) });
+        try result.put("updated", .{ .integer = @intCast(pr.updated_count) });
+        try result.put("skipped", .{ .integer = @intCast(pr.skipped_count) });
+        try result.put("failed", .{ .integer = @intCast(pr.failed_count) });
+        try result.put("duration_ms", .{ .integer = pr.duration_ms });
+
+        var resources_arr = std.json.Array.init(aa);
+        for (pr.resource_results.items) |rr| {
+            var res_obj = std.json.ObjectMap.init(aa);
+            try res_obj.put("type", .{ .string = rr.type_name });
+            try res_obj.put("name", .{ .string = rr.name });
+            try res_obj.put("action", .{ .string = rr.action });
+            try res_obj.put("updated", .{ .bool = rr.was_updated });
+            if (rr.skipped) {
+                try res_obj.put("skipped", .{ .bool = true });
+            }
+            if (rr.skip_reason) |sr| {
+                try res_obj.put("skip_reason", .{ .string = sr });
+            }
+            if (rr.error_name) |en| {
+                try res_obj.put("error", .{ .string = en });
+            }
+            try resources_arr.append(.{ .object = res_obj });
+        }
+        try result.put("resources", .{ .array = resources_arr });
+    }
+
     try obj.put("result", .{ .object = result });
 
     const node = node_info.getNodeInfo(aa) catch null;
@@ -211,8 +242,8 @@ fn cloneJsonValue(allocator: std.mem.Allocator, value: std.json.Value) !std.json
     };
 }
 
-fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_data: []const u8, status: []const u8, err_msg: ?[]const u8) void {
-    const body = buildCallbackBody(allocator, event_data, status, err_msg) catch |err| {
+fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_data: []const u8, status: []const u8, err_msg: ?[]const u8, prov_result: ?*const provision.ProvisionResult) void {
+    const body = buildCallbackBody(allocator, event_data, status, err_msg, prov_result) catch |err| {
         std.debug.print("[agent] failed to build callback body: {}\n", .{err});
         return;
     };
@@ -448,4 +479,77 @@ fn printHelp(reason: ?[]const u8) !void {
         \\  hola agent --mode watch --interval 30 --node-name db-01 https://worker.example.com/pending
         \\
     );
+}
+
+test "buildCallbackBody with ProvisionResult" {
+    const allocator = std.testing.allocator;
+
+    var resource_results = std.ArrayList(provision.ResourceResult).empty;
+    defer resource_results.deinit(allocator);
+
+    const type1 = try allocator.dupe(u8, "file");
+    const name1 = try allocator.dupe(u8, "/tmp/config");
+    const action1 = try allocator.dupe(u8, "create");
+    try resource_results.append(allocator, .{
+        .type_name = type1,
+        .name = name1,
+        .action = action1,
+        .was_updated = true,
+        .skipped = false,
+        .skip_reason = null,
+        .error_name = null,
+    });
+
+    const type2 = try allocator.dupe(u8, "execute");
+    const name2 = try allocator.dupe(u8, "reload");
+    const action2 = try allocator.dupe(u8, "run");
+    const skip2 = try allocator.dupe(u8, "up to date");
+    try resource_results.append(allocator, .{
+        .type_name = type2,
+        .name = name2,
+        .action = action2,
+        .was_updated = false,
+        .skipped = true,
+        .skip_reason = skip2,
+        .error_name = null,
+    });
+
+    var prov_result = provision.ProvisionResult{
+        .executed_count = 2,
+        .updated_count = 1,
+        .skipped_count = 1,
+        .failed_count = 0,
+        .duration_ms = 142,
+        .resource_results = resource_results,
+    };
+
+    const event_data =
+        \\{"id":"task-1","url":"https://example.com/script.rb","callback":"https://example.com/done"}
+    ;
+
+    const body = try buildCallbackBody(allocator, event_data, "ok", null, &prov_result);
+    defer allocator.free(body);
+
+    // Verify key fields exist in the JSON output
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"status\":\"ok\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"executed\":2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"updated\":1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"skipped\":1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"failed\":0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"duration_ms\":142") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"resources\":[") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"/tmp/config\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"skip_reason\":\"up to date\"") != null);
+    // url and callback should be removed
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"url\":") == null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"callback\":") == null);
+
+    // Free the duped strings
+    allocator.free(type1);
+    allocator.free(name1);
+    allocator.free(action1);
+    allocator.free(type2);
+    allocator.free(name2);
+    allocator.free(action2);
+    allocator.free(skip2);
 }

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -110,7 +110,19 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
         break :blk default_callback;
     };
 
-    std.debug.print("[agent] provisioning: {s}\n", .{url});
+    const task_id = blk: {
+        if (obj.get("id")) |v| {
+            if (v == .string) break :blk v.string;
+        }
+        break :blk "unknown";
+    };
+    const action_name = blk: {
+        if (obj.get("action")) |v| {
+            if (v == .string) break :blk v.string;
+        }
+        break :blk "unknown";
+    };
+    std.debug.print("[agent] task={s} action={s} provisioning: {s}\n", .{ task_id, action_name, url });
 
     provision_cmd.runScript(allocator, url, false) catch |err| {
         std.debug.print("[agent] provision failed: {}\n", .{err});

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -24,6 +24,21 @@ const parsers = .{
     .SECONDS = clap.parsers.int(u32, 10),
 };
 
+/// Return a display-safe URL with password masked as "***".
+/// If the URL has no password or parsing fails, returns the original string.
+fn maskUrlPassword(allocator: std.mem.Allocator, url: []const u8) []const u8 {
+    const uri = std.Uri.parse(url) catch return url;
+    if (uri.password == null) return url;
+    const user_part = if (uri.user) |u| u.percent_encoded else "";
+    const host_part = if (uri.host) |h| h.percent_encoded else "";
+    return std.fmt.allocPrint(allocator, "{s}://{s}:***@{s}{s}", .{
+        uri.scheme,
+        user_part,
+        host_part,
+        uri.path.percent_encoded,
+    }) catch url;
+}
+
 const INITIAL_BACKOFF_MS: u64 = 1000;
 const MAX_BACKOFF_MS: u64 = 30_000;
 const DEFAULT_WATCH_INTERVAL: u32 = 10;
@@ -135,7 +150,9 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
     };
     defer if (params_json) |p| allocator.free(p);
 
-    std.debug.print("[agent] task={s} action={s} provisioning: {s}\n", .{ task_id, action_name, url });
+    const display_url = maskUrlPassword(allocator, url);
+    defer if (display_url.ptr != url.ptr) allocator.free(display_url);
+    std.debug.print("[agent] task={s} action={s} provisioning: {s}\n", .{ task_id, action_name, display_url });
 
     var prov_result = provision_cmd.runScript(allocator, url, false, params_json) catch |err| {
         std.debug.print("[agent] provision failed: {}\n", .{err});
@@ -285,7 +302,9 @@ fn sseStreamCallback(data: []const u8, context: *anyopaque) anyerror!usize {
 }
 
 fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8) void {
-    std.debug.print("[agent] SSE mode, node={s}, connecting to {s}\n", .{ node_name, endpoint });
+    const display_endpoint = maskUrlPassword(allocator, endpoint);
+    defer if (display_endpoint.ptr != endpoint.ptr) allocator.free(display_endpoint);
+    std.debug.print("[agent] SSE mode, node={s}, connecting to {s}\n", .{ node_name, display_endpoint });
 
     var backoff_ms: u64 = INITIAL_BACKOFF_MS;
     while (true) {
@@ -351,7 +370,9 @@ fn sseConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []c
 // -- Watch (polling) mode --
 
 fn runWatchMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, interval_s: u32, default_callback: ?[]const u8) void {
-    std.debug.print("[agent] watch mode, node={s}, polling {s} every {d}s\n", .{ node_name, endpoint, interval_s });
+    const display_endpoint = maskUrlPassword(allocator, endpoint);
+    defer if (display_endpoint.ptr != endpoint.ptr) allocator.free(display_endpoint);
+    std.debug.print("[agent] watch mode, node={s}, polling {s} every {d}s\n", .{ node_name, display_endpoint, interval_s });
 
     while (true) {
         pollOnce(allocator, endpoint, node_name, default_callback);

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -8,9 +8,11 @@ const node_info = @import("../node_info.zig");
 const params = clap.parseParamsComptime(
     \\-h, --help                 Show help for agent
     \\-n, --node-name <NAME>     Node name (default: hostname)
-    \\-m, --mode <MODE>          Mode: sse (default) or watch
+    \\-m, --mode <MODE>          Mode: ws (default) or watch
     \\-i, --interval <SECONDS>   Watch polling interval in seconds (default: 10)
     \\-c, --callback <URL>       Default callback URL (overridden by event)
+    \\    --client-cert <PATH>   Client certificate for mTLS
+    \\    --client-key <PATH>    Client private key for mTLS
     \\<endpoint>                  Endpoint URL
     \\
 );
@@ -20,6 +22,7 @@ const parsers = .{
     .URL = clap.parsers.string,
     .NAME = clap.parsers.string,
     .MODE = clap.parsers.string,
+    .PATH = clap.parsers.string,
     .SECONDS = clap.parsers.int(u32, 10),
 };
 
@@ -36,6 +39,31 @@ fn maskUrlPassword(allocator: std.mem.Allocator, url: []const u8) []const u8 {
         host_part,
         uri.path.percent_encoded,
     }) catch url;
+}
+
+const TlsClientAuth = struct {
+    cert: ?[]const u8 = null,
+    key: ?[]const u8 = null,
+};
+
+fn effectivePort(uri: std.Uri) u16 {
+    if (uri.port) |p| return p;
+    if (std.mem.eql(u8, uri.scheme, "https") or std.mem.eql(u8, uri.scheme, "wss")) return 443;
+    if (std.mem.eql(u8, uri.scheme, "http") or std.mem.eql(u8, uri.scheme, "ws")) return 80;
+    return 0;
+}
+
+fn originMatches(url_a: []const u8, url_b: []const u8) bool {
+    const uri_a = std.Uri.parse(url_a) catch return false;
+    const uri_b = std.Uri.parse(url_b) catch return false;
+    const host_a = if (uri_a.host) |h| h.percent_encoded else return false;
+    const host_b = if (uri_b.host) |h| h.percent_encoded else return false;
+    if (!std.mem.eql(u8, host_a, host_b)) return false;
+    if (effectivePort(uri_a) != effectivePort(uri_b)) return false;
+    // Treat https/wss and http/ws as equivalent scheme pairs
+    const secure_a = std.mem.eql(u8, uri_a.scheme, "https") or std.mem.eql(u8, uri_a.scheme, "wss");
+    const secure_b = std.mem.eql(u8, uri_b.scheme, "https") or std.mem.eql(u8, uri_b.scheme, "wss");
+    return secure_a == secure_b;
 }
 
 const INITIAL_BACKOFF_MS: u64 = 1000;
@@ -80,7 +108,7 @@ fn parseIso8601(s: []const u8) !i64 {
     return days * 86400 + @as(i64, hour) * 3600 + @as(i64, min) * 60 + sec;
 }
 
-fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callback: ?[]const u8) void {
+fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callback: ?[]const u8, endpoint: []const u8, tls_auth: TlsClientAuth) void {
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch |err| {
         std.debug.print("[agent] failed to parse task: {}\n", .{err});
         return;
@@ -156,7 +184,7 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
     var prov_result = provision_cmd.runScript(allocator, url, false, params_json) catch |err| {
         std.debug.print("[agent] provision failed: {}\n", .{err});
         if (callback_url) |cb| {
-            sendCallback(allocator, cb, data, "error", @errorName(err), null);
+            sendCallback(allocator, cb, data, "error", @errorName(err), null, endpoint, tls_auth);
         }
         return;
     };
@@ -164,7 +192,7 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
 
     std.debug.print("[agent] provision complete\n", .{});
     if (callback_url) |cb| {
-        sendCallback(allocator, cb, data, "ok", null, &prov_result);
+        sendCallback(allocator, cb, data, "ok", null, &prov_result, endpoint, tls_auth);
     }
 }
 
@@ -261,7 +289,7 @@ fn cloneJsonValue(allocator: std.mem.Allocator, value: std.json.Value) !std.json
     };
 }
 
-fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_data: []const u8, status: []const u8, err_msg: ?[]const u8, prov_result: ?*const provision.ProvisionResult) void {
+fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_data: []const u8, status: []const u8, err_msg: ?[]const u8, prov_result: ?*const provision.ProvisionResult, endpoint: []const u8, tls_auth: TlsClientAuth) void {
     const body = buildCallbackBody(allocator, event_data, status, err_msg, prov_result) catch |err| {
         std.debug.print("[agent] failed to build callback body: {}\n", .{err});
         return;
@@ -270,10 +298,28 @@ fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_da
 
     std.debug.print("[agent] callback POST {s}\n", .{callback_url});
 
-    var resp = http.post(allocator, callback_url, .{
+    // Use mTLS if callback host matches endpoint host
+    const use_tls_auth = originMatches(callback_url, endpoint);
+    const cfg = http.Config{
+        .client_cert = if (use_tls_auth) tls_auth.cert else null,
+        .client_key = if (use_tls_auth) tls_auth.key else null,
+    };
+    var client = http.Client.init(allocator, cfg) catch |err| {
+        std.debug.print("[agent] failed to init HTTP client: {}\n", .{err});
+        return;
+    };
+    defer client.deinit();
+
+    var req = http.Request.build(allocator, .POST, callback_url, .{
         .body = body,
         .headers = .{ .@"Content-Type" = "application/json" },
     }) catch |err| {
+        std.debug.print("[agent] failed to build request: {}\n", .{err});
+        return;
+    };
+    defer req.deinit();
+
+    var resp = client.request(req) catch |err| {
         std.debug.print("[agent] callback POST failed: {}\n", .{err});
         return;
     };
@@ -284,7 +330,7 @@ fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_da
 
 // -- WebSocket mode --
 
-fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8) void {
+fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8, tls_auth: TlsClientAuth) void {
     // Convert http(s) URL to ws(s) URL
     const ws_endpoint = blk: {
         if (std.mem.startsWith(u8, endpoint, "https://")) {
@@ -302,7 +348,7 @@ fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []c
 
     var backoff_ms: u64 = INITIAL_BACKOFF_MS;
     while (true) {
-        wsConnect(allocator, ws_endpoint, node_name, default_callback) catch {
+        wsConnect(allocator, ws_endpoint, node_name, default_callback, tls_auth) catch {
             std.debug.print("[agent] reconnecting in {d}ms...\n", .{backoff_ms});
             std.Thread.sleep(backoff_ms * std.time.ns_per_ms);
             backoff_ms = @min(backoff_ms * 2, MAX_BACKOFF_MS);
@@ -317,17 +363,19 @@ fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []c
 const WsContext = struct {
     allocator: std.mem.Allocator,
     default_callback: ?[]const u8,
+    endpoint: []const u8,
+    tls_auth: TlsClientAuth,
 };
 
 fn wsWriteCallback(ptr: [*]const u8, size: usize, nmemb: usize, userdata: *anyopaque) callconv(.c) usize {
     const ctx: *WsContext = @ptrCast(@alignCast(userdata));
     const total = size * nmemb;
     if (total == 0) return 0;
-    handleWsMessage(ctx.allocator, ptr[0..total], ctx.default_callback);
+    handleWsMessage(ctx.allocator, ptr[0..total], ctx.default_callback, ctx.endpoint, ctx.tls_auth);
     return total;
 }
 
-fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8) !void {
+fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8, tls_auth: TlsClientAuth) !void {
     const curl = @import("../curl.zig");
     const handle = curl.curl_easy_init() orelse return error.ConnectionFailed;
     defer curl.curl_easy_cleanup(handle);
@@ -335,6 +383,18 @@ fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []co
     const url_z = try allocator.dupeZ(u8, endpoint);
     defer allocator.free(url_z);
     _ = curl.curl_easy_setopt(handle, .CURLOPT_URL, url_z.ptr);
+
+    // mTLS client certificate
+    if (tls_auth.cert) |cert| {
+        const cert_z = try allocator.dupeZ(u8, cert);
+        defer allocator.free(cert_z);
+        _ = curl.curl_easy_setopt(handle, .CURLOPT_SSLCERT, cert_z.ptr);
+    }
+    if (tls_auth.key) |key| {
+        const key_z = try allocator.dupeZ(u8, key);
+        defer allocator.free(key_z);
+        _ = curl.curl_easy_setopt(handle, .CURLOPT_SSLKEY, key_z.ptr);
+    }
 
     // Custom headers
     var headers: ?*curl.curl_slist = null;
@@ -353,7 +413,7 @@ fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []co
     defer if (headers) |h| curl.curl_slist_free_all(h);
 
     // Write callback receives WebSocket text frame payloads
-    var ctx = WsContext{ .allocator = allocator, .default_callback = default_callback };
+    var ctx = WsContext{ .allocator = allocator, .default_callback = default_callback, .endpoint = endpoint, .tls_auth = tls_auth };
     _ = curl.curl_easy_setopt(handle, .CURLOPT_WRITEFUNCTION, @as(curl.WriteCallback, @ptrCast(&wsWriteCallback)));
     _ = curl.curl_easy_setopt(handle, .CURLOPT_WRITEDATA, @as(*anyopaque, @ptrCast(&ctx)));
 
@@ -366,7 +426,7 @@ fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []co
     }
 }
 
-fn handleWsMessage(allocator: std.mem.Allocator, msg: []const u8, default_callback: ?[]const u8) void {
+fn handleWsMessage(allocator: std.mem.Allocator, msg: []const u8, default_callback: ?[]const u8, endpoint: []const u8, tls_auth: TlsClientAuth) void {
     // Parse {"type": "task"|"snapshot-task", "data": {...}}
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, msg, .{}) catch |err| {
         std.debug.print("[agent] failed to parse WS message: {}\n", .{err});
@@ -388,32 +448,48 @@ fn handleWsMessage(allocator: std.mem.Allocator, msg: []const u8, default_callba
         if (obj.get("data")) |data_val| {
             const task_json = std.fmt.allocPrint(allocator, "{f}", .{std.json.fmt(data_val, .{})}) catch return;
             defer allocator.free(task_json);
-            handleTaskJson(allocator, task_json, default_callback);
+            handleTaskJson(allocator, task_json, default_callback, endpoint, tls_auth);
         }
     }
 }
 
 // -- Watch (polling) mode --
 
-fn runWatchMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, interval_s: u32, default_callback: ?[]const u8) void {
+fn runWatchMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, interval_s: u32, default_callback: ?[]const u8, tls_auth: TlsClientAuth) void {
     const display_endpoint = maskUrlPassword(allocator, endpoint);
     defer if (display_endpoint.ptr != endpoint.ptr) allocator.free(display_endpoint);
     std.debug.print("[agent] watch mode, node={s}, polling {s} every {d}s\n", .{ node_name, display_endpoint, interval_s });
 
     while (true) {
-        pollOnce(allocator, endpoint, node_name, default_callback);
+        pollOnce(allocator, endpoint, node_name, default_callback, tls_auth);
         std.Thread.sleep(@as(u64, interval_s) * std.time.ns_per_s);
     }
 }
 
-fn pollOnce(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8) void {
-    var resp = http.request(allocator, .GET, endpoint, .{
+fn pollOnce(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8, tls_auth: TlsClientAuth) void {
+    const cfg = http.Config{
+        .client_cert = tls_auth.cert,
+        .client_key = tls_auth.key,
+    };
+    var client = http.Client.init(allocator, cfg) catch |err| {
+        std.debug.print("[agent] failed to init HTTP client: {}\n", .{err});
+        return;
+    };
+    defer client.deinit();
+
+    var req = http.Request.build(allocator, .GET, endpoint, .{
         .headers = .{
             .@"X-Hola-Node" = node_name,
             .@"X-Hola-Platform" = node_info.getOs(),
             .@"X-Hola-Arch" = node_info.getCpuArch(),
         },
     }) catch |err| {
+        std.debug.print("[agent] failed to build request: {}\n", .{err});
+        return;
+    };
+    defer req.deinit();
+
+    var resp = client.request(req) catch |err| {
         std.debug.print("[agent] poll failed: {}\n", .{err});
         return;
     };
@@ -438,11 +514,11 @@ fn pollOnce(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []con
                 if (item != .object) continue;
                 const task_json = std.fmt.allocPrint(allocator, "{f}", .{std.json.fmt(item, .{})}) catch continue;
                 defer allocator.free(task_json);
-                handleTaskJson(allocator, task_json, default_callback);
+                handleTaskJson(allocator, task_json, default_callback, endpoint, tls_auth);
             }
         },
         .object => {
-            handleTaskJson(allocator, resp.body, default_callback);
+            handleTaskJson(allocator, resp.body, default_callback, endpoint, tls_auth);
         },
         else => {
             std.debug.print("[agent] poll response is not a JSON object or array\n", .{});
@@ -474,12 +550,16 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
     const node_name = res.args.@"node-name" orelse getDefaultNodeName(allocator);
     const default_callback = res.args.callback;
     const interval = res.args.interval orelse DEFAULT_WATCH_INTERVAL;
+    const tls_auth = TlsClientAuth{
+        .cert = res.args.@"client-cert",
+        .key = res.args.@"client-key",
+    };
 
     const agent_mode = res.args.mode orelse "ws";
     if (std.mem.eql(u8, agent_mode, "ws") or std.mem.eql(u8, agent_mode, "sse")) {
-        runSseMode(allocator, endpoint, node_name, default_callback);
+        runSseMode(allocator, endpoint, node_name, default_callback, tls_auth);
     } else if (std.mem.eql(u8, agent_mode, "watch")) {
-        runWatchMode(allocator, endpoint, node_name, interval, default_callback);
+        runWatchMode(allocator, endpoint, node_name, interval, default_callback, tls_auth);
     } else {
         std.debug.print("Invalid mode: {s}\n", .{agent_mode});
         std.debug.print("Valid modes: ws, watch\n", .{});
@@ -501,10 +581,12 @@ fn printHelp(reason: ?[]const u8) !void {
         \\Supports WebSocket (streaming) and watch (polling) modes.
         \\
         \\Options:
-        \\  -n, --node-name NAME   Node name sent as X-Hola-Node header (default: hostname)
-        \\  -m, --mode MODE        Mode: ws (default) or watch
-        \\  -i, --interval SECS    Watch polling interval in seconds (default: 10)
-        \\  -c, --callback URL     Default callback URL (overridden by event payload)
+        \\  -n, --node-name NAME     Node name sent as X-Hola-Node header (default: hostname)
+        \\  -m, --mode MODE          Mode: ws (default) or watch
+        \\  -i, --interval SECS      Watch polling interval in seconds (default: 10)
+        \\  -c, --callback URL       Default callback URL (overridden by event payload)
+        \\      --client-cert PATH   Client certificate for mTLS (PEM)
+        \\      --client-key PATH    Client private key for mTLS (PEM)
         \\
         \\Task JSON Format:
         \\  {"url": "https://r2.example.com/task.rb", "callback": "https://example.com/done", ...}
@@ -599,4 +681,32 @@ test "buildCallbackBody with ProvisionResult" {
     allocator.free(name2);
     allocator.free(action2);
     allocator.free(skip2);
+}
+
+test "originMatches same origin" {
+    try std.testing.expect(originMatches("https://hub.example.com/events", "https://hub.example.com/callback"));
+}
+
+test "originMatches implicit vs explicit port 443" {
+    try std.testing.expect(originMatches("https://hub.example.com/a", "https://hub.example.com:443/b"));
+}
+
+test "originMatches wss equals https" {
+    try std.testing.expect(originMatches("wss://hub.example.com:443/ws", "https://hub.example.com/callback"));
+}
+
+test "originMatches different port" {
+    try std.testing.expect(!originMatches("https://hub.example.com/a", "https://hub.example.com:8443/b"));
+}
+
+test "originMatches https vs http" {
+    try std.testing.expect(!originMatches("https://hub.example.com/a", "http://hub.example.com/b"));
+}
+
+test "originMatches different host" {
+    try std.testing.expect(!originMatches("https://a.example.com/x", "https://b.example.com/x"));
+}
+
+test "originMatches invalid url" {
+    try std.testing.expect(!originMatches("not-a-url", "https://hub.example.com/x"));
 }

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -303,6 +303,7 @@ fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_da
     const cfg = http.Config{
         .client_cert = if (use_tls_auth) tls_auth.cert else null,
         .client_key = if (use_tls_auth) tls_auth.key else null,
+        .retry = .{ .max_attempts = 3, .initial_backoff_ms = 1000 },
     };
     var client = http.Client.init(allocator, cfg) catch |err| {
         std.debug.print("[agent] failed to init HTTP client: {}\n", .{err});

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -122,9 +122,21 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
         }
         break :blk "unknown";
     };
+    // Extract params field as JSON string for data_bag injection
+    const params_json: ?[]const u8 = blk: {
+        if (obj.get("params")) |v| {
+            if (v == .object) {
+                const json_str = std.fmt.allocPrint(allocator, "{f}", .{std.json.fmt(v, .{})}) catch break :blk null;
+                break :blk json_str;
+            }
+        }
+        break :blk null;
+    };
+    defer if (params_json) |p| allocator.free(p);
+
     std.debug.print("[agent] task={s} action={s} provisioning: {s}\n", .{ task_id, action_name, url });
 
-    provision_cmd.runScript(allocator, url, false) catch |err| {
+    provision_cmd.runScript(allocator, url, false, params_json) catch |err| {
         std.debug.print("[agent] provision failed: {}\n", .{err});
         if (callback_url) |cb| {
             sendCallback(allocator, cb, data, "error", @errorName(err));

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -137,8 +137,12 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
         }
     }
 
+    const logger = @import("../logger.zig");
     var result = runScript(allocator, script_path_or_url, use_pretty_output, res.args.params) catch |err| {
         std.debug.print("Provision failed: {}\n", .{err});
+        if (logger.getLogPath()) |log_path| {
+            std.debug.print("Log file: {s}\n", .{log_path});
+        }
         return;
     };
     defer result.deinit(allocator);

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -6,6 +6,7 @@ const http = @import("../http.zig");
 const params = clap.parseParamsComptime(
     \\-h, --help            Show help for provision
     \\-o, --output <MODE>   Output mode: pretty (default) or plain
+    \\-p, --params <JSON>   JSON string to inject as data_bag
     \\<path>                Path to provision file (.rb)
     \\
 );
@@ -13,11 +14,13 @@ const params = clap.parseParamsComptime(
 const parsers = .{
     .path = clap.parsers.string,
     .MODE = clap.parsers.string,
+    .JSON = clap.parsers.string,
 };
 
 /// Download a remote script to a temp file, run provision, then clean up.
 /// Accepts both local paths and HTTP(S) URLs.
-pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, use_pretty_output: bool) !void {
+/// params_json: optional JSON string to inject as data_bag (agent mode).
+pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, use_pretty_output: bool, params_json: ?[]const u8) !void {
     const is_url = std.mem.startsWith(u8, script_path_or_url, "http://") or
         std.mem.startsWith(u8, script_path_or_url, "https://");
 
@@ -102,6 +105,7 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, u
     try provision.run(allocator, .{
         .script_path = script_path,
         .use_pretty_output = use_pretty_output,
+        .params_json = params_json,
     });
 }
 
@@ -133,7 +137,7 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
         }
     }
 
-    runScript(allocator, script_path_or_url, use_pretty_output) catch |err| {
+    runScript(allocator, script_path_or_url, use_pretty_output, res.args.params) catch |err| {
         std.debug.print("Provision failed: {}\n", .{err});
     };
 }

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -15,34 +15,9 @@ const parsers = .{
     .MODE = clap.parsers.string,
 };
 
-pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
-    var diag = clap.Diagnostic{};
-    var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
-        .allocator = allocator,
-        .diagnostic = &diag,
-    }) catch |err| {
-        try diag.reportToFile(std.fs.File.stderr(), err);
-        return;
-    };
-    defer res.deinit();
-
-    if (res.args.help != 0) return printHelp(null);
-
-    const script_path_or_url = res.positionals[0] orelse return printHelp("Missing provision file path or URL.");
-
-    var use_pretty_output = true;
-    if (res.args.output) |output_mode| {
-        if (std.mem.eql(u8, output_mode, "plain")) {
-            use_pretty_output = false;
-        } else if (std.mem.eql(u8, output_mode, "pretty")) {
-            use_pretty_output = true;
-        } else {
-            std.debug.print("Invalid output mode: {s}\n", .{output_mode});
-            std.debug.print("Valid modes: pretty, plain\n", .{});
-            return error.InvalidOutputMode;
-        }
-    }
-
+/// Download a remote script to a temp file, run provision, then clean up.
+/// Accepts both local paths and HTTP(S) URLs.
+pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, use_pretty_output: bool) !void {
     const is_url = std.mem.startsWith(u8, script_path_or_url, "http://") or
         std.mem.startsWith(u8, script_path_or_url, "https://");
 
@@ -76,7 +51,10 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
             try allocator.dupe(u8, "/tmp");
         defer allocator.free(temp_dir);
 
-        const temp_file = try std.fmt.allocPrint(allocator, "{s}/provision-{d}.rb", .{ temp_dir, std.time.timestamp() });
+        var rand_buf: [8]u8 = undefined;
+        std.crypto.random.bytes(&rand_buf);
+        const rand_hex = std.fmt.bytesToHex(rand_buf, .lower);
+        const temp_file = try std.fmt.allocPrint(allocator, "{s}/provision-{d}-{s}.rb", .{ temp_dir, std.time.timestamp(), &rand_hex });
         temp_file_path = temp_file;
 
         const cfg = http.Config{};
@@ -113,7 +91,7 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
             return error.DownloadFailed;
         }
 
-        const file = try std.fs.cwd().createFile(temp_file, .{});
+        const file = try std.fs.cwd().createFile(temp_file, .{ .exclusive = true });
         defer file.close();
         try file.writeAll(response.body);
 
@@ -121,10 +99,41 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
         break :blk temp_file;
     } else script_path_or_url;
 
-    provision.run(allocator, .{
+    try provision.run(allocator, .{
         .script_path = script_path,
         .use_pretty_output = use_pretty_output,
+    });
+}
+
+pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
+    var diag = clap.Diagnostic{};
+    var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
+        .allocator = allocator,
+        .diagnostic = &diag,
     }) catch |err| {
+        try diag.reportToFile(std.fs.File.stderr(), err);
+        return;
+    };
+    defer res.deinit();
+
+    if (res.args.help != 0) return printHelp(null);
+
+    const script_path_or_url = res.positionals[0] orelse return printHelp("Missing provision file path or URL.");
+
+    var use_pretty_output = true;
+    if (res.args.output) |output_mode| {
+        if (std.mem.eql(u8, output_mode, "plain")) {
+            use_pretty_output = false;
+        } else if (std.mem.eql(u8, output_mode, "pretty")) {
+            use_pretty_output = true;
+        } else {
+            std.debug.print("Invalid output mode: {s}\n", .{output_mode});
+            std.debug.print("Valid modes: pretty, plain\n", .{});
+            return error.InvalidOutputMode;
+        }
+    }
+
+    runScript(allocator, script_path_or_url, use_pretty_output) catch |err| {
         std.debug.print("Provision failed: {}\n", .{err});
     };
 }

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -20,7 +20,7 @@ const parsers = .{
 /// Download a remote script to a temp file, run provision, then clean up.
 /// Accepts both local paths and HTTP(S) URLs.
 /// params_json: optional JSON string to inject as data_bag (agent mode).
-pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, use_pretty_output: bool, params_json: ?[]const u8) !void {
+pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, use_pretty_output: bool, params_json: ?[]const u8) !provision.ProvisionResult {
     const is_url = std.mem.startsWith(u8, script_path_or_url, "http://") or
         std.mem.startsWith(u8, script_path_or_url, "https://");
 
@@ -102,7 +102,7 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, u
         break :blk temp_file;
     } else script_path_or_url;
 
-    try provision.run(allocator, .{
+    return try provision.run(allocator, .{
         .script_path = script_path,
         .use_pretty_output = use_pretty_output,
         .params_json = params_json,
@@ -137,9 +137,11 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
         }
     }
 
-    runScript(allocator, script_path_or_url, use_pretty_output, res.args.params) catch |err| {
+    var result = runScript(allocator, script_path_or_url, use_pretty_output, res.args.params) catch |err| {
         std.debug.print("Provision failed: {}\n", .{err});
+        return;
     };
+    defer result.deinit(allocator);
 }
 
 fn printHelp(reason: ?[]const u8) !void {

--- a/src/curl.zig
+++ b/src/curl.zig
@@ -89,6 +89,8 @@ pub const CURLoption = enum(c_int) {
     CURLOPT_CAPATH = 10097,
     CURLOPT_SSL_VERIFYPEER = 64,
     CURLOPT_SSL_VERIFYHOST = 81,
+    CURLOPT_SSLCERT = 10025,
+    CURLOPT_SSLKEY = 10087,
 
     // WebSocket
     CURLOPT_CONNECT_ONLY = 141,

--- a/src/curl.zig
+++ b/src/curl.zig
@@ -90,6 +90,9 @@ pub const CURLoption = enum(c_int) {
     CURLOPT_SSL_VERIFYPEER = 64,
     CURLOPT_SSL_VERIFYHOST = 81,
 
+    // WebSocket
+    CURLOPT_CONNECT_ONLY = 141,
+
     // Debug
     CURLOPT_VERBOSE = 41,
 
@@ -98,8 +101,12 @@ pub const CURLoption = enum(c_int) {
 
 pub const CURLINFO = enum(c_int) {
     CURLINFO_RESPONSE_CODE = 0x200002,
+    CURLINFO_ACTIVESOCKET = 0x500028,
     _,
 };
+
+pub const curl_socket_t = c_int;
+pub const CURL_SOCKET_BAD: curl_socket_t = -1;
 
 pub const CURL_HTTP_VERSION = enum(c_long) {
     CURL_HTTP_VERSION_NONE = 0,
@@ -145,6 +152,24 @@ pub extern fn curl_slist_free_all(list: ?*curl_slist) void;
 pub const WriteCallback = *const fn (ptr: [*]const u8, size: usize, nmemb: usize, userdata: *anyopaque) callconv(.c) usize;
 pub const HeaderCallback = *const fn (ptr: [*]const u8, size: usize, nmemb: usize, userdata: *anyopaque) callconv(.c) usize;
 pub const ProgressCallback = *const fn (clientp: *anyopaque, dltotal: c_longlong, dlnow: c_longlong, ultotal: c_longlong, ulnow: c_longlong) callconv(.c) c_int;
+
+// WebSocket
+pub const curl_ws_frame = extern struct {
+    age: c_int,
+    flags: c_int,
+    offset: curl_off_t,
+    bytesleft: curl_off_t,
+    len: usize,
+};
+
+pub const CURLWS_TEXT: c_uint = 1 << 0;
+pub const CURLWS_CLOSE: c_uint = 1 << 3;
+pub const CURLWS_PING: c_uint = 1 << 4;
+pub const CURLWS_PONG: c_uint = 1 << 6;
+
+pub extern fn curl_ws_recv(curl: *CURL, buffer: [*]u8, buflen: usize, recv: *usize, metap: *?*const curl_ws_frame) CURLcode;
+pub extern fn curl_ws_send(curl: *CURL, buffer: [*]const u8, buflen: usize, sent: *usize, fragsize: curl_off_t, flags: c_uint) CURLcode;
+pub extern fn curl_ws_meta(curl: *CURL) ?*const curl_ws_frame;
 
 // Proxy types
 pub const CURLproxytype = enum(c_long) {

--- a/src/http/client.zig
+++ b/src/http/client.zig
@@ -177,6 +177,18 @@ pub const Client = struct {
         _ = curl.curl_easy_setopt(handle, .CURLOPT_SSL_VERIFYPEER, verify_peer);
         _ = curl.curl_easy_setopt(handle, .CURLOPT_SSL_VERIFYHOST, verify_host);
 
+        // mTLS client certificate
+        if (self.config.client_cert) |cert| {
+            const cert_z = try self.allocator.dupeZ(u8, cert);
+            defer self.allocator.free(cert_z);
+            _ = curl.curl_easy_setopt(handle, .CURLOPT_SSLCERT, cert_z.ptr);
+        }
+        if (self.config.client_key) |key| {
+            const key_z = try self.allocator.dupeZ(u8, key);
+            defer self.allocator.free(key_z);
+            _ = curl.curl_easy_setopt(handle, .CURLOPT_SSLKEY, key_z.ptr);
+        }
+
         // Protocol-specific configuration (reuse protocol variable from URL transformation above)
         switch (protocol) {
             .SFTP, .SCP => {

--- a/src/http/client.zig
+++ b/src/http/client.zig
@@ -459,7 +459,7 @@ fn progressCallback(userdata: *anyopaque, dltotal: curl.curl_off_t, dlnow: curl.
     // Note: Logging disabled here to avoid log spam on large files (called very frequently)
     // Uncomment only for debugging: logger.debug("Progress: {d}/{d}", .{ downloaded, total });
     ctx.callback(downloaded, total, ctx.user_context);
-    return 0; // Return 0 to continue
+    return 0;
 }
 
 fn bodyWriteCallback(ptr: [*]const u8, size: usize, nmemb: usize, userdata: *anyopaque) callconv(.c) usize {

--- a/src/http/config.zig
+++ b/src/http/config.zig
@@ -41,6 +41,12 @@ pub const Config = struct {
     /// HTTP proxy URL (e.g., "http://proxy.example.com:8080")
     proxy: ?[]const u8 = null,
 
+    /// Client certificate for mTLS (PEM file path)
+    client_cert: ?[]const u8 = null,
+
+    /// Client private key for mTLS (PEM file path)
+    client_key: ?[]const u8 = null,
+
     /// Retry configuration
     retry: RetryConfig = .{},
 

--- a/src/http/types.zig
+++ b/src/http/types.zig
@@ -110,7 +110,7 @@ pub const Request = struct {
         if (T == @TypeOf(null)) return req;
 
         const info = @typeInfo(T);
-        if (info != .Struct) return req;
+        if (info != .@"struct") return req;
 
         // Handle body
         if (@hasField(T, "body")) {
@@ -120,10 +120,10 @@ pub const Request = struct {
         // Handle headers as anonymous struct
         if (@hasField(T, "headers")) {
             const headers_info = @typeInfo(@TypeOf(opts.headers));
-            if (headers_info == .Struct) {
+            if (headers_info == .@"struct") {
                 req.headers = std.StringHashMap([]const u8).init(allocator);
                 req.headers_owned = true;
-                inline for (headers_info.Struct.fields) |field| {
+                inline for (headers_info.@"struct".fields) |field| {
                     try req.headers.?.put(try allocator.dupe(u8, field.name), try allocator.dupe(u8, @field(opts.headers, field.name)));
                 }
             }

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const clap = @import("clap");
 const logger = @import("logger.zig");
 const help_formatter = @import("help_formatter.zig");
-const build_options = @import("build_options");
+pub const build_options = @import("build_options");
 const commands = @import("commands.zig");
 
 const is_macos = builtin.os.tag == .macos;

--- a/src/main.zig
+++ b/src/main.zig
@@ -105,6 +105,10 @@ fn dispatchCommand(command: []const u8, allocator: std.mem.Allocator, iter: *std
         try commands.node_info.run(allocator, iter);
         return;
     }
+    if (std.mem.eql(u8, command, "agent")) {
+        try commands.agent.run(allocator, iter);
+        return;
+    }
 
     try printMainHelp(command);
 }
@@ -146,6 +150,7 @@ fn printMainHelp(unknown: ?[]const u8) !void {
         .{ .command = "provision", .description = "Run infrastructure-as-code scripts" },
         .{ .command = "node-info", .description = "Display complete node information (like Chef Ohai)" },
         .{ .command = "apply", .description = "Execute full bootstrap sequence" },
+        .{ .command = "agent", .description = "Connect to SSE endpoint and run provision on events" },
         .{ .command = "help", .description = "Show this help menu" },
     };
     help_formatter.HelpFormatter.printCommandTable(&command_items);
@@ -163,6 +168,7 @@ fn printMainHelp(unknown: ?[]const u8) !void {
         .{ .prefix = "Node information:", .command = "node-info" },
         .{ .prefix = "Full bootstrap:", .command = "apply --github user/dotfiles" },
         .{ .prefix = "Dry run:", .command = "apply --dry-run" },
+        .{ .prefix = "Agent mode:", .command = "agent https://worker.example.com/events" },
     };
     help_formatter.HelpFormatter.printExamples(&examples);
     help_formatter.HelpFormatter.newline();

--- a/src/node_info.zig
+++ b/src/node_info.zig
@@ -734,8 +734,8 @@ fn getDefaultGatewayMacOS(allocator: std.mem.Allocator) !?DefaultGateway {
         return null;
     }
 
-    // Allocate buffer
-    const buf = try allocator.alloc(u8, buf_size);
+    // Allocate buffer aligned for rt_msghdr
+    const buf = try allocator.alignedAlloc(u8, comptime std.mem.Alignment.of(c.struct_rt_msghdr), buf_size);
     defer allocator.free(buf);
 
     // Get routing table

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -21,6 +21,7 @@ const AsyncExecutor = @import("async_executor.zig").AsyncExecutor;
 pub const Options = struct {
     script_path: []const u8,
     use_pretty_output: bool = true, // Default to pretty output
+    params_json: ?[]const u8 = null, // JSON string for data_bag injection
 };
 
 const ProvisionRunner = struct {
@@ -692,6 +693,52 @@ fn registerResourceBindings(mrb_ptr: *mruby.mrb_state, zig_module: *mruby.RClass
     }
 }
 
+/// Inject params JSON into mruby as $_hola_params global variable.
+/// Uses mruby's JSON.parse to convert the JSON string into a Ruby Hash.
+fn injectParams(mrb: *mruby.mrb_state, params_json: []const u8) !void {
+    // Build Ruby code: $_hola_params = JSON.parse('...')
+    // Escape single quotes in JSON to avoid breaking the Ruby string literal
+    var escaped_len: usize = 0;
+    for (params_json) |ch| {
+        escaped_len += if (ch == '\'' or ch == '\\') @as(usize, 2) else 1;
+    }
+
+    const allocator = std.heap.c_allocator;
+    const buf = try allocator.alloc(u8, escaped_len + 64); // prefix + suffix overhead
+    defer allocator.free(buf);
+
+    var pos: usize = 0;
+    const prefix = "$_hola_params = JSON.parse('";
+    @memcpy(buf[pos .. pos + prefix.len], prefix);
+    pos += prefix.len;
+
+    for (params_json) |ch| {
+        if (ch == '\'' or ch == '\\') {
+            buf[pos] = '\\';
+            pos += 1;
+        }
+        buf[pos] = ch;
+        pos += 1;
+    }
+
+    const suffix = "')";
+    @memcpy(buf[pos .. pos + suffix.len], suffix);
+    pos += suffix.len;
+
+    // Evaluate the Ruby code
+    var code_buf: [4096:0]u8 = undefined;
+    if (pos > 4096) return error.ParamsTooLarge;
+    @memcpy(code_buf[0..pos], buf[0..pos]);
+    code_buf[pos] = 0;
+    _ = mruby.mrb_load_string(mrb, &code_buf);
+
+    const exc = mruby.mrb_get_exception(mrb);
+    if (mruby.mrb_test(exc)) {
+        mruby.mrb_print_error(mrb);
+        return error.MRubyException;
+    }
+}
+
 pub fn run(allocator: std.mem.Allocator, opts: Options) !void {
     var runner = ProvisionRunner.init(allocator);
     defer runner.deinit();
@@ -766,6 +813,14 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !void {
     try mrb.evalString(resources.file_edit.ruby_prelude);
     // Load Ruby-only custom resources
     try mrb.evalString(@embedFile("resources/apt_update_resource.rb"));
+
+    // Load data_bag support
+    try mrb.evalString(@embedFile("ruby_prelude/data_bag.rb"));
+
+    // Inject params as $_hola_params if provided (agent mode)
+    if (opts.params_json) |params_json| {
+        try injectParams(mrb_ptr, params_json);
+    }
 
     // Load test helper only in debug builds
     if (builtin.mode == .Debug) {

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -32,6 +32,7 @@ pub const ResourceResult = struct {
     skipped: bool,
     skip_reason: ?[]const u8,
     error_name: ?[]const u8,
+    output: ?[]const u8,
 };
 
 pub const ProvisionResult = struct {
@@ -49,6 +50,7 @@ pub const ProvisionResult = struct {
             allocator.free(rr.action);
             if (rr.skip_reason) |sr| allocator.free(sr);
             if (rr.error_name) |en| allocator.free(en);
+            if (rr.output) |o| allocator.free(o);
         }
         self.resource_results.deinit(allocator);
     }
@@ -870,6 +872,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
             allocator.free(rr.action);
             if (rr.skip_reason) |sr| allocator.free(sr);
             if (rr.error_name) |en| allocator.free(en);
+            if (rr.output) |o| allocator.free(o);
         }
         resource_results.deinit(allocator);
     }
@@ -1165,6 +1168,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
                 .skipped = false,
                 .skip_reason = null,
                 .error_name = try allocator.dupe(u8, @errorName(err)),
+                .output = null,
             });
 
             // Check if this resource has ignore_failure set
@@ -1176,6 +1180,8 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
                 return err;
             }
         };
+        // Free resource-allocated output after duping into resource_results
+        defer if (result.output) |o| std.heap.c_allocator.free(o);
         res.was_updated = result.was_updated;
 
         // Update resource status with action and skip reason
@@ -1193,6 +1199,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
                 .skipped = false,
                 .skip_reason = if (result.skip_reason) |sr| try allocator.dupe(u8, sr) else null,
                 .error_name = null,
+                .output = if (result.output) |o| try allocator.dupe(u8, o) else null,
             });
 
             // Collect notifications from updated resources (only if actually updated, not "up to date")
@@ -1223,6 +1230,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
                 .skipped = true,
                 .skip_reason = if (result.skip_reason) |sr| try allocator.dupe(u8, sr) else null,
                 .error_name = null,
+                .output = null,
             });
         }
     }

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -24,6 +24,36 @@ pub const Options = struct {
     params_json: ?[]const u8 = null, // JSON string for data_bag injection
 };
 
+pub const ResourceResult = struct {
+    type_name: []const u8,
+    name: []const u8,
+    action: []const u8,
+    was_updated: bool,
+    skipped: bool,
+    skip_reason: ?[]const u8,
+    error_name: ?[]const u8,
+};
+
+pub const ProvisionResult = struct {
+    executed_count: usize,
+    updated_count: usize,
+    skipped_count: usize,
+    failed_count: usize,
+    duration_ms: i64,
+    resource_results: std.ArrayList(ResourceResult),
+
+    pub fn deinit(self: *ProvisionResult, allocator: std.mem.Allocator) void {
+        for (self.resource_results.items) |rr| {
+            allocator.free(rr.type_name);
+            allocator.free(rr.name);
+            allocator.free(rr.action);
+            if (rr.skip_reason) |sr| allocator.free(sr);
+            if (rr.error_name) |en| allocator.free(en);
+        }
+        self.resource_results.deinit(allocator);
+    }
+};
+
 const ProvisionRunner = struct {
     allocator: std.mem.Allocator,
     resources: std.ArrayList(resources.ResourceWithMetadata),
@@ -739,7 +769,7 @@ fn injectParams(mrb: *mruby.mrb_state, params_json: []const u8) !void {
     }
 }
 
-pub fn run(allocator: std.mem.Allocator, opts: Options) !void {
+pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     var runner = ProvisionRunner.init(allocator);
     defer runner.deinit();
 
@@ -833,6 +863,19 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !void {
 
     // Record start time for timer
     const start_time = std.time.nanoTimestamp();
+
+    // Initialize resource results collection
+    var resource_results = std.ArrayList(ResourceResult).empty;
+    errdefer {
+        for (resource_results.items) |rr| {
+            allocator.free(rr.type_name);
+            allocator.free(rr.name);
+            allocator.free(rr.action);
+            if (rr.skip_reason) |sr| allocator.free(sr);
+            if (rr.error_name) |en| allocator.free(en);
+        }
+        resource_results.deinit(allocator);
+    }
 
     // Initialize modern display with the specified output mode
     var display = try modern_display.ModernProvisionDisplay.init(allocator, opts.use_pretty_output);
@@ -1117,6 +1160,16 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !void {
             try display.resourceError(res.id.type_name, res.id.name, @errorName(err));
             try display.update();
 
+            try resource_results.append(allocator, .{
+                .type_name = try allocator.dupe(u8, res.id.type_name),
+                .name = try allocator.dupe(u8, res.id.name),
+                .action = try allocator.dupe(u8, ""),
+                .was_updated = false,
+                .skipped = false,
+                .skip_reason = null,
+                .error_name = try allocator.dupe(u8, @errorName(err)),
+            });
+
             // Check if this resource has ignore_failure set
             if (res.resource.shouldIgnoreFailure()) {
                 // Continue to next resource if ignore_failure is true
@@ -1134,6 +1187,16 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !void {
             // Pass skip_reason to resourceUpdated so it can handle "up to date" case
             try display.resourceUpdated(res.id.type_name, res.id.name, result.action, result.skip_reason);
             try display.update();
+
+            try resource_results.append(allocator, .{
+                .type_name = try allocator.dupe(u8, res.id.type_name),
+                .name = try allocator.dupe(u8, res.id.name),
+                .action = try allocator.dupe(u8, result.action),
+                .was_updated = true,
+                .skipped = false,
+                .skip_reason = if (result.skip_reason) |sr| try allocator.dupe(u8, sr) else null,
+                .error_name = null,
+            });
 
             // Collect notifications from updated resources (only if actually updated, not "up to date")
             if (result.skip_reason == null or !std.mem.eql(u8, result.skip_reason.?, "up to date")) {
@@ -1154,6 +1217,16 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !void {
             // Resource was not updated - show skip reason (including "up to date")
             try display.resourceSkipped(res.id.type_name, res.id.name, result.action, result.skip_reason);
             try display.update();
+
+            try resource_results.append(allocator, .{
+                .type_name = try allocator.dupe(u8, res.id.type_name),
+                .name = try allocator.dupe(u8, res.id.name),
+                .action = try allocator.dupe(u8, result.action),
+                .was_updated = false,
+                .skipped = true,
+                .skip_reason = if (result.skip_reason) |sr| try allocator.dupe(u8, sr) else null,
+                .error_name = null,
+            });
         }
     }
 
@@ -1197,4 +1270,17 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !void {
 
     // Show execution summary with duration
     try display.showSummaryWithDuration(0, 0);
+
+    // Compute duration
+    const end_time = std.time.nanoTimestamp();
+    const elapsed_ms = @divTrunc(end_time - start_time, std.time.ns_per_ms);
+
+    return ProvisionResult{
+        .executed_count = display.executed_count,
+        .updated_count = display.updated_count,
+        .skipped_count = display.skipped_count,
+        .failed_count = display.failed_count,
+        .duration_ms = @intCast(elapsed_ms),
+        .resource_results = resource_results,
+    };
 }

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -734,7 +734,7 @@ fn injectParams(mrb: *mruby.mrb_state, params_json: []const u8) !void {
     }
 
     const allocator = std.heap.c_allocator;
-    const buf = try allocator.alloc(u8, escaped_len + 64); // prefix + suffix overhead
+    const buf = try allocator.alloc(u8, escaped_len + 64 + 1); // prefix + suffix + null terminator
     defer allocator.free(buf);
 
     var pos: usize = 0;
@@ -755,12 +755,9 @@ fn injectParams(mrb: *mruby.mrb_state, params_json: []const u8) !void {
     @memcpy(buf[pos .. pos + suffix.len], suffix);
     pos += suffix.len;
 
-    // Evaluate the Ruby code
-    var code_buf: [4096:0]u8 = undefined;
-    if (pos > 4096) return error.ParamsTooLarge;
-    @memcpy(code_buf[0..pos], buf[0..pos]);
-    code_buf[pos] = 0;
-    _ = mruby.mrb_load_string(mrb, &code_buf);
+    // Null-terminate and evaluate the Ruby code
+    buf[pos] = 0;
+    _ = mruby.mrb_load_string(mrb, buf.ptr);
 
     const exc = mruby.mrb_get_exception(mrb);
     if (mruby.mrb_test(exc)) {

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -544,6 +544,24 @@ export fn zig_add_systemd_unit_resource(mrb: *mruby.mrb_state, self: mruby.mrb_v
     );
 }
 
+// Zig callback for mount resource (Linux-only)
+export fn zig_add_mount_resource(mrb: *mruby.mrb_state, self: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    if (!is_linux) {
+        return mruby.mrb_nil_value();
+    }
+
+    return addSimpleResourceWithMetadata(
+        resources.mount_res.Resource,
+        "mount",
+        "mount_point",
+        "mount_res",
+        "common",
+        mrb,
+        self,
+        resources.mount_res.zigAddResource,
+    );
+}
+
 // Zig callback for package resource (cross-platform)
 export fn zig_add_package_resource(mrb: *mruby.mrb_state, self: mruby.mrb_value) callconv(.c) mruby.mrb_value {
     return addPackageResourceWithMetadata(mrb, self);
@@ -715,6 +733,7 @@ fn registerResourceBindings(mrb_ptr: *mruby.mrb_state, zig_module: *mruby.RClass
         .{ .name = "add_macos_defaults", .handler = zig_add_macos_defaults_resource, .args_spec = mruby.MRB_ARGS_REQ(2) | mruby.MRB_ARGS_OPT(6), .platform = .macos },
         .{ .name = "add_apt_repository", .handler = zig_add_apt_repository_resource, .args_spec = mruby.MRB_ARGS_REQ(10) | mruby.MRB_ARGS_OPT(4), .platform = .linux },
         .{ .name = "add_systemd_unit", .handler = zig_add_systemd_unit_resource, .args_spec = mruby.MRB_ARGS_REQ(3) | mruby.MRB_ARGS_OPT(4), .platform = .linux },
+        .{ .name = "add_mount", .handler = zig_add_mount_resource, .args_spec = mruby.MRB_ARGS_REQ(9) | mruby.MRB_ARGS_OPT(5), .platform = .linux },
         .{ .name = "add_package", .handler = zig_add_package_resource, .args_spec = mruby.MRB_ARGS_REQ(4) | mruby.MRB_ARGS_OPT(6) },
         .{ .name = "add_homebrew_package", .handler = zig_add_homebrew_package_resource, .args_spec = mruby.MRB_ARGS_REQ(4) | mruby.MRB_ARGS_OPT(5), .platform = .macos },
         .{ .name = "add_apt_package", .handler = zig_add_apt_package_resource, .args_spec = mruby.MRB_ARGS_REQ(4) | mruby.MRB_ARGS_OPT(5), .platform = .linux },
@@ -840,6 +859,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     // On non-Linux, the Ruby preludes detect absence of ZigBackend entrypoints
     try mrb.evalString(resources.apt_repository.ruby_prelude);
     try mrb.evalString(resources.systemd_unit.ruby_prelude);
+    try mrb.evalString(resources.mount_res.ruby_prelude);
     // Load package resources (delegator and platform-specific)
     try mrb.evalString(resources.package.ruby_prelude);
     try mrb.evalString(resources.homebrew_package.ruby_prelude);

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -667,6 +667,20 @@ export fn zig_add_file_edit_resource(mrb: *mruby.mrb_state, self: mruby.mrb_valu
     );
 }
 
+// Zig callback for extract resource (cross-platform)
+export fn zig_add_extract_resource(mrb: *mruby.mrb_state, self: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    return addSimpleResourceWithMetadata(
+        resources.extract.Resource,
+        "extract",
+        "destination",
+        "extract",
+        "common",
+        mrb,
+        self,
+        resources.extract.zigAddResource,
+    );
+}
+
 const ResourcePlatform = enum {
     all,
     macos,
@@ -710,6 +724,7 @@ fn registerResourceBindings(mrb_ptr: *mruby.mrb_state, zig_module: *mruby.RClass
         .{ .name = "add_group", .handler = zig_add_group_resource, .args_spec = mruby.MRB_ARGS_REQ(9) | mruby.MRB_ARGS_OPT(5) },
         .{ .name = "add_aws_kms", .handler = zig_add_aws_kms_resource, .args_spec = mruby.MRB_ARGS_REQ(15) | mruby.MRB_ARGS_OPT(5) },
         .{ .name = "add_file_edit", .handler = zig_add_file_edit_resource, .args_spec = mruby.MRB_ARGS_REQ(6) | mruby.MRB_ARGS_OPT(5) },
+        .{ .name = "add_extract", .handler = zig_add_extract_resource, .args_spec = mruby.MRB_ARGS_REQ(8) | mruby.MRB_ARGS_OPT(5) },
     };
 
     inline for (bindings) |binding| {
@@ -840,6 +855,8 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     try mrb.evalString(resources.aws_kms.ruby_prelude);
     // Load file_edit resource
     try mrb.evalString(resources.file_edit.ruby_prelude);
+    // Load extract resource
+    try mrb.evalString(resources.extract.ruby_prelude);
     // Load Ruby-only custom resources
     try mrb.evalString(@embedFile("resources/apt_update_resource.rb"));
 

--- a/src/resources.zig
+++ b/src/resources.zig
@@ -14,6 +14,7 @@ pub const route = @import("resources/route.zig");
 pub const git = @import("resources/git.zig");
 pub const aws_kms = @import("resources/aws_kms.zig");
 pub const file_edit = @import("resources/file_edit.zig");
+pub const extract = @import("resources/extract.zig");
 
 // macOS-only resources
 pub const macos_dock = if (builtin.os.tag == .macos)
@@ -212,6 +213,7 @@ const ResourceMacOs = union(enum) {
     group: group.Resource,
     aws_kms: aws_kms.Resource,
     file_edit: file_edit.Resource,
+    extract: extract.Resource,
 
     pub fn deinit(self: ResourceMacOs, allocator: std.mem.Allocator) void {
         deinitResourceUnion(self, allocator);
@@ -252,6 +254,7 @@ const ResourceGeneric = union(enum) {
     group: group.Resource,
     aws_kms: aws_kms.Resource,
     file_edit: file_edit.Resource,
+    extract: extract.Resource,
 
     pub fn deinit(self: ResourceGeneric, allocator: std.mem.Allocator) void {
         deinitResourceUnion(self, allocator);

--- a/src/resources.zig
+++ b/src/resources.zig
@@ -50,6 +50,13 @@ else
         pub const ruby_prelude = @embedFile("resources/systemd_unit_resource.rb");
     };
 
+pub const mount_res = if (builtin.os.tag == .linux)
+    @import("resources/mount.zig")
+else
+    struct {
+        pub const ruby_prelude = @embedFile("resources/mount_resource.rb");
+    };
+
 // Cross-platform package resource (supports homebrew on macOS, apt on Linux)
 pub const package = @import("resources/package.zig");
 
@@ -124,6 +131,7 @@ fn payloadName(payload: anytype) []const u8 {
     }
     if (@hasField(Payload, "path")) return payload.path;
     if (@hasField(Payload, "target")) return payload.target;
+    if (@hasField(Payload, "mount_point")) return payload.mount_point;
     if (@hasField(Payload, "destination")) return payload.destination;
     if (@hasField(Payload, "username")) return payload.username;
     if (@hasField(Payload, "group_name")) return payload.group_name;
@@ -245,6 +253,7 @@ const ResourceGeneric = union(enum) {
     link: link.Resource,
     apt_repository: apt_repository.Resource,
     systemd_unit: systemd_unit.Resource,
+    mount_res: mount_res.Resource,
     package: package.Resource,
     apt_package: apt_package.Resource,
     ruby_block: ruby_block.Resource,

--- a/src/resources/execute.zig
+++ b/src/resources/execute.zig
@@ -77,11 +77,12 @@ pub const Resource = struct {
 
         switch (self.action) {
             .run => {
-                try applyRun(self);
+                const output = try applyRun(self);
                 return base.ApplyResult{
                     .was_updated = true,
                     .action = "run",
                     .skip_reason = "up to date",
+                    .output = output,
                 };
             },
             .nothing => {
@@ -239,7 +240,7 @@ pub const Resource = struct {
         };
     }
 
-    fn applyRun(self: Resource) !void {
+    fn applyRun(self: Resource) !?[]const u8 {
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
         defer arena.deinit();
         const allocator = arena.allocator();
@@ -332,6 +333,15 @@ pub const Resource = struct {
                 return error.CommandFailed;
             },
         }
+
+        // Build combined output for structured result
+        const stdout_trimmed = std.mem.trim(u8, stdout, &std.ascii.whitespace);
+        const stderr_trimmed = std.mem.trim(u8, stderr, &std.ascii.whitespace);
+        if (stdout_trimmed.len == 0 and stderr_trimmed.len == 0) return null;
+
+        if (stderr_trimmed.len == 0) return try std.heap.c_allocator.dupe(u8, stdout_trimmed);
+        if (stdout_trimmed.len == 0) return try std.heap.c_allocator.dupe(u8, stderr_trimmed);
+        return try std.fmt.allocPrint(std.heap.c_allocator, "{s}\n{s}", .{ stdout_trimmed, stderr_trimmed });
     }
 };
 

--- a/src/resources/extract.zig
+++ b/src/resources/extract.zig
@@ -1,0 +1,732 @@
+/// extract resource - Extract files from archives using native Zig std.tar + std.compress
+/// Supported formats: .tar.gz/.tgz, .tar.xz/.txz, .tar (uncompressed)
+const std = @import("std");
+const mruby = @import("../mruby.zig");
+const base = @import("../base_resource.zig");
+const logger = @import("../logger.zig");
+
+pub const FileMapping = struct {
+    pattern: []const u8, // glob pattern, e.g. "*/s5cmd"
+    target: []const u8, // destination filename, e.g. "s5cmd"
+};
+
+pub const ArchiveType = enum {
+    tar_gz,
+    tar_xz,
+    tar,
+    unknown,
+};
+
+pub const Resource = struct {
+    path: []const u8,
+    destination: []const u8,
+    file_mappings: []const FileMapping,
+    strip_components: u32,
+    attrs: base.FileAttributes,
+    action: Action,
+    common: base.CommonProps,
+
+    pub const Action = enum {
+        extract, // extract all, rename matched files
+        extract_files, // only extract matched files
+    };
+
+    pub fn deinit(self: Resource, allocator: std.mem.Allocator) void {
+        allocator.free(self.path);
+        allocator.free(self.destination);
+        for (self.file_mappings) |m| {
+            allocator.free(m.pattern);
+            allocator.free(m.target);
+        }
+        allocator.free(self.file_mappings);
+        self.attrs.deinit(allocator);
+        var common = self.common;
+        common.deinit(allocator);
+    }
+
+    pub fn apply(self: Resource) !base.ApplyResult {
+        const action_name: []const u8 = switch (self.action) {
+            .extract => "extract",
+            .extract_files => "extract_files",
+        };
+
+        const skip_reason = try self.common.shouldRun(self.attrs.owner, self.attrs.group);
+        if (skip_reason) |reason| {
+            return base.ApplyResult{
+                .was_updated = false,
+                .action = action_name,
+                .skip_reason = reason,
+            };
+        }
+
+        // Idempotency: marker records fingerprint + file list.
+        // Skip only if fingerprint matches AND all recorded files still exist.
+        if (checkMarker(self.destination, self.path)) {
+            return base.ApplyResult{
+                .was_updated = false,
+                .action = action_name,
+                .skip_reason = "up to date",
+            };
+        }
+
+        // Ensure destination directory exists (recursive)
+        try makeDirRecursive(self.destination);
+
+        const archive_type = detectArchiveType(self.path);
+        if (archive_type == .unknown) {
+            logger.err("[extract] unsupported archive type for {s}", .{self.path});
+            return error.UnsupportedArchiveType;
+        }
+
+        const alloc = std.heap.c_allocator;
+
+        var output_buf = std.ArrayList(u8).empty;
+        defer output_buf.deinit(alloc);
+
+        // extracted_paths: tracks files created by this run (for targeted attrs)
+        var extracted_paths: std.ArrayListUnmanaged([]const u8) = .{};
+        defer {
+            for (extracted_paths.items) |p| alloc.free(p);
+            extracted_paths.deinit(alloc);
+        }
+
+        if (self.file_mappings.len == 0) {
+            try self.extractAll(archive_type, &output_buf, &extracted_paths);
+        } else {
+            try self.extractWithMappings(archive_type, &output_buf, &extracted_paths);
+        }
+
+        // Apply file attributes only to regular files created by this extraction.
+        // Skip symlinks to avoid modifying link targets outside our management scope.
+        if (self.attrs.mode != null or self.attrs.owner != null or self.attrs.group != null) {
+            for (extracted_paths.items) |rel| {
+                const full = std.fs.path.join(alloc, &.{ self.destination, rel }) catch continue;
+                defer alloc.free(full);
+                // Skip symlinks — applyFileAttributes follows links and would modify the target
+                var buf: [std.fs.max_path_bytes]u8 = undefined;
+                if (std.fs.readLinkAbsolute(full, &buf)) |_| continue else |_| {}
+                base.applyFileAttributes(full, self.attrs) catch |err| {
+                    logger.warn("[extract] failed to apply attributes to {s}: {}", .{ full, err });
+                };
+            }
+        }
+
+        // Write marker file for idempotency (fingerprint + file list)
+        writeMarker(self.destination, self.path, extracted_paths.items);
+
+        const output = if (output_buf.items.len > 0)
+            alloc.dupe(u8, output_buf.items) catch null
+        else
+            null;
+
+        return base.ApplyResult{
+            .was_updated = true,
+            .action = action_name,
+            .output = output,
+        };
+    }
+
+    /// Full extraction: extract to temp dir first, collect file list,
+    /// then copy to destination. This avoids including pre-existing files
+    /// in the extracted_paths / marker.
+    fn extractAll(self: Resource, archive_type: ArchiveType, output_buf: *std.ArrayList(u8), extracted_paths: *std.ArrayListUnmanaged([]const u8)) !void {
+        const alloc = std.heap.c_allocator;
+
+        // Extract to temp dir first to get clean file list
+        const tmp_dir_path = std.fmt.allocPrint(alloc, "/tmp/hola-extract-all-{d}", .{std.time.nanoTimestamp()}) catch return error.OutOfMemory;
+        defer alloc.free(tmp_dir_path);
+        try makeDirRecursive(tmp_dir_path);
+        defer std.fs.deleteTreeAbsolute(tmp_dir_path) catch {};
+
+        const file = std.fs.openFileAbsolute(self.path, .{}) catch |err| {
+            logger.err("[extract] failed to open archive {s}: {}", .{ self.path, err });
+            return err;
+        };
+        defer file.close();
+
+        var tmp_dir = try std.fs.openDirAbsolute(tmp_dir_path, .{});
+        defer tmp_dir.close();
+
+        try pipeArchiveToFileSystem(file, archive_type, tmp_dir, .{
+            .strip_components = self.strip_components,
+        }, alloc);
+
+        // Collect file list from temp dir (these are exactly our extracted files)
+        var walker = try walkDirRecursive(alloc, tmp_dir_path);
+        defer walker.deinit(alloc);
+
+        // Copy each file to destination and record in extracted_paths.
+        // Errors propagate up to prevent marker from being written on partial failure.
+        for (walker.items) |rel| {
+            const src_path = try std.fs.path.join(alloc, &.{ tmp_dir_path, rel });
+            defer alloc.free(src_path);
+            const dest_path = try std.fs.path.join(alloc, &.{ self.destination, rel });
+            defer alloc.free(dest_path);
+
+            try ensureParentDirRecursive(dest_path);
+            try copyFile(src_path, dest_path);
+            try extracted_paths.append(alloc, rel); // transfer ownership
+        }
+
+        try output_buf.appendSlice(alloc, "extracted all files to ");
+        try output_buf.appendSlice(alloc, self.destination);
+    }
+
+    /// Extract with file_mappings: supports both `all` and `files_only` modes.
+    /// - all: extract all files and symlinks, matched entries get renamed,
+    ///   unmatched entries keep their original paths (with strip_components applied).
+    ///   Empty directories are not preserved.
+    /// - files_only: only extract files/symlinks that match a pattern
+    fn extractWithMappings(self: Resource, archive_type: ArchiveType, output_buf: *std.ArrayList(u8), extracted_paths: *std.ArrayListUnmanaged([]const u8)) !void {
+        const alloc = std.heap.c_allocator;
+
+        // Create temp directory
+        const tmp_dir_path = std.fmt.allocPrint(alloc, "/tmp/hola-extract-{d}", .{std.time.nanoTimestamp()}) catch return error.OutOfMemory;
+        defer alloc.free(tmp_dir_path);
+
+        std.fs.makeDirAbsolute(tmp_dir_path) catch |err| switch (err) {
+            error.PathAlreadyExists => {},
+            else => return err,
+        };
+        defer std.fs.deleteTreeAbsolute(tmp_dir_path) catch {};
+
+        // Extract all to temp dir (raw, no strip)
+        const file = std.fs.openFileAbsolute(self.path, .{}) catch |err| {
+            logger.err("[extract] failed to open archive {s}: {}", .{ self.path, err });
+            return err;
+        };
+        defer file.close();
+
+        var tmp_dir = try std.fs.openDirAbsolute(tmp_dir_path, .{});
+        defer tmp_dir.close();
+
+        try pipeArchiveToFileSystem(file, archive_type, tmp_dir, .{}, alloc);
+
+        // Walk temp dir
+        var walker = try walkDirRecursive(alloc, tmp_dir_path);
+        defer {
+            for (walker.items) |entry| alloc.free(entry);
+            walker.deinit(alloc);
+        }
+
+        // Track which files were matched (for `all` mode to know which are unmatched)
+        var matched = try alloc.alloc(bool, walker.items.len);
+        defer alloc.free(matched);
+        @memset(matched, false);
+
+        // Phase 1a: match patterns against archive entries (no writes yet)
+        // match_idx[i] = index into walker.items that mapping[i] matched, or null
+        var match_idx = try alloc.alloc(?usize, self.file_mappings.len);
+        defer alloc.free(match_idx);
+        @memset(match_idx, null);
+
+        for (self.file_mappings, 0..) |mapping, mi| {
+            for (walker.items, 0..) |relative_path, idx| {
+                if (globMatch(mapping.pattern, relative_path)) {
+                    match_idx[mi] = idx;
+                    matched[idx] = true;
+                    break;
+                }
+            }
+        }
+
+        // Phase 1b: in extract_files mode, validate all mappings hit before writing
+        if (self.action == .extract_files) {
+            for (self.file_mappings, 0..) |mapping, mi| {
+                if (match_idx[mi] == null) {
+                    logger.err("[extract] pattern '{s}' did not match any file in archive {s}", .{ mapping.pattern, self.path });
+                    return error.PatternNotMatched;
+                }
+            }
+        }
+
+        // Phase 1c: write matched files (all validated)
+        for (self.file_mappings, 0..) |mapping, mi| {
+            if (match_idx[mi]) |idx| {
+                const relative_path = walker.items[idx];
+                const src_path = try std.fs.path.join(alloc, &.{ tmp_dir_path, relative_path });
+                defer alloc.free(src_path);
+                const dest_path = try std.fs.path.join(alloc, &.{ self.destination, mapping.target });
+                defer alloc.free(dest_path);
+
+                try ensureParentDirRecursive(dest_path);
+                try copyFile(src_path, dest_path);
+                try extracted_paths.append(alloc, try alloc.dupe(u8, mapping.target));
+
+                try output_buf.appendSlice(alloc, relative_path);
+                try output_buf.appendSlice(alloc, " -> ");
+                try output_buf.appendSlice(alloc, mapping.target);
+                try output_buf.appendSlice(alloc, "\n");
+            }
+        }
+
+        // Phase 2: in `all` mode, copy unmatched files with strip_components
+        if (self.action == .extract) {
+            for (walker.items, 0..) |relative_path, idx| {
+                if (matched[idx]) continue;
+
+                const stripped = stripComponents(relative_path, self.strip_components);
+                if (stripped.len == 0) continue; // fully stripped away
+
+                const src_path = try std.fs.path.join(alloc, &.{ tmp_dir_path, relative_path });
+                defer alloc.free(src_path);
+                const dest_path = try std.fs.path.join(alloc, &.{ self.destination, stripped });
+                defer alloc.free(dest_path);
+
+                try ensureParentDirRecursive(dest_path);
+                try copyFile(src_path, dest_path);
+                try extracted_paths.append(alloc, try alloc.dupe(u8, stripped));
+
+                try output_buf.appendSlice(alloc, relative_path);
+                try output_buf.appendSlice(alloc, " -> ");
+                try output_buf.appendSlice(alloc, stripped);
+                try output_buf.appendSlice(alloc, "\n");
+            }
+        }
+    }
+};
+
+/// Decompress and pipe tar archive to filesystem
+fn pipeArchiveToFileSystem(file: std.fs.File, archive_type: ArchiveType, dir: std.fs.Dir, pipe_opts: std.tar.PipeOptions, allocator: std.mem.Allocator) !void {
+    // Use diagnostics to collect non-fatal errors (e.g. stripped directory entries)
+    // instead of failing the whole extraction
+    var diagnostics: std.tar.Diagnostics = .{ .allocator = allocator };
+    defer diagnostics.deinit();
+
+    const opts: std.tar.PipeOptions = .{
+        .strip_components = pipe_opts.strip_components,
+        .mode_mode = pipe_opts.mode_mode,
+        .exclude_empty_directories = pipe_opts.exclude_empty_directories,
+        .diagnostics = &diagnostics,
+    };
+
+    var file_read_buf: [4096]u8 = undefined;
+    var file_reader = std.fs.File.Reader.init(file, &file_read_buf);
+
+    switch (archive_type) {
+        .tar_gz => {
+            var decompress_buf: [std.compress.flate.max_window_len]u8 = undefined;
+            var decompress = std.compress.flate.Decompress.init(&file_reader.interface, .gzip, &decompress_buf);
+            try std.tar.pipeToFileSystem(dir, &decompress.reader, opts);
+        },
+        .tar_xz => {
+            const old_reader = file_reader.interface.adaptToOldInterface();
+            var xz_decomp = try std.compress.xz.decompress(allocator, old_reader);
+            defer xz_decomp.deinit();
+            var xz_reader_buf: [4096]u8 = undefined;
+            var adapter = xz_decomp.reader().adaptToNewApi(&xz_reader_buf);
+            try std.tar.pipeToFileSystem(dir, &adapter.new_interface, opts);
+        },
+        .tar => {
+            try std.tar.pipeToFileSystem(dir, &file_reader.interface, opts);
+        },
+        .unknown => unreachable,
+    }
+
+    // Log real errors (not stripped-prefix warnings)
+    for (diagnostics.errors.items) |err| {
+        switch (err) {
+            .unable_to_create_file => |info| {
+                logger.warn("[extract] unable to create file: {s}", .{info.file_name});
+            },
+            .unable_to_create_sym_link => |info| {
+                logger.warn("[extract] unable to create symlink: {s} -> {s}", .{ info.file_name, info.link_name });
+            },
+            .components_outside_stripped_prefix => {},
+            .unsupported_file_type => {},
+        }
+    }
+}
+
+/// Check if a path exists without following symlinks.
+/// Returns true for regular files, directories, and symlinks (even dangling ones).
+fn pathExistsNoFollow(path: []const u8) bool {
+    // First try readLinkAbsolute — succeeds for any symlink (dangling or not)
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    if (std.fs.readLinkAbsolute(path, &buf)) |_| return true else |_| {}
+    // Not a symlink — check as regular file/dir
+    std.fs.accessAbsolute(path, .{}) catch return false;
+    return true;
+}
+
+fn makeDirRecursive(path: []const u8) !void {
+    std.fs.makeDirAbsolute(path) catch |err| switch (err) {
+        error.PathAlreadyExists => return,
+        error.FileNotFound => {
+            // Parent doesn't exist — recurse
+            if (std.fs.path.dirname(path)) |parent| {
+                try makeDirRecursive(parent);
+                std.fs.makeDirAbsolute(path) catch |e| switch (e) {
+                    error.PathAlreadyExists => {},
+                    else => return e,
+                };
+            } else {
+                return err;
+            }
+        },
+        else => return err,
+    };
+}
+
+fn ensureParentDirRecursive(path: []const u8) !void {
+    if (std.fs.path.dirname(path)) |parent| {
+        try makeDirRecursive(parent);
+    }
+}
+
+fn copyFile(src: []const u8, dst: []const u8) !void {
+    try ensureParentDirRecursive(dst);
+
+    // Try to read as symlink first
+    var target_buf: [std.fs.max_path_bytes]u8 = undefined;
+    if (std.fs.readLinkAbsolute(src, &target_buf)) |target| {
+        // Source is a symlink — recreate at destination
+        std.fs.deleteFileAbsolute(dst) catch {};
+        std.posix.symlinkat(target, std.posix.AT.FDCWD, dst) catch |err| {
+            logger.warn("[extract] symlink creation failed {s}: {}", .{ dst, err });
+            return err;
+        };
+    } else |_| {
+        // Not a symlink — regular file copy
+        try copyRegularFile(src, dst);
+    }
+}
+
+fn copyRegularFile(src: []const u8, dst: []const u8) !void {
+    const in_file = try std.fs.openFileAbsolute(src, .{});
+    defer in_file.close();
+
+    try ensureParentDirRecursive(dst);
+
+    const out_file = try std.fs.createFileAbsolute(dst, .{ .truncate = true });
+    defer out_file.close();
+
+    var buf: [8192]u8 = undefined;
+    while (true) {
+        const n = try in_file.read(&buf);
+        if (n == 0) break;
+        try out_file.writeAll(buf[0..n]);
+    }
+
+    // Preserve source file mode (especially executable bit)
+    const stat = try in_file.stat();
+    out_file.chmod(stat.mode) catch {};
+}
+
+/// Strip N leading path components from a relative path.
+/// e.g. stripComponents("a/b/c", 1) => "b/c"
+fn stripComponents(path: []const u8, count: u32) []const u8 {
+    var remaining = path;
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        if (std.mem.indexOfScalar(u8, remaining, '/')) |sep| {
+            remaining = remaining[sep + 1 ..];
+        } else {
+            return ""; // fully consumed
+        }
+    }
+    return remaining;
+}
+
+/// Walk a directory recursively and return all file relative paths
+fn walkDirRecursive(allocator: std.mem.Allocator, root: []const u8) !std.ArrayListUnmanaged([]const u8) {
+    var results: std.ArrayListUnmanaged([]const u8) = .{};
+    try walkDirRecursiveInner(allocator, root, "", &results);
+    return results;
+}
+
+fn walkDirRecursiveInner(allocator: std.mem.Allocator, root: []const u8, prefix: []const u8, results: *std.ArrayListUnmanaged([]const u8)) !void {
+    const full_path = if (prefix.len > 0)
+        try std.fs.path.join(allocator, &.{ root, prefix })
+    else
+        try allocator.dupe(u8, root);
+    defer allocator.free(full_path);
+
+    var dir = std.fs.openDirAbsolute(full_path, .{ .iterate = true }) catch return;
+    defer dir.close();
+
+    var iter = dir.iterate();
+    while (try iter.next()) |entry| {
+        const relative = if (prefix.len > 0)
+            try std.fs.path.join(allocator, &.{ prefix, entry.name })
+        else
+            try allocator.dupe(u8, entry.name);
+
+        switch (entry.kind) {
+            .directory => {
+                try walkDirRecursiveInner(allocator, root, relative, results);
+                allocator.free(relative);
+            },
+            .file, .sym_link => {
+                try results.append(allocator, relative);
+            },
+            else => allocator.free(relative),
+        }
+    }
+}
+
+const MARKER_NAME = ".hola-extracted";
+
+/// Build a fingerprint line: "path\tsize\tmtime_ns"
+fn buildFingerprint(alloc: std.mem.Allocator, archive_path: []const u8) ?[]const u8 {
+    const archive_file = std.fs.openFileAbsolute(archive_path, .{}) catch return null;
+    defer archive_file.close();
+    const stat = archive_file.stat() catch return null;
+    return std.fmt.allocPrint(alloc, "{s}\t{d}\t{d}", .{ archive_path, stat.size, stat.mtime }) catch null;
+}
+
+/// Check marker: fingerprint must match AND all recorded files must still exist.
+/// Marker format: first line = fingerprint, remaining lines = extracted file paths (relative to destination).
+fn checkMarker(destination: []const u8, archive_path: []const u8) bool {
+    const alloc = std.heap.c_allocator;
+    const marker_path = std.fs.path.join(alloc, &.{ destination, MARKER_NAME }) catch return false;
+    defer alloc.free(marker_path);
+    const content = std.fs.cwd().readFileAlloc(alloc, marker_path, 1024 * 1024) catch return false;
+    defer alloc.free(content);
+
+    // First line is fingerprint
+    var line_iter = std.mem.splitScalar(u8, content, '\n');
+    const first_line = line_iter.next() orelse return false;
+
+    const fingerprint = buildFingerprint(alloc, archive_path) orelse return false;
+    defer alloc.free(fingerprint);
+    if (!std.mem.eql(u8, first_line, fingerprint)) return false;
+
+    // Remaining lines are file paths — verify each exists (without following symlinks)
+    while (line_iter.next()) |line| {
+        if (line.len == 0) continue;
+        const file_path = std.fs.path.join(alloc, &.{ destination, line }) catch return false;
+        defer alloc.free(file_path);
+        if (!pathExistsNoFollow(file_path)) return false;
+    }
+
+    return true;
+}
+
+/// Write marker: fingerprint + file list.
+fn writeMarker(destination: []const u8, archive_path: []const u8, files: []const []const u8) void {
+    const alloc = std.heap.c_allocator;
+    const marker_path = std.fs.path.join(alloc, &.{ destination, MARKER_NAME }) catch return;
+    defer alloc.free(marker_path);
+    const fingerprint = buildFingerprint(alloc, archive_path) orelse return;
+    defer alloc.free(fingerprint);
+    const file = std.fs.createFileAbsolute(marker_path, .{ .truncate = true }) catch return;
+    defer file.close();
+    file.writeAll(fingerprint) catch {};
+    file.writeAll("\n") catch {};
+    for (files) |rel| {
+        file.writeAll(rel) catch {};
+        file.writeAll("\n") catch {};
+    }
+}
+
+pub fn detectArchiveType(path: []const u8) ArchiveType {
+    if (std.mem.endsWith(u8, path, ".tar.gz") or std.mem.endsWith(u8, path, ".tgz")) {
+        return .tar_gz;
+    } else if (std.mem.endsWith(u8, path, ".tar.xz") or std.mem.endsWith(u8, path, ".txz")) {
+        return .tar_xz;
+    } else if (std.mem.endsWith(u8, path, ".tar")) {
+        return .tar;
+    }
+    return .unknown;
+}
+
+/// Simple glob matching: `*` matches one path segment (no `/`), other chars match literally.
+pub fn globMatch(pattern: []const u8, path: []const u8) bool {
+    var pat_iter = std.mem.splitScalar(u8, pattern, '/');
+    var path_iter = std.mem.splitScalar(u8, path, '/');
+
+    while (true) {
+        const pat_seg = pat_iter.next();
+        const path_seg = path_iter.next();
+
+        if (pat_seg == null and path_seg == null) return true;
+        if (pat_seg == null or path_seg == null) return false;
+
+        if (!segmentMatch(pat_seg.?, path_seg.?)) return false;
+    }
+}
+
+fn segmentMatch(pattern: []const u8, text: []const u8) bool {
+    if (std.mem.eql(u8, pattern, "*")) return true;
+
+    var pi: usize = 0;
+    var ti: usize = 0;
+    var star_pi: ?usize = null;
+    var star_ti: ?usize = null;
+
+    while (ti < text.len) {
+        if (pi < pattern.len and (pattern[pi] == text[ti] or pattern[pi] == '?')) {
+            pi += 1;
+            ti += 1;
+        } else if (pi < pattern.len and pattern[pi] == '*') {
+            star_pi = pi;
+            star_ti = ti;
+            pi += 1;
+        } else if (star_pi) |sp| {
+            pi = sp + 1;
+            star_ti = star_ti.? + 1;
+            ti = star_ti.?;
+        } else {
+            return false;
+        }
+    }
+
+    while (pi < pattern.len and pattern[pi] == '*') pi += 1;
+    return pi == pattern.len;
+}
+
+pub const ruby_prelude = @embedFile("extract_resource.rb");
+
+pub fn zigAddResource(
+    mrb: *mruby.mrb_state,
+    self_val: mruby.mrb_value,
+    resource_list: *std.ArrayList(Resource),
+    allocator: std.mem.Allocator,
+) mruby.mrb_value {
+    _ = self_val;
+
+    var path_val: mruby.mrb_value = undefined;
+    var destination_val: mruby.mrb_value = undefined;
+    var files_val: mruby.mrb_value = undefined;
+    var mode_val: mruby.mrb_value = undefined;
+    var owner_val: mruby.mrb_value = undefined;
+    var group_val: mruby.mrb_value = undefined;
+    var action_val: mruby.mrb_value = undefined;
+    var strip_val: mruby.mrb_value = undefined;
+    var only_if_val: mruby.mrb_value = undefined;
+    var not_if_val: mruby.mrb_value = undefined;
+    var ignore_failure_val: mruby.mrb_value = undefined;
+    var notifications_val: mruby.mrb_value = undefined;
+    var subscriptions_val: mruby.mrb_value = undefined;
+
+    _ = mruby.mrb_get_args(mrb, "SSASSSSS|oooAA", &path_val, &destination_val, &files_val, &mode_val, &owner_val, &group_val, &action_val, &strip_val, &only_if_val, &not_if_val, &ignore_failure_val, &notifications_val, &subscriptions_val);
+
+    const path = allocator.dupe(u8, std.mem.span(mruby.mrb_str_to_cstr(mrb, path_val))) catch return mruby.mrb_nil_value();
+    const destination = allocator.dupe(u8, std.mem.span(mruby.mrb_str_to_cstr(mrb, destination_val))) catch return mruby.mrb_nil_value();
+
+    // Parse files array: [[pattern, target], ...]
+    var mappings_list = std.ArrayList(FileMapping).initCapacity(allocator, 4) catch std.ArrayList(FileMapping).empty;
+
+    const files_len = mruby.mrb_ary_len(mrb, files_val);
+    for (0..@intCast(files_len)) |i| {
+        const pair = mruby.mrb_ary_ref(mrb, files_val, @intCast(i));
+        const pair_len = mruby.mrb_ary_len(mrb, pair);
+        if (pair_len >= 2) {
+            const pattern_val = mruby.mrb_ary_ref(mrb, pair, 0);
+            const target_val = mruby.mrb_ary_ref(mrb, pair, 1);
+
+            const pat = allocator.dupe(u8, std.mem.span(mruby.mrb_str_to_cstr(mrb, pattern_val))) catch continue;
+            const tgt = allocator.dupe(u8, std.mem.span(mruby.mrb_str_to_cstr(mrb, target_val))) catch {
+                allocator.free(pat);
+                continue;
+            };
+
+            mappings_list.append(allocator, .{
+                .pattern = pat,
+                .target = tgt,
+            }) catch continue;
+        }
+    }
+
+    const file_mappings = mappings_list.toOwnedSlice(allocator) catch return mruby.mrb_nil_value();
+
+    // Parse action
+    const action_str = std.mem.span(mruby.mrb_str_to_cstr(mrb, action_val));
+    const action: Resource.Action = if (std.mem.eql(u8, action_str, "extract_files"))
+        .extract_files
+    else
+        .extract;
+
+    // Parse strip_components
+    const strip_str = std.mem.span(mruby.mrb_str_to_cstr(mrb, strip_val));
+    const strip_components: u32 = if (strip_str.len > 0)
+        std.fmt.parseInt(u32, strip_str, 10) catch 0
+    else
+        0;
+
+    // Parse mode
+    const mode_str = std.mem.span(mruby.mrb_str_to_cstr(mrb, mode_val));
+    const mode: ?u32 = if (mode_str.len > 0)
+        std.fmt.parseInt(u32, mode_str, 8) catch null
+    else
+        null;
+
+    // Parse owner
+    const owner_str = std.mem.span(mruby.mrb_str_to_cstr(mrb, owner_val));
+    const owner: ?[]const u8 = if (owner_str.len > 0)
+        allocator.dupe(u8, owner_str) catch null
+    else
+        null;
+
+    // Parse group
+    const group_str = std.mem.span(mruby.mrb_str_to_cstr(mrb, group_val));
+    const group_opt: ?[]const u8 = if (group_str.len > 0)
+        allocator.dupe(u8, group_str) catch null
+    else
+        null;
+
+    var common = base.CommonProps.init(allocator);
+    base.fillCommonFromRuby(&common, mrb, only_if_val, not_if_val, ignore_failure_val, notifications_val, subscriptions_val, allocator);
+
+    resource_list.append(allocator, .{
+        .path = path,
+        .destination = destination,
+        .file_mappings = file_mappings,
+        .strip_components = strip_components,
+        .attrs = .{
+            .mode = mode,
+            .owner = owner,
+            .group = group_opt,
+        },
+        .action = action,
+        .common = common,
+    }) catch return mruby.mrb_nil_value();
+
+    return mruby.mrb_nil_value();
+}
+
+test "detectArchiveType" {
+    const testing = std.testing;
+    try testing.expectEqual(ArchiveType.tar_gz, detectArchiveType("/tmp/foo.tar.gz"));
+    try testing.expectEqual(ArchiveType.tar_gz, detectArchiveType("/tmp/foo.tgz"));
+    try testing.expectEqual(ArchiveType.tar_xz, detectArchiveType("/tmp/foo.tar.xz"));
+    try testing.expectEqual(ArchiveType.tar_xz, detectArchiveType("/tmp/foo.txz"));
+    try testing.expectEqual(ArchiveType.tar, detectArchiveType("/tmp/foo.tar"));
+    try testing.expectEqual(ArchiveType.unknown, detectArchiveType("/tmp/foo.zip"));
+    try testing.expectEqual(ArchiveType.unknown, detectArchiveType("/tmp/foo.rar"));
+    try testing.expectEqual(ArchiveType.unknown, detectArchiveType("/tmp/foo"));
+}
+
+test "globMatch basic patterns" {
+    const testing = std.testing;
+    try testing.expect(globMatch("foo/bar", "foo/bar"));
+    try testing.expect(!globMatch("foo/bar", "foo/baz"));
+
+    try testing.expect(globMatch("*/s5cmd", "s5cmd_2.3.0_Linux-64bit/s5cmd"));
+    try testing.expect(globMatch("*/LICENSE", "some_dir/LICENSE"));
+    try testing.expect(!globMatch("*/s5cmd", "a/b/s5cmd"));
+
+    try testing.expect(globMatch("s5cmd_*/s5cmd", "s5cmd_2.3.0/s5cmd"));
+    try testing.expect(!globMatch("s5cmd_*/s5cmd", "other/s5cmd"));
+
+    try testing.expect(globMatch("bin/tool", "bin/tool"));
+    try testing.expect(!globMatch("bin/tool", "bin/other"));
+}
+
+test "stripComponents" {
+    const testing = std.testing;
+    try testing.expectEqualStrings("b/c", stripComponents("a/b/c", 1));
+    try testing.expectEqualStrings("c", stripComponents("a/b/c", 2));
+    try testing.expectEqualStrings("", stripComponents("a/b/c", 3));
+    try testing.expectEqualStrings("a/b/c", stripComponents("a/b/c", 0));
+    try testing.expectEqualStrings("", stripComponents("a", 1));
+}
+
+test "globMatch edge cases" {
+    const testing = std.testing;
+    try testing.expect(globMatch("README", "README"));
+    try testing.expect(!globMatch("README", "LICENSE"));
+    try testing.expect(globMatch("*", "anything"));
+    try testing.expect(!globMatch("*", "a/b"));
+}

--- a/src/resources/extract_resource.rb
+++ b/src/resources/extract_resource.rb
@@ -1,0 +1,105 @@
+module ZigBackend
+end
+
+class ExtractResource
+  def initialize(path, &block)
+    @path = File.expand_path(path)
+    @destination = ""
+    @files_map = {}
+    @strip_components = 0
+    @mode = ""
+    @owner = ""
+    @group = ""
+    @action = "extract"
+    @only_if_proc = nil
+    @not_if_proc = nil
+    @ignore_failure = false
+    @notifications = []
+    @subscriptions = []
+
+    instance_eval(&block) if block
+
+    only_if_arg = @only_if_proc || nil
+    not_if_arg = @not_if_proc || nil
+    notifications_arg = @notifications.map { |n| [n[:target], n[:action], n[:timing]] }
+    subscriptions_arg = @subscriptions.map { |s| [s[:target], s[:action], s[:timing]] }
+
+    files_array = @files_map.map { |pattern, target| [pattern.to_s, target.to_s] }
+
+    ZigBackend.add_extract(
+      @path,
+      @destination,
+      files_array,
+      @mode,
+      @owner,
+      @group,
+      @action.to_s,
+      @strip_components.to_s,
+      only_if_arg,
+      not_if_arg,
+      @ignore_failure,
+      notifications_arg,
+      subscriptions_arg
+    )
+  end
+
+  def destination(value)
+    @destination = File.expand_path(value)
+  end
+
+  def files(hash)
+    @files_map.merge!(hash)
+  end
+
+  def strip_components(value)
+    @strip_components = value.to_i
+  end
+
+  def mode(value)
+    @mode = value.to_s
+  end
+
+  def owner(value)
+    @owner = value.to_s
+  end
+
+  def group(value)
+    @group = value.to_s
+  end
+
+  def action(value)
+    @action = value.to_s
+  end
+
+  def only_if(command = nil, &block)
+    @only_if_proc = command&.to_s || block
+  end
+
+  def not_if(command = nil, &block)
+    @not_if_proc = command&.to_s || block
+  end
+
+  def ignore_failure(value)
+    @ignore_failure = value
+  end
+
+  def notifies(action, target_resource, timer = :delayed)
+    @notifications << {
+      target: target_resource,
+      action: action.to_s,
+      timing: timer.to_s
+    }
+  end
+
+  def subscribes(action, source_resource, timer = :delayed)
+    @subscriptions << {
+      target: source_resource,
+      action: action.to_s,
+      timing: timer.to_s
+    }
+  end
+end
+
+def extract(path, &block)
+  ExtractResource.new(path, &block)
+end

--- a/src/resources/file.zig
+++ b/src/resources/file.zig
@@ -51,11 +51,12 @@ pub const Resource = struct {
 
         switch (self.action) {
             .create => {
-                const was_created = try applyCreate(self);
+                const create_result = try applyCreate(self);
                 return base.ApplyResult{
-                    .was_updated = was_created,
+                    .was_updated = create_result.was_updated,
                     .action = action_name,
-                    .skip_reason = if (was_created) null else "up to date",
+                    .skip_reason = if (create_result.was_updated) null else "up to date",
+                    .output = create_result.output,
                 };
             },
             .delete => {
@@ -69,7 +70,9 @@ pub const Resource = struct {
         }
     }
 
-    fn applyCreate(self: Resource) !bool {
+    const CreateResult = struct { was_updated: bool, output: ?[]const u8 };
+
+    fn applyCreate(self: Resource) !CreateResult {
         try base.ensureParentDir(self.path);
         const is_abs = std.fs.path.isAbsolute(self.path);
 
@@ -120,19 +123,21 @@ pub const Resource = struct {
                     true;
 
                 if (mode_matches) {
-                    return false; // File exists with same content and mode
+                    return .{ .was_updated = false, .output = null };
                 }
 
                 // Only mode differs; fix attributes without rewriting
                 base.applyFileAttributes(self.path, self.attrs) catch |err| {
                     logger.warn("Failed to apply file attributes for {s}: {}", .{ self.path, err });
                 };
-                return true;
+                return .{ .was_updated = true, .output = null };
             }
         }
 
         // File doesn't exist or content differs, create/update it
         // Generate diff if file existed and log it
+        var diff_output: ?[]const u8 = null;
+        errdefer if (diff_output) |d| std.heap.c_allocator.free(d);
         if (existing_content) |old_content| {
             const diff = git.diffStrings(
                 std.heap.c_allocator,
@@ -146,9 +151,11 @@ pub const Resource = struct {
             };
 
             if (diff) |d| {
-                defer std.heap.c_allocator.free(d);
                 if (d.len > 0) {
                     logger.info("File diff for {s}:\n{s}", .{ self.path, d });
+                    diff_output = d;
+                } else {
+                    std.heap.c_allocator.free(d);
                 }
             }
         }
@@ -197,7 +204,7 @@ pub const Resource = struct {
             logger.warn("Failed to apply file attributes for {s}: {}", .{ self.path, err });
         };
 
-        return true; // File was created or updated
+        return .{ .was_updated = true, .output = diff_output };
     }
 
     fn applyDelete(self: Resource) !void {

--- a/src/resources/mount.zig
+++ b/src/resources/mount.zig
@@ -1,0 +1,607 @@
+const std = @import("std");
+const mruby = @import("../mruby.zig");
+const base = @import("../base_resource.zig");
+const builtin = @import("builtin");
+const logger = @import("../logger.zig");
+
+pub const Resource = struct {
+    mount_point: []const u8,
+    device: []const u8,
+    device_type: DeviceType,
+    fstype: []const u8,
+    options: []const u8,
+    dump: u8,
+    pass: u8,
+    supports_remount: bool,
+    action: Action,
+    common: base.CommonProps,
+
+    pub const DeviceType = enum { device, label, uuid };
+
+    pub const Action = enum {
+        mount_action,
+        umount,
+        remount,
+        enable,
+        disable,
+        nothing,
+    };
+
+    pub fn deinit(self: Resource, allocator: std.mem.Allocator) void {
+        allocator.free(self.mount_point);
+        allocator.free(self.device);
+        allocator.free(self.fstype);
+        allocator.free(self.options);
+        var common = self.common;
+        common.deinit(allocator);
+    }
+
+    pub fn apply(self: Resource) !base.ApplyResult {
+        if (builtin.os.tag != .linux) {
+            return base.ApplyResult{
+                .was_updated = false,
+                .action = "skipped",
+                .skip_reason = "mount only available on Linux",
+            };
+        }
+
+        const skip_reason = try self.common.shouldRun(null, null);
+        if (skip_reason) |reason| {
+            return base.ApplyResult{
+                .was_updated = false,
+                .action = self.actionName(),
+                .skip_reason = reason,
+            };
+        }
+
+        const was_updated = switch (self.action) {
+            .mount_action => try self.applyMount(),
+            .umount => try self.applyUmount(),
+            .remount => try self.applyRemount(),
+            .enable => try self.applyEnable(),
+            .disable => try self.applyDisable(),
+            .nothing => false,
+        };
+
+        return base.ApplyResult{
+            .was_updated = was_updated,
+            .action = self.actionName(),
+            .skip_reason = if (was_updated) null else "up to date",
+        };
+    }
+
+    fn actionName(self: Resource) []const u8 {
+        return switch (self.action) {
+            .mount_action => "mount",
+            .umount => "umount",
+            .remount => "remount",
+            .enable => "enable",
+            .disable => "disable",
+            .nothing => "nothing",
+        };
+    }
+
+    fn applyMount(self: Resource) !bool {
+        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer arena.deinit();
+        const allocator = arena.allocator();
+
+        if (try isMounted(allocator, self.mount_point)) {
+            return false;
+        }
+
+        var argv = std.ArrayList([]const u8).empty;
+        defer argv.deinit(allocator);
+
+        try argv.append(allocator, "/bin/mount");
+        try argv.append(allocator, "-t");
+        try argv.append(allocator, self.fstype);
+        try argv.append(allocator, "-o");
+        try argv.append(allocator, self.options);
+
+        switch (self.device_type) {
+            .uuid => {
+                try argv.append(allocator, "-U");
+                try argv.append(allocator, self.device);
+            },
+            .label => {
+                try argv.append(allocator, "-L");
+                try argv.append(allocator, self.device);
+            },
+            .device => {
+                try argv.append(allocator, self.device);
+            },
+        }
+        try argv.append(allocator, self.mount_point);
+
+        _ = try runCommand(allocator, argv.items);
+        return true;
+    }
+
+    fn applyUmount(self: Resource) !bool {
+        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer arena.deinit();
+        const allocator = arena.allocator();
+
+        if (!try isMounted(allocator, self.mount_point)) {
+            return false;
+        }
+
+        _ = try runCommand(allocator, &[_][]const u8{ "/bin/umount", self.mount_point });
+        return true;
+    }
+
+    fn applyRemount(self: Resource) !bool {
+        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer arena.deinit();
+        const allocator = arena.allocator();
+
+        if (!try isMounted(allocator, self.mount_point)) {
+            return false;
+        }
+
+        if (self.supports_remount) {
+            const remount_opts = try std.fmt.allocPrint(allocator, "remount,{s}", .{self.options});
+            _ = try runCommand(allocator, &[_][]const u8{ "/bin/mount", "-o", remount_opts, self.mount_point });
+        } else {
+            _ = try runCommand(allocator, &[_][]const u8{ "/bin/umount", self.mount_point });
+
+            var argv = std.ArrayList([]const u8).empty;
+            defer argv.deinit(allocator);
+            try argv.append(allocator, "/bin/mount");
+            try argv.append(allocator, "-t");
+            try argv.append(allocator, self.fstype);
+            try argv.append(allocator, "-o");
+            try argv.append(allocator, self.options);
+
+            switch (self.device_type) {
+                .uuid => {
+                    try argv.append(allocator, "-U");
+                    try argv.append(allocator, self.device);
+                },
+                .label => {
+                    try argv.append(allocator, "-L");
+                    try argv.append(allocator, self.device);
+                },
+                .device => {
+                    try argv.append(allocator, self.device);
+                },
+            }
+            try argv.append(allocator, self.mount_point);
+            _ = try runCommand(allocator, argv.items);
+        }
+        return true;
+    }
+
+    fn applyEnable(self: Resource) !bool {
+        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer arena.deinit();
+        const allocator = arena.allocator();
+
+        const device_str = try self.fstabDeviceString(allocator);
+        const new_line = try std.fmt.allocPrint(
+            allocator,
+            "{s}\t{s}\t{s}\t{s}\t{d}\t{d}",
+            .{ device_str, self.mount_point, self.fstype, self.options, self.dump, self.pass },
+        );
+
+        const existing = parseFstab(allocator, self.mount_point) catch null;
+        if (existing) |entry| {
+            if (std.mem.eql(u8, entry.line, new_line)) {
+                return false;
+            }
+        }
+
+        // Read fstab, replace or append
+        const fstab_content = std.fs.cwd().readFileAlloc(allocator, "/etc/fstab", 1024 * 1024) catch |err| switch (err) {
+            error.FileNotFound => "",
+            else => return err,
+        };
+        var output = std.ArrayList(u8).empty;
+        defer output.deinit(allocator);
+
+        var replaced = false;
+        var last_match_line: ?usize = null;
+
+        // Find last matching line index
+        var line_idx: usize = 0;
+        var lines_iter = std.mem.splitScalar(u8, fstab_content, '\n');
+        while (lines_iter.next()) |line| {
+            const trimmed = std.mem.trim(u8, line, " \t");
+            if (trimmed.len > 0 and trimmed[0] != '#') {
+                if (parseFstabFields(trimmed)) |fields| {
+                    if (std.mem.eql(u8, fields.mount_point, self.mount_point)) {
+                        last_match_line = line_idx;
+                    }
+                }
+            }
+            line_idx += 1;
+        }
+
+        // Rebuild fstab
+        var line_idx2: usize = 0;
+        var lines_iter2 = std.mem.splitScalar(u8, fstab_content, '\n');
+        while (lines_iter2.next()) |line| {
+            if (last_match_line != null and line_idx2 == last_match_line.?) {
+                try output.appendSlice(allocator, new_line);
+                replaced = true;
+            } else {
+                try output.appendSlice(allocator, line);
+            }
+            if (lines_iter2.peek() != null) {
+                try output.append(allocator, '\n');
+            }
+            line_idx2 += 1;
+        }
+
+        if (!replaced) {
+            // Append new entry
+            if (output.items.len > 0 and output.items[output.items.len - 1] != '\n') {
+                try output.append(allocator, '\n');
+            }
+            try output.appendSlice(allocator, new_line);
+            try output.append(allocator, '\n');
+        }
+
+        try atomicWriteFstab(output.items);
+        return true;
+    }
+
+    fn applyDisable(self: Resource) !bool {
+        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        defer arena.deinit();
+        const allocator = arena.allocator();
+
+        const existing = parseFstab(allocator, self.mount_point) catch null;
+        if (existing == null) {
+            return false;
+        }
+
+        const fstab_content = std.fs.cwd().readFileAlloc(allocator, "/etc/fstab", 1024 * 1024) catch |err| switch (err) {
+            error.FileNotFound => return false,
+            else => return err,
+        };
+        var output = std.ArrayList(u8).empty;
+        defer output.deinit(allocator);
+
+        // Find last matching line index
+        var last_match_line: ?usize = null;
+        var line_idx: usize = 0;
+        var lines_iter = std.mem.splitScalar(u8, fstab_content, '\n');
+        while (lines_iter.next()) |line| {
+            const trimmed = std.mem.trim(u8, line, " \t");
+            if (trimmed.len > 0 and trimmed[0] != '#') {
+                if (parseFstabFields(trimmed)) |fields| {
+                    if (std.mem.eql(u8, fields.mount_point, self.mount_point)) {
+                        last_match_line = line_idx;
+                    }
+                }
+            }
+            line_idx += 1;
+        }
+
+        // Rebuild without the matched line
+        var line_idx2: usize = 0;
+        var lines_iter2 = std.mem.splitScalar(u8, fstab_content, '\n');
+        while (lines_iter2.next()) |line| {
+            if (last_match_line != null and line_idx2 == last_match_line.?) {
+                line_idx2 += 1;
+                continue;
+            }
+            if (output.items.len > 0) {
+                try output.append(allocator, '\n');
+            }
+            try output.appendSlice(allocator, line);
+            line_idx2 += 1;
+        }
+
+        if (output.items.len > 0 and output.items[output.items.len - 1] != '\n') {
+            try output.append(allocator, '\n');
+        }
+
+        try atomicWriteFstab(output.items);
+        return true;
+    }
+
+    pub fn fstabDeviceString(self: Resource, allocator: std.mem.Allocator) ![]const u8 {
+        return switch (self.device_type) {
+            .uuid => try std.fmt.allocPrint(allocator, "UUID={s}", .{self.device}),
+            .label => try std.fmt.allocPrint(allocator, "LABEL={s}", .{self.device}),
+            .device => try allocator.dupe(u8, self.device),
+        };
+    }
+
+    fn atomicWriteFstab(content: []const u8) !void {
+        const tmp_path = "/etc/fstab.hola.tmp";
+        const file = try std.fs.createFileAbsolute(tmp_path, .{ .truncate = true });
+        defer file.close();
+        try file.writeAll(content);
+
+        try std.fs.renameAbsolute(tmp_path, "/etc/fstab");
+    }
+
+    pub fn actionFromString(action_str: []const u8) Action {
+        if (std.mem.eql(u8, action_str, "mount")) return .mount_action;
+        if (std.mem.eql(u8, action_str, "umount")) return .umount;
+        if (std.mem.eql(u8, action_str, "remount")) return .remount;
+        if (std.mem.eql(u8, action_str, "enable")) return .enable;
+        if (std.mem.eql(u8, action_str, "disable")) return .disable;
+        return .nothing;
+    }
+
+    fn deviceTypeFromString(dt_str: []const u8) DeviceType {
+        if (std.mem.eql(u8, dt_str, "uuid")) return .uuid;
+        if (std.mem.eql(u8, dt_str, "label")) return .label;
+        return .device;
+    }
+};
+
+pub const FstabFields = struct {
+    device: []const u8,
+    mount_point: []const u8,
+    fstype: []const u8,
+    options: []const u8,
+    dump: []const u8,
+    pass: []const u8,
+    line: []const u8,
+};
+
+pub fn parseFstabFields(line: []const u8) ?FstabFields {
+    const trimmed = std.mem.trim(u8, line, " \t");
+    if (trimmed.len == 0 or trimmed[0] == '#') return null;
+
+    var fields: [6][]const u8 = undefined;
+    var count: usize = 0;
+    var iter = std.mem.tokenizeAny(u8, trimmed, " \t");
+    while (iter.next()) |field| {
+        if (count >= 6) break;
+        fields[count] = field;
+        count += 1;
+    }
+    if (count < 4) return null;
+
+    return FstabFields{
+        .device = fields[0],
+        .mount_point = fields[1],
+        .fstype = fields[2],
+        .options = fields[3],
+        .dump = if (count > 4) fields[4] else "0",
+        .pass = if (count > 5) fields[5] else "0",
+        .line = trimmed,
+    };
+}
+
+fn parseFstab(allocator: std.mem.Allocator, mount_point: []const u8) !?FstabFields {
+    const content = try std.fs.cwd().readFileAlloc(allocator, "/etc/fstab", 1024 * 1024);
+
+    var result: ?FstabFields = null;
+    var lines_iter = std.mem.splitScalar(u8, content, '\n');
+    while (lines_iter.next()) |line| {
+        if (parseFstabFields(line)) |fields| {
+            if (std.mem.eql(u8, fields.mount_point, mount_point)) {
+                result = fields;
+            }
+        }
+    }
+    return result;
+}
+
+fn isMounted(allocator: std.mem.Allocator, mount_point: []const u8) !bool {
+    const output = try runCommand(allocator, &[_][]const u8{"/bin/mount"});
+
+    var lines_iter = std.mem.splitScalar(u8, output, '\n');
+    while (lines_iter.next()) |line| {
+        if (parseMountOutputLine(line, mount_point)) return true;
+    }
+    return false;
+}
+
+pub fn parseMountOutputLine(line: []const u8, mount_point: []const u8) bool {
+    // Format: "device on mount_point type fstype (options)"
+    const needle = " on ";
+    const on_idx = std.mem.indexOf(u8, line, needle) orelse return false;
+    const after_on = line[on_idx + needle.len ..];
+    const type_idx = std.mem.indexOf(u8, after_on, " type ") orelse return false;
+    const mp = after_on[0..type_idx];
+    return std.mem.eql(u8, mp, mount_point);
+}
+
+fn runCommand(allocator: std.mem.Allocator, argv: []const []const u8) ![]const u8 {
+    var child = std.process.Child.init(argv, allocator);
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+
+    try child.spawn();
+
+    const stdout = try child.stdout.?.readToEndAlloc(allocator, std.math.maxInt(usize));
+    const stderr = try child.stderr.?.readToEndAlloc(allocator, std.math.maxInt(usize));
+    defer allocator.free(stderr);
+
+    const term = try child.wait();
+
+    switch (term) {
+        .Exited => |code| {
+            if (code != 0) {
+                logger.debug("[mount] command failed with code {d}\n", .{code});
+                if (stderr.len > 0) {
+                    logger.err("  stderr: {s}\n", .{stderr});
+                }
+                return error.CommandFailed;
+            }
+        },
+        else => return error.CommandFailed,
+    }
+
+    return stdout;
+}
+
+pub const ruby_prelude = @embedFile("mount_resource.rb");
+
+pub fn zigAddResource(
+    mrb: *mruby.mrb_state,
+    _: mruby.mrb_value,
+    mount_resources: *std.ArrayList(Resource),
+    allocator: std.mem.Allocator,
+) mruby.mrb_value {
+    var mount_point_val: mruby.mrb_value = undefined;
+    var device_val: mruby.mrb_value = undefined;
+    var device_type_val: mruby.mrb_value = undefined;
+    var fstype_val: mruby.mrb_value = undefined;
+    var options_val: mruby.mrb_value = undefined;
+    var dump_val: mruby.mrb_value = undefined;
+    var pass_val: mruby.mrb_value = undefined;
+    var supports_remount_val: mruby.mrb_value = undefined;
+    var actions_val: mruby.mrb_value = undefined;
+    var only_if_val: mruby.mrb_value = undefined;
+    var not_if_val: mruby.mrb_value = undefined;
+    var ignore_failure_val: mruby.mrb_value = undefined;
+    var notifications_val: mruby.mrb_value = undefined;
+    var subscriptions_val: mruby.mrb_value = undefined;
+
+    // Format: SSSSSSSoA|oooAA (7 strings + 1 object + 1 array | optionals)
+    _ = mruby.mrb_get_args(
+        mrb,
+        "SSSSSSSoA|oooAA",
+        &mount_point_val,
+        &device_val,
+        &device_type_val,
+        &fstype_val,
+        &options_val,
+        &dump_val,
+        &pass_val,
+        &supports_remount_val,
+        &actions_val,
+        &only_if_val,
+        &not_if_val,
+        &ignore_failure_val,
+        &notifications_val,
+        &subscriptions_val,
+    );
+
+    const mount_point_cstr = mruby.mrb_str_to_cstr(mrb, mount_point_val);
+    const mount_point_span = std.mem.span(mount_point_cstr);
+
+    const device_cstr = mruby.mrb_str_to_cstr(mrb, device_val);
+    const device_span = std.mem.span(device_cstr);
+
+    const device_type_cstr = mruby.mrb_str_to_cstr(mrb, device_type_val);
+    const device_type = Resource.deviceTypeFromString(std.mem.span(device_type_cstr));
+
+    const fstype_cstr = mruby.mrb_str_to_cstr(mrb, fstype_val);
+    const fstype_span = std.mem.span(fstype_cstr);
+
+    const options_cstr = mruby.mrb_str_to_cstr(mrb, options_val);
+    const options_span = std.mem.span(options_cstr);
+
+    const dump_cstr = mruby.mrb_str_to_cstr(mrb, dump_val);
+    const dump = std.fmt.parseInt(u8, std.mem.span(dump_cstr), 10) catch 0;
+
+    const pass_cstr = mruby.mrb_str_to_cstr(mrb, pass_val);
+    const pass_num = std.fmt.parseInt(u8, std.mem.span(pass_cstr), 10) catch 0;
+
+    const supports_remount = mruby.mrb_test(supports_remount_val);
+
+    const actions_len = mruby.mrb_ary_len(mrb, actions_val);
+
+    logger.debug("[mount] actions_len = {d}", .{actions_len});
+
+    var i: mruby.mrb_int = 0;
+    while (i < actions_len) : (i += 1) {
+        const action_val = mruby.mrb_ary_ref(mrb, actions_val, @intCast(i));
+        const action_cstr = mruby.mrb_str_to_cstr(mrb, action_val);
+        const action = Resource.actionFromString(std.mem.span(action_cstr));
+
+        const mount_point = allocator.dupe(u8, mount_point_span) catch return mruby.mrb_nil_value();
+        const device = allocator.dupe(u8, device_span) catch return mruby.mrb_nil_value();
+        const fstype = allocator.dupe(u8, fstype_span) catch return mruby.mrb_nil_value();
+        const options = allocator.dupe(u8, options_span) catch return mruby.mrb_nil_value();
+
+        var common = base.CommonProps.init(allocator);
+        base.fillCommonFromRuby(&common, mrb, only_if_val, not_if_val, ignore_failure_val, notifications_val, subscriptions_val, allocator);
+
+        mount_resources.append(allocator, .{
+            .mount_point = mount_point,
+            .device = device,
+            .device_type = device_type,
+            .fstype = fstype,
+            .options = options,
+            .dump = dump,
+            .pass = pass_num,
+            .supports_remount = supports_remount,
+            .action = action,
+            .common = common,
+        }) catch return mruby.mrb_nil_value();
+    }
+
+    return mruby.mrb_nil_value();
+}
+
+// Tests
+test "parseFstabFields parses standard fstab line" {
+    const line = "/dev/sda1\t/\text4\tdefaults\t0\t1";
+    const fields = parseFstabFields(line).?;
+    try std.testing.expectEqualStrings("/dev/sda1", fields.device);
+    try std.testing.expectEqualStrings("/", fields.mount_point);
+    try std.testing.expectEqualStrings("ext4", fields.fstype);
+    try std.testing.expectEqualStrings("defaults", fields.options);
+    try std.testing.expectEqualStrings("0", fields.dump);
+    try std.testing.expectEqualStrings("1", fields.pass);
+}
+
+test "parseFstabFields skips comments" {
+    const line = "# /dev/sda1 / ext4 defaults 0 1";
+    try std.testing.expect(parseFstabFields(line) == null);
+}
+
+test "parseFstabFields skips empty lines" {
+    try std.testing.expect(parseFstabFields("") == null);
+    try std.testing.expect(parseFstabFields("   ") == null);
+}
+
+test "parseFstabFields parses line with spaces" {
+    const line = "UUID=abc-123   /mnt/data   ext4   defaults,noatime   0   2";
+    const fields = parseFstabFields(line).?;
+    try std.testing.expectEqualStrings("UUID=abc-123", fields.device);
+    try std.testing.expectEqualStrings("/mnt/data", fields.mount_point);
+    try std.testing.expectEqualStrings("ext4", fields.fstype);
+    try std.testing.expectEqualStrings("defaults,noatime", fields.options);
+    try std.testing.expectEqualStrings("0", fields.dump);
+    try std.testing.expectEqualStrings("2", fields.pass);
+}
+
+test "parseFstabFields handles minimal fields" {
+    const line = "/dev/sdb1 /mnt/backup xfs rw";
+    const fields = parseFstabFields(line).?;
+    try std.testing.expectEqualStrings("/dev/sdb1", fields.device);
+    try std.testing.expectEqualStrings("/mnt/backup", fields.mount_point);
+    try std.testing.expectEqualStrings("xfs", fields.fstype);
+    try std.testing.expectEqualStrings("rw", fields.options);
+    try std.testing.expectEqualStrings("0", fields.dump);
+    try std.testing.expectEqualStrings("0", fields.pass);
+}
+
+test "actionFromString converts correctly" {
+    try std.testing.expect(Resource.actionFromString("mount") == .mount_action);
+    try std.testing.expect(Resource.actionFromString("umount") == .umount);
+    try std.testing.expect(Resource.actionFromString("remount") == .remount);
+    try std.testing.expect(Resource.actionFromString("enable") == .enable);
+    try std.testing.expect(Resource.actionFromString("disable") == .disable);
+    try std.testing.expect(Resource.actionFromString("unknown") == .nothing);
+}
+
+test "parseMountOutputLine matches mount point" {
+    const line = "/dev/sda1 on / type ext4 (rw,relatime)";
+    try std.testing.expect(parseMountOutputLine(line, "/"));
+    try std.testing.expect(!parseMountOutputLine(line, "/mnt"));
+}
+
+test "parseMountOutputLine handles NFS" {
+    const line = "server:/export on /mnt/nfs type nfs (rw,hard,intr)";
+    try std.testing.expect(parseMountOutputLine(line, "/mnt/nfs"));
+    try std.testing.expect(!parseMountOutputLine(line, "/mnt"));
+}
+
+test "parseMountOutputLine rejects invalid lines" {
+    try std.testing.expect(!parseMountOutputLine("", "/mnt"));
+    try std.testing.expect(!parseMountOutputLine("no on keyword here", "/mnt"));
+}

--- a/src/resources/mount_resource.rb
+++ b/src/resources/mount_resource.rb
@@ -1,0 +1,106 @@
+module ZigBackend
+end
+
+class MountResource
+  def initialize(name, &block)
+    @mount_point = name
+    @device = ""
+    @device_type = "device"
+    @fstype = "auto"
+    @options = ["defaults"]
+    @dump = 0
+    @pass = 2
+    @supports = { remount: false }
+    @action = [:mount, :enable]
+    @only_if_proc = nil
+    @not_if_proc = nil
+    @ignore_failure = false
+    @notifications = []
+    @subscriptions = []
+    instance_eval(&block) if block
+
+    only_if_arg = @only_if_proc || nil
+    not_if_arg = @not_if_proc || nil
+
+    notifications_arg = @notifications.map { |n| [n[:target], n[:action], n[:timing]] }
+    subscriptions_arg = @subscriptions.map { |s| [s[:target], s[:action], s[:timing]] }
+
+    actions_arg = Array(@action).map(&:to_s)
+    options_str = Array(@options).join(",")
+    supports_remount = @supports[:remount] ? true : false
+
+    return unless ZigBackend.respond_to?(:add_mount)
+
+    ZigBackend.add_mount(
+      @mount_point, @device, @device_type.to_s, @fstype,
+      options_str, @dump.to_s, @pass.to_s, supports_remount,
+      actions_arg,
+      only_if_arg, not_if_arg, @ignore_failure,
+      notifications_arg, subscriptions_arg
+    )
+  end
+
+  def device(value)
+    @device = value.to_s
+  end
+
+  def device_type(value)
+    @device_type = value.to_s
+  end
+
+  def fstype(value)
+    @fstype = value.to_s
+  end
+
+  def options(value)
+    @options = Array(value)
+  end
+
+  def dump(value)
+    @dump = value.to_i
+  end
+
+  def pass(value)
+    @pass = value.to_i
+  end
+
+  def supports(value)
+    @supports = value
+  end
+
+  def action(value)
+    @action = value
+  end
+
+  def only_if(command = nil, &block)
+    @only_if_proc = command&.to_s || block
+  end
+
+  def not_if(command = nil, &block)
+    @not_if_proc = command&.to_s || block
+  end
+
+  def ignore_failure(value)
+    @ignore_failure = value
+  end
+
+  def notifies(action, target_resource, timer = :delayed)
+    @notifications << {
+      target: target_resource,
+      action: action.to_s,
+      timing: timer.to_s
+    }
+  end
+
+  def subscribes(action, source_resource, timer = :delayed)
+    @subscriptions << {
+      target: source_resource,
+      action: action.to_s,
+      timing: timer.to_s
+    }
+  end
+end
+
+def mount(name, &block)
+  MountResource.new(name, &block)
+end

--- a/src/ruby_prelude/data_bag.rb
+++ b/src/ruby_prelude/data_bag.rb
@@ -1,0 +1,10 @@
+# data_bag support for agent mode
+# $_hola_params is injected by the provision engine as a parsed Hash
+$_hola_params ||= {}
+
+def data_bag(*keys)
+  keys.reduce($_hola_params) do |val, key|
+    return nil unless val.is_a?(Hash)
+    val[key.to_s]
+  end
+end

--- a/src/sse.zig
+++ b/src/sse.zig
@@ -1,0 +1,164 @@
+const std = @import("std");
+
+/// A parsed SSE event
+pub const Event = struct {
+    event_type: ?[]const u8 = null,
+    data: ?[]const u8 = null,
+    id: ?[]const u8 = null,
+
+    pub fn deinit(self: *Event, allocator: std.mem.Allocator) void {
+        if (self.event_type) |v| allocator.free(v);
+        if (self.data) |v| allocator.free(v);
+        if (self.id) |v| allocator.free(v);
+    }
+};
+
+/// Incremental SSE line-protocol parser.
+/// Feed raw bytes via `feed()`, poll complete events via `next()`.
+pub const Parser = struct {
+    allocator: std.mem.Allocator,
+    line_buf: std.ArrayList(u8),
+    // Accumulated fields for the current event
+    data_buf: std.ArrayList(u8),
+    event_type: ?[]const u8 = null,
+    event_id: ?[]const u8 = null,
+    has_data: bool = false,
+    // Queue of complete events ready to be consumed
+    events: std.ArrayList(Event),
+
+    pub fn init(allocator: std.mem.Allocator) Parser {
+        return .{
+            .allocator = allocator,
+            .line_buf = std.ArrayList(u8).empty,
+            .data_buf = std.ArrayList(u8).empty,
+            .events = std.ArrayList(Event).empty,
+        };
+    }
+
+    pub fn deinit(self: *Parser) void {
+        self.line_buf.deinit(self.allocator);
+        self.data_buf.deinit(self.allocator);
+        if (self.event_type) |v| self.allocator.free(v);
+        if (self.event_id) |v| self.allocator.free(v);
+        for (self.events.items) |*ev| ev.deinit(self.allocator);
+        self.events.deinit(self.allocator);
+    }
+
+    /// Feed a chunk of raw bytes from the HTTP stream.
+    pub fn feed(self: *Parser, data: []const u8) !void {
+        for (data) |byte| {
+            if (byte == '\n') {
+                try self.processLine();
+                self.line_buf.clearRetainingCapacity();
+            } else if (byte == '\r') {
+                // ignore CR, we handle LF
+            } else {
+                try self.line_buf.append(self.allocator, byte);
+            }
+        }
+    }
+
+    /// Return the next complete event, or null.
+    pub fn next(self: *Parser) ?Event {
+        if (self.events.items.len == 0) return null;
+        return self.events.orderedRemove(0);
+    }
+
+    fn processLine(self: *Parser) !void {
+        const line = self.line_buf.items;
+
+        // Empty line → dispatch event
+        if (line.len == 0) {
+            if (self.has_data) {
+                const ev = Event{
+                    .event_type = self.event_type,
+                    .data = try self.allocator.dupe(u8, self.data_buf.items),
+                    .id = self.event_id,
+                };
+                try self.events.append(self.allocator, ev);
+                // Reset accumulators (ownership transferred)
+                self.event_type = null;
+                self.event_id = null;
+                self.data_buf.clearRetainingCapacity();
+                self.has_data = false;
+            }
+            return;
+        }
+
+        // Comment line
+        if (line[0] == ':') return;
+
+        // Parse "field: value" or "field:value"
+        var field: []const u8 = line;
+        var value: []const u8 = "";
+        if (std.mem.indexOfScalar(u8, line, ':')) |colon| {
+            field = line[0..colon];
+            const rest = line[colon + 1 ..];
+            value = if (rest.len > 0 and rest[0] == ' ') rest[1..] else rest;
+        }
+
+        if (std.mem.eql(u8, field, "data")) {
+            if (self.has_data) try self.data_buf.append(self.allocator, '\n');
+            try self.data_buf.appendSlice(self.allocator, value);
+            self.has_data = true;
+        } else if (std.mem.eql(u8, field, "event")) {
+            if (self.event_type) |old| self.allocator.free(old);
+            self.event_type = try self.allocator.dupe(u8, value);
+        } else if (std.mem.eql(u8, field, "id")) {
+            if (self.event_id) |old| self.allocator.free(old);
+            self.event_id = try self.allocator.dupe(u8, value);
+        }
+        // "retry" and unknown fields are ignored
+    }
+};
+
+// Tests
+test "parse single event" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+    defer parser.deinit();
+
+    try parser.feed("event: provision\ndata: {\"url\":\"https://example.com/test.rb\"}\n\n");
+
+    var ev = parser.next() orelse return error.ExpectedEvent;
+    defer ev.deinit(allocator);
+
+    try std.testing.expectEqualStrings("provision", ev.event_type.?);
+    try std.testing.expectEqualStrings("{\"url\":\"https://example.com/test.rb\"}", ev.data.?);
+}
+
+test "parse multi-line data" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+    defer parser.deinit();
+
+    try parser.feed("data: line1\ndata: line2\n\n");
+
+    var ev = parser.next() orelse return error.ExpectedEvent;
+    defer ev.deinit(allocator);
+
+    try std.testing.expectEqualStrings("line1\nline2", ev.data.?);
+}
+
+test "ignore comments and empty chunks" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+    defer parser.deinit();
+
+    try parser.feed(": this is a comment\n\n");
+    try std.testing.expect(parser.next() == null);
+}
+
+test "incremental feed across chunks" {
+    const allocator = std.testing.allocator;
+    var parser = Parser.init(allocator);
+    defer parser.deinit();
+
+    try parser.feed("data: hel");
+    try parser.feed("lo\n\n");
+
+    var ev = parser.next() orelse return error.ExpectedEvent;
+    defer ev.deinit(allocator);
+
+    try std.testing.expectEqualStrings("hello", ev.data.?);
+}


### PR DESCRIPTION
## Summary

- **Agent command**: Long-running daemon that receives tasks via WebSocket or HTTP polling, executes provision scripts, and reports results via callback
- **mTLS support**: `--client-cert` / `--client-key` for mutual TLS authentication (Cloudflare API Shield compatible)
- **Extract resource**: Archive extraction (tar.gz/tar.xz/tar) with glob-based file mapping, strip_components, and marker-based idempotency
- **Mount resource**: Linux filesystem mount/umount/remount/enable/disable with fstab management
- **ProvisionResult**: Structured execution results with per-resource output, enabling agent callback reporting
- **data_bag**: Parameter injection for provision scripts via `--params` JSON or agent task payload
- **User-agent fix**: `build_options` was not exported, user-agent always reported 0.1.0

## Commits

- `feat(agent)`: Add agent command with WebSocket and watch polling modes
- `feat(agent)`: Replace SSE with WebSocket connection mode
- `feat(agent)`: Add mTLS client certificate support with origin-based callback detection
- `feat(resource)`: Add extract resource for archive extraction
- `feat(resource)`: Add mount resource for Linux filesystem mounts
- `feat(resource)`: Capture output in ApplyResult for execute and file resources
- `feat(provision)`: Return structured ProvisionResult from run()
- `feat(provision)`: Add data_bag support for parameter injection
- `fix(provision)`: Remove 4KB buffer limit in data_bag params injection
- `fix(provision)`: Show log file path on failure
- `fix(agent)`: Add retry for callback POST requests
- `fix(agent)`: Mask password in URL log output
- `fix`: Expose build_options so user-agent reports correct version

## Test plan

- [x] `zig build` and `zig build test` pass on macOS
- [x] Cross-compile `zig build -Dtarget=x86_64-linux-gnu` passes
- [x] Mount resource: 9/9 Docker integration tests pass (tmpfs, loop device, umount, disable, remount, fstab replace, idempotency, macOS no-op)
- [x] Extract resource: unit tests for archive detection, glob matching, strip_components
- [x] Agent mTLS: originMatches unit tests (port normalization, scheme equivalence)
- [x] mTLS verified with Cloudflare API Shield (curl --cert/--key)
- [x] Agent WebSocket mode end-to-end with hub