### PR TITLE
feat: add secrets_bag support for sensitive data injection

### DIFF
--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -177,11 +177,23 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
     };
     defer if (params_json) |p| allocator.free(p);
 
+    // Extract secrets field as JSON string for secrets_bag injection
+    const secrets_json: ?[]const u8 = blk: {
+        if (obj.get("secrets")) |v| {
+            if (v == .object) {
+                const json_str = std.fmt.allocPrint(allocator, "{f}", .{std.json.fmt(v, .{})}) catch break :blk null;
+                break :blk json_str;
+            }
+        }
+        break :blk null;
+    };
+    defer if (secrets_json) |s| allocator.free(s);
+
     const display_url = maskUrlPassword(allocator, url);
     defer if (display_url.ptr != url.ptr) allocator.free(display_url);
     std.debug.print("[agent] task={s} action={s} provisioning: {s}\n", .{ task_id, action_name, display_url });
 
-    var prov_result = provision_cmd.runScript(allocator, url, false, params_json) catch |err| {
+    var prov_result = provision_cmd.runScript(allocator, url, false, params_json, secrets_json) catch |err| {
         std.debug.print("[agent] provision failed: {}\n", .{err});
         if (callback_url) |cb| {
             sendCallback(allocator, cb, data, "error", @errorName(err), null, endpoint, tls_auth);
@@ -208,6 +220,7 @@ fn buildCallbackBody(allocator: std.mem.Allocator, event_data: []const u8, statu
 
     _ = obj.fetchSwapRemove("url");
     _ = obj.fetchSwapRemove("callback");
+    _ = obj.fetchSwapRemove("secrets");
 
     var result = std.json.ObjectMap.init(aa);
     try result.put("status", .{ .string = status });
@@ -654,7 +667,7 @@ test "buildCallbackBody with ProvisionResult" {
     };
 
     const event_data =
-        \\{"id":"task-1","url":"https://example.com/script.rb","callback":"https://example.com/done"}
+        \\{"id":"task-1","url":"https://example.com/script.rb","callback":"https://example.com/done","secrets":{"api_key":"sk-123"}}
     ;
 
     const body = try buildCallbackBody(allocator, event_data, "ok", null, &prov_result);
@@ -670,9 +683,11 @@ test "buildCallbackBody with ProvisionResult" {
     try std.testing.expect(std.mem.indexOf(u8, body, "\"resources\":[") != null);
     try std.testing.expect(std.mem.indexOf(u8, body, "\"/tmp/config\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, body, "\"skip_reason\":\"up to date\"") != null);
-    // url and callback should be removed
+    // url, callback, and secrets should be removed
     try std.testing.expect(std.mem.indexOf(u8, body, "\"url\":") == null);
     try std.testing.expect(std.mem.indexOf(u8, body, "\"callback\":") == null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"secrets\":") == null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "sk-123") == null);
 
     // Free the duped strings
     allocator.free(type1);

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -7,6 +7,7 @@ const params = clap.parseParamsComptime(
     \\-h, --help            Show help for provision
     \\-o, --output <MODE>   Output mode: pretty (default) or plain
     \\-p, --params <JSON>   JSON string to inject as data_bag
+    \\-s, --secrets <JSON>  JSON string to inject as secrets_bag
     \\<path>                Path to provision file (.rb)
     \\
 );
@@ -20,7 +21,7 @@ const parsers = .{
 /// Download a remote script to a temp file, run provision, then clean up.
 /// Accepts both local paths and HTTP(S) URLs.
 /// params_json: optional JSON string to inject as data_bag (agent mode).
-pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, use_pretty_output: bool, params_json: ?[]const u8) !provision.ProvisionResult {
+pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, use_pretty_output: bool, params_json: ?[]const u8, secrets_json: ?[]const u8) !provision.ProvisionResult {
     const is_url = std.mem.startsWith(u8, script_path_or_url, "http://") or
         std.mem.startsWith(u8, script_path_or_url, "https://");
 
@@ -106,6 +107,7 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, u
         .script_path = script_path,
         .use_pretty_output = use_pretty_output,
         .params_json = params_json,
+        .secrets_json = secrets_json,
     });
 }
 
@@ -138,7 +140,7 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
     }
 
     const logger = @import("../logger.zig");
-    var result = runScript(allocator, script_path_or_url, use_pretty_output, res.args.params) catch |err| {
+    var result = runScript(allocator, script_path_or_url, use_pretty_output, res.args.params, res.args.secrets) catch |err| {
         std.debug.print("Provision failed: {}\n", .{err});
         if (logger.getLogPath()) |log_path| {
             std.debug.print("Log file: {s}\n", .{log_path});
@@ -163,6 +165,8 @@ fn printHelp(reason: ?[]const u8) !void {
         \\
         \\Options:
         \\  -o, --output MODE    Output mode: pretty (default) or plain
+        \\  -p, --params JSON    JSON string to inject as data_bag
+        \\  -s, --secrets JSON   JSON string to inject as secrets_bag
         \\
         \\Examples
         \\  # Local file

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -22,6 +22,7 @@ pub const Options = struct {
     script_path: []const u8,
     use_pretty_output: bool = true, // Default to pretty output
     params_json: ?[]const u8 = null, // JSON string for data_bag injection
+    secrets_json: ?[]const u8 = null, // JSON string for secrets_bag injection
 };
 
 pub const ResourceResult = struct {
@@ -759,26 +760,25 @@ fn registerResourceBindings(mrb_ptr: *mruby.mrb_state, zig_module: *mruby.RClass
     }
 }
 
-/// Inject params JSON into mruby as $_hola_params global variable.
-/// Uses mruby's JSON.parse to convert the JSON string into a Ruby Hash.
-fn injectParams(mrb: *mruby.mrb_state, params_json: []const u8) !void {
-    // Build Ruby code: $_hola_params = JSON.parse('...')
-    // Escape single quotes in JSON to avoid breaking the Ruby string literal
+/// Inject a JSON string into mruby as a global variable via JSON.parse.
+fn injectJsonGlobal(mrb: *mruby.mrb_state, global_name: []const u8, json_str: []const u8) !void {
     var escaped_len: usize = 0;
-    for (params_json) |ch| {
+    for (json_str) |ch| {
         escaped_len += if (ch == '\'' or ch == '\\') @as(usize, 2) else 1;
     }
 
     const allocator = std.heap.c_allocator;
-    const buf = try allocator.alloc(u8, escaped_len + 64 + 1); // prefix + suffix + null terminator
+    const buf = try allocator.alloc(u8, global_name.len + escaped_len + 64 + 1);
     defer allocator.free(buf);
 
     var pos: usize = 0;
-    const prefix = "$_hola_params = JSON.parse('";
-    @memcpy(buf[pos .. pos + prefix.len], prefix);
-    pos += prefix.len;
+    @memcpy(buf[pos .. pos + global_name.len], global_name);
+    pos += global_name.len;
+    const assign = " = JSON.parse('";
+    @memcpy(buf[pos .. pos + assign.len], assign);
+    pos += assign.len;
 
-    for (params_json) |ch| {
+    for (json_str) |ch| {
         if (ch == '\'' or ch == '\\') {
             buf[pos] = '\\';
             pos += 1;
@@ -791,7 +791,6 @@ fn injectParams(mrb: *mruby.mrb_state, params_json: []const u8) !void {
     @memcpy(buf[pos .. pos + suffix.len], suffix);
     pos += suffix.len;
 
-    // Null-terminate and evaluate the Ruby code
     buf[pos] = 0;
     _ = mruby.mrb_load_string(mrb, buf.ptr);
 
@@ -800,6 +799,16 @@ fn injectParams(mrb: *mruby.mrb_state, params_json: []const u8) !void {
         mruby.mrb_print_error(mrb);
         return error.MRubyException;
     }
+}
+
+/// Inject params JSON into mruby as $_hola_params global variable.
+fn injectParams(mrb: *mruby.mrb_state, params_json: []const u8) !void {
+    try injectJsonGlobal(mrb, "$_hola_params", params_json);
+}
+
+/// Inject secrets JSON into mruby as $_hola_secrets global variable.
+fn injectSecrets(mrb: *mruby.mrb_state, secrets_json: []const u8) !void {
+    try injectJsonGlobal(mrb, "$_hola_secrets", secrets_json);
 }
 
 pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
@@ -883,9 +892,17 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     // Load data_bag support
     try mrb.evalString(@embedFile("ruby_prelude/data_bag.rb"));
 
+    // Load secrets_bag support
+    try mrb.evalString(@embedFile("ruby_prelude/secrets_bag.rb"));
+
     // Inject params as $_hola_params if provided (agent mode)
     if (opts.params_json) |params_json| {
         try injectParams(mrb_ptr, params_json);
+    }
+
+    // Inject secrets as $_hola_secrets if provided
+    if (opts.secrets_json) |secrets_json| {
+        try injectSecrets(mrb_ptr, secrets_json);
     }
 
     // Load test helper only in debug builds
@@ -1325,4 +1342,47 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
         .duration_ms = @intCast(elapsed_ms),
         .resource_results = resource_results,
     };
+}
+
+test "injectSecrets and secrets_bag reads values correctly" {
+    var mrb = try mruby.State.init();
+    defer mrb.deinit();
+
+    const mrb_ptr = mrb.mrb orelse return error.MRubyNotInitialized;
+
+    // Register ZigBackend module with JSON functions
+    const zig_module = mruby.mrb_define_module(mrb_ptr, "ZigBackend");
+    json.setAllocator(std.testing.allocator);
+    for (json.mruby_module_def.getFunctions()) |func| {
+        mruby.mrb_define_module_function(mrb_ptr, zig_module, func.name.ptr, func.func, func.args);
+    }
+    try mrb.evalString(json.ruby_prelude);
+
+    // Load secrets_bag prelude
+    try mrb.evalString(@embedFile("ruby_prelude/secrets_bag.rb"));
+
+    // Inject secrets
+    try injectSecrets(mrb_ptr, "{\"api_key\":\"sk-123\",\"nested\":{\"token\":\"abc\"}}");
+
+    // Test simple key access
+    try mrb.evalString("$_test_result = secrets_bag('api_key')");
+    const sym = mruby.mrb_intern_cstr(mrb_ptr, "$_test_result");
+    const result = mruby.mrb_gv_get(mrb_ptr, sym);
+    try std.testing.expect(mruby.zig_mrb_string_p(result) != 0);
+    const cstr = mruby.mrb_str_to_cstr(mrb_ptr, result);
+    try std.testing.expectEqualStrings("sk-123", std.mem.span(cstr));
+
+    // Test nested key access
+    try mrb.evalString("$_test_result2 = secrets_bag('nested', 'token')");
+    const sym2 = mruby.mrb_intern_cstr(mrb_ptr, "$_test_result2");
+    const result2 = mruby.mrb_gv_get(mrb_ptr, sym2);
+    try std.testing.expect(mruby.zig_mrb_string_p(result2) != 0);
+    const cstr2 = mruby.mrb_str_to_cstr(mrb_ptr, result2);
+    try std.testing.expectEqualStrings("abc", std.mem.span(cstr2));
+
+    // Test missing key returns nil
+    try mrb.evalString("$_test_result3 = secrets_bag('nonexistent')");
+    const sym3 = mruby.mrb_intern_cstr(mrb_ptr, "$_test_result3");
+    const result3 = mruby.mrb_gv_get(mrb_ptr, sym3);
+    try std.testing.expect(!mruby.mrb_test(result3));
 }

--- a/src/resources/git.zig
+++ b/src/resources/git.zig
@@ -146,6 +146,98 @@ pub const Resource = struct {
         }
     }
 
+    /// State for temporarily switching effective user/group identity.
+    /// Used so that libgit2 operations (clone, fetch, open) run under the
+    /// uid/gid specified by the resource's `user`/`group` attributes.
+    const MAX_NGROUPS = 64;
+
+    const UserSwitch = struct {
+        original_uid: c_uint,
+        original_gid: c_uint,
+        original_ngroups: c_int,
+        original_groups: [MAX_NGROUPS]c_uint,
+        switched: bool,
+    };
+
+    const posix_c = @cImport({
+        @cInclude("unistd.h");
+        @cInclude("pwd.h");
+        @cInclude("grp.h");
+    });
+
+    /// Switch the process effective uid/gid to the target user/group.
+    /// Returns a context that must be passed to `restoreEffectiveUser` to undo the switch.
+    /// If user and group are both null, returns a no-op context.
+    fn switchEffectiveUser(user: ?[]const u8, group: ?[]const u8) !UserSwitch {
+        if (user == null and group == null) {
+            return UserSwitch{ .original_uid = 0, .original_gid = 0, .original_ngroups = 0, .original_groups = undefined, .switched = false };
+        }
+
+        const original_uid = posix_c.geteuid();
+        const original_gid = posix_c.getegid();
+
+        // Save supplementary groups before initgroups overwrites them
+        var original_groups: [MAX_NGROUPS]c_uint = undefined;
+        const original_ngroups = posix_c.getgroups(MAX_NGROUPS, &original_groups);
+
+        // Set group first (must be done while still running as root)
+        if (group) |groupname| {
+            const gid = try base.getGroupId(groupname);
+            if (posix_c.setegid(gid) != 0) {
+                logger.err("[git] failed to setegid for group '{s}'", .{groupname});
+                return error.SetGroupFailed;
+            }
+        } else if (user) |username| {
+            // No explicit group — use the user's primary group
+            const username_z = try std.posix.toPosixPath(username);
+            const pwd = posix_c.getpwnam(&username_z);
+            if (pwd != null) {
+                _ = posix_c.setegid(pwd.*.pw_gid);
+            }
+        }
+
+        // Initialize supplementary groups for proper file access
+        if (user) |username| {
+            const username_z = try std.posix.toPosixPath(username);
+            const current_egid = posix_c.getegid();
+            _ = posix_c.initgroups(&username_z, @intCast(current_egid));
+        }
+
+        // Switch effective uid last (drops privileges)
+        if (user) |username| {
+            const uid = try base.getUserId(username);
+            if (posix_c.seteuid(uid) != 0) {
+                // Rollback group change
+                _ = posix_c.setegid(original_gid);
+                logger.err("[git] failed to seteuid for user '{s}'", .{username});
+                return error.SetUserFailed;
+            }
+            logger.debug("[git] switched effective user to '{s}' (uid={})", .{ username, uid });
+        }
+
+        return UserSwitch{
+            .original_uid = original_uid,
+            .original_gid = original_gid,
+            .original_ngroups = original_ngroups,
+            .original_groups = original_groups,
+            .switched = true,
+        };
+    }
+
+    /// Restore effective uid/gid to the values saved in the UserSwitch context.
+    fn restoreEffectiveUser(ctx: UserSwitch) void {
+        if (!ctx.switched) return;
+        // Restore uid first — real uid is still root so this always succeeds,
+        // and we need root back before we can restore the group.
+        _ = posix_c.seteuid(ctx.original_uid);
+        _ = posix_c.setegid(ctx.original_gid);
+        // Restore supplementary groups that initgroups may have overwritten
+        if (ctx.original_ngroups >= 0) {
+            _ = posix_c.setgroups(@intCast(ctx.original_ngroups), &ctx.original_groups);
+        }
+        logger.debug("[git] restored effective user (uid={}, gid={})", .{ ctx.original_uid, ctx.original_gid });
+    }
+
     /// Context for custom credentials and certificate callbacks
     const SshContext = struct {
         ssh_key_path: ?[]const u8,
@@ -365,9 +457,18 @@ pub const Resource = struct {
         clone_opts.fetch_opts.callbacks.certificate_check = certificateCheckCallback;
         clone_opts.fetch_opts.callbacks.payload = &ssh_ctx;
 
+        // Switch effective user so libgit2 creates files with correct ownership
+        // and passes safe.directory / SSH key permission checks
+        const user_ctx = try switchEffectiveUser(self.user, self.group);
+        errdefer restoreEffectiveUser(user_ctx);
+
         // Perform clone
         var repo_ptr: ?*c.git_repository = null;
         const code = c.git_clone(&repo_ptr, url_c.ptr, dest_c.ptr, &clone_opts);
+
+        // Restore root before ownership fixup (chown requires root)
+        restoreEffectiveUser(user_ctx);
+
         if (code != 0) {
             const err = c.git_error_last();
             if (err != null) {
@@ -415,6 +516,10 @@ pub const Resource = struct {
         // Initialize libgit2 in this thread
         var git = try git_client.Client.init();
         defer git.deinit();
+
+        // Switch effective user for fetch/reset operations
+        const user_ctx = try switchEffectiveUser(self.user, self.group);
+        defer restoreEffectiveUser(user_ctx);
 
         // Fetch from remote
         const remote_c = try dupZ(allocator, self.remote);
@@ -515,28 +620,45 @@ pub const Resource = struct {
 
         if (!dest_exists or !isGitRepo(self.destination)) {
             // Clone the repository with custom credentials (async)
+            // (cloneRepositoryImpl handles user switching internally)
             try self.cloneRepository(allocator);
             was_updated = true;
         } else {
-            // Repository exists, fetch and reset (async)
-            const repo = try openRepository(allocator, self.destination) orelse return error.OpenRepoFailed;
-            defer c.git_repository_free(repo);
+            // Switch effective user for git_repository_open (safe.directory check)
+            const open_ctx = try switchEffectiveUser(self.user, self.group);
+            const repo = openRepository(allocator, self.destination) catch |err| {
+                restoreEffectiveUser(open_ctx);
+                return err;
+            };
+            restoreEffectiveUser(open_ctx);
+
+            const repo_nonnull = repo orelse return error.OpenRepoFailed;
+            defer c.git_repository_free(repo_nonnull);
 
             const fetch_ctx = FetchContext{
                 .resource = self,
                 .allocator = allocator,
-                .repo = repo,
+                .repo = repo_nonnull,
             };
             was_updated = try AsyncExecutor.executeWithContext(FetchContext, bool, fetch_ctx, fetchAndUpdateAsync);
         }
 
         // Update submodules if enabled
         if (self.enable_submodules and was_updated) {
-            const repo = try openRepository(allocator, self.destination) orelse return error.OpenRepoFailed;
-            defer c.git_repository_free(repo);
+            const sub_ctx = try switchEffectiveUser(self.user, self.group);
+            const sub_repo_opt = openRepository(allocator, self.destination) catch |err| {
+                restoreEffectiveUser(sub_ctx);
+                return err;
+            };
+            const sub_repo = sub_repo_opt orelse {
+                restoreEffectiveUser(sub_ctx);
+                return error.OpenRepoFailed;
+            };
+            defer c.git_repository_free(sub_repo);
 
             // Initialize and update submodules
-            const code = c.git_submodule_foreach(repo, submoduleUpdateCallback, null);
+            const code = c.git_submodule_foreach(sub_repo, submoduleUpdateCallback, null);
+            restoreEffectiveUser(sub_ctx);
             if (code != 0) {
                 logger.warn("[git] submodule update failed", .{});
             }

--- a/src/resources/git.zig
+++ b/src/resources/git.zig
@@ -565,13 +565,21 @@ pub const Resource = struct {
         defer allocator.free(current_rev);
 
         // Resolve target revision
-        const target_ref = if (std.mem.eql(u8, self.revision, "HEAD"))
-            try std.fmt.allocPrint(allocator, "{s}/{s}", .{ self.remote, self.checkout_branch orelse "deploy" })
-        else
-            try allocator.dupe(u8, self.revision);
-        defer allocator.free(target_ref);
-
-        const target_rev = try resolveRevision(allocator, repo, target_ref);
+        // For "HEAD", use checkout_branch on the remote.
+        // For other values, try as-is first (tag, SHA, or already-qualified ref),
+        // then fall back to {remote}/{revision} (bare branch name after fetch).
+        const target_rev = blk: {
+            if (std.mem.eql(u8, self.revision, "HEAD")) {
+                const ref = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ self.remote, self.checkout_branch orelse "deploy" });
+                defer allocator.free(ref);
+                break :blk try resolveRevision(allocator, repo, ref);
+            }
+            break :blk resolveRevision(allocator, repo, self.revision) catch {
+                const qualified = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ self.remote, self.revision });
+                defer allocator.free(qualified);
+                break :blk try resolveRevision(allocator, repo, qualified);
+            };
+        };
         defer allocator.free(target_rev);
 
         // Compare revisions

--- a/src/ruby_prelude/secrets_bag.rb
+++ b/src/ruby_prelude/secrets_bag.rb
@@ -1,0 +1,10 @@
+# secrets_bag support for sensitive data (passwords, API keys, etc.)
+# $_hola_secrets is injected by the provision engine as a parsed Hash
+$_hola_secrets ||= {}
+
+def secrets_bag(*keys)
+  keys.reduce($_hola_secrets) do |val, key|
+    return nil unless val.is_a?(Hash)
+    val[key.to_s]
+  end
+end


### PR DESCRIPTION
## Summary

- Add `--secrets <JSON>` CLI parameter for `hola provision` command
- Add `secrets` field support in agent task JSON, with automatic stripping from callback responses
- New `secrets_bag()` Ruby DSL function for accessing injected secrets in provision scripts
- Refactor `injectParams` into reusable `injectJsonGlobal` helper

## Test plan

- [x] `zig build test` passes (includes mruby integration test for secrets_bag + callback stripping test)
- [x] Manual CLI test: `hola provision script.rb --secrets '{"api_key":"sk-123"}' --output plain`
- [x] Verified `secrets_bag("key")`, nested access, and missing key returns nil
- [x] Verified callback body does not contain secrets field or values