### PR TITLE
fix(dock): clear stale CurrentHost shadow so Dock reads AnyHost value

### DIFF
--- a/src/commands/dock.zig
+++ b/src/commands/dock.zig
@@ -1,60 +1,144 @@
 const std = @import("std");
 const plist = @import("../plist.zig");
 
-pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
-    _ = iter;
+const c_cf = @cImport({
+    @cInclude("CoreFoundation/CoreFoundation.h");
+});
 
-    const readDockPref = struct {
-        fn call(alloc: std.mem.Allocator, key: []const u8) !?plist.Value {
-            const c = @cImport({
-                @cInclude("CoreFoundation/CoreFoundation.h");
-            });
+/// Read a dock preference from a specific host domain (AnyHost or CurrentHost).
+fn readDockPrefFromHost(alloc: std.mem.Allocator, key: []const u8, host: c_cf.CFStringRef) !?plist.Value {
+    const key_cf = c_cf.CFStringCreateWithCString(null, key.ptr, c_cf.kCFStringEncodingUTF8);
+    if (key_cf == null) return error.OutOfMemory;
+    defer c_cf.CFRelease(key_cf);
 
-            const key_cf = c.CFStringCreateWithCString(null, key.ptr, c.kCFStringEncodingUTF8);
-            if (key_cf == null) return error.OutOfMemory;
-            defer c.CFRelease(key_cf);
+    const domain = c_cf.CFStringCreateWithCString(null, "com.apple.dock", c_cf.kCFStringEncodingUTF8);
+    if (domain == null) return error.OutOfMemory;
+    defer c_cf.CFRelease(domain);
 
-            const domain = c.CFStringCreateWithCString(null, "com.apple.dock", c.kCFStringEncodingUTF8);
-            if (domain == null) return error.OutOfMemory;
-            defer c.CFRelease(domain);
+    const value_cf = c_cf.CFPreferencesCopyValue(key_cf, domain, c_cf.kCFPreferencesCurrentUser, host);
+    if (value_cf == null) return null;
+    defer c_cf.CFRelease(value_cf);
 
-            const value_cf = c.CFPreferencesCopyValue(key_cf, domain, c.kCFPreferencesCurrentUser, c.kCFPreferencesAnyHost);
-            if (value_cf == null) {
-                return null;
-            }
-            defer c.CFRelease(value_cf);
+    const type_id = c_cf.CFGetTypeID(value_cf);
 
-            const type_id = c.CFGetTypeID(value_cf);
-
-            if (type_id == c.CFNumberGetTypeID()) {
-                const num = @as(c.CFNumberRef, @ptrCast(value_cf));
-                var int_val: c_longlong = undefined;
-                if (c.CFNumberGetValue(num, c.kCFNumberLongLongType, &int_val) != 0) {
-                    return plist.Value{ .integer = @as(i64, @intCast(int_val)) };
-                }
-                return null;
-            } else if (type_id == c.CFBooleanGetTypeID()) {
-                const bool_val = c.CFBooleanGetValue(@as(c.CFBooleanRef, @ptrCast(value_cf)));
-                return plist.Value{ .boolean = bool_val != 0 };
-            } else if (type_id == c.CFStringGetTypeID()) {
-                const str = @as(c.CFStringRef, @ptrCast(value_cf));
-                const max_len = c.CFStringGetMaximumSizeForEncoding(c.CFStringGetLength(str), c.kCFStringEncodingUTF8);
-                var buf = try alloc.alloc(u8, @as(usize, @intCast(max_len)) + 1);
-                if (c.CFStringGetCString(str, buf.ptr, @as(c_long, @intCast(buf.len)), c.kCFStringEncodingUTF8) == 0) {
-                    alloc.free(buf);
-                    return null;
-                }
-                const len = std.mem.indexOfScalar(u8, buf, 0) orelse buf.len;
-                const str_slice = try alloc.dupe(u8, buf[0..len]);
-                alloc.free(buf);
-                return plist.Value{ .string = str_slice };
-            } else if (type_id == c.CFArrayGetTypeID()) {
-                return plist.Value{ .array = undefined };
-            }
-
+    if (type_id == c_cf.CFNumberGetTypeID()) {
+        const num = @as(c_cf.CFNumberRef, @ptrCast(value_cf));
+        var int_val: c_longlong = undefined;
+        if (c_cf.CFNumberGetValue(num, c_cf.kCFNumberLongLongType, &int_val) != 0) {
+            return plist.Value{ .integer = @as(i64, @intCast(int_val)) };
+        }
+        return null;
+    } else if (type_id == c_cf.CFBooleanGetTypeID()) {
+        const bool_val = c_cf.CFBooleanGetValue(@as(c_cf.CFBooleanRef, @ptrCast(value_cf)));
+        return plist.Value{ .boolean = bool_val != 0 };
+    } else if (type_id == c_cf.CFStringGetTypeID()) {
+        const str = @as(c_cf.CFStringRef, @ptrCast(value_cf));
+        const max_len = c_cf.CFStringGetMaximumSizeForEncoding(c_cf.CFStringGetLength(str), c_cf.kCFStringEncodingUTF8);
+        var buf = try alloc.alloc(u8, @as(usize, @intCast(max_len)) + 1);
+        if (c_cf.CFStringGetCString(str, buf.ptr, @as(c_long, @intCast(buf.len)), c_cf.kCFStringEncodingUTF8) == 0) {
+            alloc.free(buf);
             return null;
         }
-    }.call;
+        const len = std.mem.indexOfScalar(u8, buf, 0) orelse buf.len;
+        const str_slice = try alloc.dupe(u8, buf[0..len]);
+        alloc.free(buf);
+        return plist.Value{ .string = str_slice };
+    } else if (type_id == c_cf.CFArrayGetTypeID()) {
+        return plist.Value{ .array = undefined };
+    }
+
+    return null;
+}
+
+/// Compare two scalar plist values for equality. Treats bool and integer 0/1
+/// as equivalent because CFPreferences sometimes stores booleans as CFNumbers.
+fn scalarValuesEqual(a: plist.Value, b: plist.Value) bool {
+    return switch (a) {
+        .boolean => |x| switch (b) {
+            .boolean => |y| x == y,
+            .integer => |y| (if (x) @as(i64, 1) else 0) == y,
+            else => false,
+        },
+        .integer => |x| switch (b) {
+            .integer => |y| x == y,
+            .boolean => |y| x == (if (y) @as(i64, 1) else 0),
+            else => false,
+        },
+        .float => |x| switch (b) {
+            .float => |y| x == y,
+            else => false,
+        },
+        .string => |x| switch (b) {
+            .string => |y| std.mem.eql(u8, x, y),
+            else => false,
+        },
+        else => false,
+    };
+}
+
+fn fmtScalarValue(val: plist.Value, buf: *[32]u8) []const u8 {
+    return switch (val) {
+        .boolean => |b| if (b) "true" else "false",
+        .integer => |i| std.fmt.bufPrint(buf, "{d}", .{i}) catch "<int>",
+        .string => |s| s,
+        else => "<complex>",
+    };
+}
+
+/// Return the `defaults` type flag for the scalar so the migration hint
+/// writes the value back into AnyHost with the correct type.
+fn defaultsTypeFlag(val: plist.Value) []const u8 {
+    return switch (val) {
+        .boolean => "-bool",
+        .integer => "-int",
+        .float => "-float",
+        .string => "-string",
+        else => "",
+    };
+}
+
+/// Read a dock preference from AnyHost (matches defaults(1) default behavior),
+/// falling back to CurrentHost when AnyHost is unset so that legacy installs
+/// with only ByHost values still export their real configuration. Warn to
+/// stderr when the two domains disagree or when CurrentHost is shadowing an
+/// expected AnyHost value. Callers own the returned value and must deinit it.
+fn readDockPref(alloc: std.mem.Allocator, key: []const u8) !?plist.Value {
+    const any = try readDockPrefFromHost(alloc, key, c_cf.kCFPreferencesAnyHost);
+    var cur = try readDockPrefFromHost(alloc, key, c_cf.kCFPreferencesCurrentHost);
+    var return_cur = false;
+    defer if (!return_cur) {
+        if (cur) |*v| v.deinit(alloc);
+    };
+
+    var fmt_buf1: [32]u8 = undefined;
+    var fmt_buf2: [32]u8 = undefined;
+
+    if (any) |any_val| {
+        if (cur) |cur_val| {
+            if (!scalarValuesEqual(any_val, cur_val)) {
+                std.debug.print("warning: com.apple.dock/{s}: AnyHost={s}, CurrentHost={s} (stale); using AnyHost\n", .{
+                    key, fmtScalarValue(any_val, &fmt_buf1), fmtScalarValue(cur_val, &fmt_buf2),
+                });
+                std.debug.print("  hint: defaults -currentHost delete com.apple.dock {s}\n", .{key});
+            }
+        }
+        return any;
+    } else if (cur) |cur_val| {
+        std.debug.print("warning: com.apple.dock/{s}: only CurrentHost={s} is set; using it for compatibility\n", .{
+            key, fmtScalarValue(cur_val, &fmt_buf1),
+        });
+        std.debug.print("  hint: migrate with: defaults write com.apple.dock {s} {s} {s} && defaults -currentHost delete com.apple.dock {s}\n", .{
+            key, defaultsTypeFlag(cur_val), fmtScalarValue(cur_val, &fmt_buf2), key,
+        });
+        return_cur = true;
+        return cur;
+    }
+
+    return null;
+}
+
+pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
+    _ = iter;
 
     const home_dir = std.process.getEnvVarOwned(allocator, "HOME") catch {
         std.debug.print("Error: HOME environment variable not set\n", .{});
@@ -219,5 +303,6 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
     try std.fmt.format(output.writer(allocator), "  largesize {d}\n", .{largesize});
     try output.appendSlice(allocator, "end\n");
 
-    std.debug.print("{s}", .{output.items});
+    const stdout = std.fs.File.stdout();
+    try stdout.writeAll(output.items);
 }

--- a/src/commands/dock.zig
+++ b/src/commands/dock.zig
@@ -18,7 +18,7 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
             if (domain == null) return error.OutOfMemory;
             defer c.CFRelease(domain);
 
-            const value_cf = c.CFPreferencesCopyValue(key_cf, domain, c.kCFPreferencesCurrentUser, c.kCFPreferencesCurrentHost);
+            const value_cf = c.CFPreferencesCopyValue(key_cf, domain, c.kCFPreferencesCurrentUser, c.kCFPreferencesAnyHost);
             if (value_cf == null) {
                 return null;
             }

--- a/src/resources/macos_dock.zig
+++ b/src/resources/macos_dock.zig
@@ -102,15 +102,16 @@ pub const Resource = struct {
         // Use CFPreferences to get actual current value (may not be in plist file)
         if (self.tilesize) |size| {
             const current_size_value = readDockPrefWithCFPreferences(allocator, "tilesize") catch null;
-            const needs_change = if (current_size_value) |val| blk: {
-                defer val.deinit(allocator);
+            defer if (current_size_value) |*v| v.deinit(allocator);
+            const has_shadow = currentHostHasShadow("tilesize");
+            const needs_change = has_shadow or if (current_size_value) |val| blk: {
                 switch (val) {
                     .integer => |i| break :blk i != size,
                     else => break :blk true,
                 }
             } else true;
 
-            logger.debug("macos_dock: tilesize requested={d}, current={?}, needs_change={}", .{ size, current_size_value, needs_change });
+            logger.debug("macos_dock: tilesize requested={d}, current={?}, shadow={}, needs_change={}", .{ size, current_size_value, has_shadow, needs_change });
 
             if (needs_change) {
                 try updateDockPrefWithCFPreferences(allocator, "tilesize", .{ .integer = size });
@@ -122,8 +123,9 @@ pub const Resource = struct {
 
         if (self.orientation) |orient| {
             const current_orient_value = readDockPrefWithCFPreferences(allocator, "orientation") catch null;
-            const needs_change = if (current_orient_value) |val| blk: {
-                defer val.deinit(allocator);
+            defer if (current_orient_value) |*v| v.deinit(allocator);
+            const has_shadow = currentHostHasShadow("orientation");
+            const needs_change = has_shadow or if (current_orient_value) |val| blk: {
                 const current_orient = switch (val) {
                     .string => |s| s,
                     else => break :blk true,
@@ -131,7 +133,7 @@ pub const Resource = struct {
                 break :blk !std.mem.eql(u8, current_orient, orient);
             } else true;
 
-            logger.debug("macos_dock: orientation requested={s}, current={?}, needs_change={}", .{ orient, current_orient_value, needs_change });
+            logger.debug("macos_dock: orientation requested={s}, current={?}, shadow={}, needs_change={}", .{ orient, current_orient_value, has_shadow, needs_change });
 
             if (needs_change) {
                 const orient_copy = try allocator.dupe(u8, orient);
@@ -145,8 +147,9 @@ pub const Resource = struct {
 
         if (self.autohide) |hide| {
             const current_autohide_value = readDockPrefWithCFPreferences(allocator, "autohide") catch null;
-            const needs_change = if (current_autohide_value) |val| blk: {
-                defer val.deinit(allocator);
+            defer if (current_autohide_value) |*v| v.deinit(allocator);
+            const has_shadow = currentHostHasShadow("autohide");
+            const needs_change = has_shadow or if (current_autohide_value) |val| blk: {
                 const current_autohide = switch (val) {
                     .boolean => |b| b,
                     else => break :blk true,
@@ -154,7 +157,7 @@ pub const Resource = struct {
                 break :blk current_autohide != hide;
             } else true;
 
-            logger.debug("macos_dock: autohide requested={}, current={?}, needs_change={}", .{ hide, current_autohide_value, needs_change });
+            logger.debug("macos_dock: autohide requested={}, current={?}, shadow={}, needs_change={}", .{ hide, current_autohide_value, has_shadow, needs_change });
 
             if (needs_change) {
                 try updateDockPrefWithCFPreferences(allocator, "autohide", .{ .boolean = hide });
@@ -166,8 +169,9 @@ pub const Resource = struct {
 
         if (self.magnification) |mag| {
             const current_mag_value = readDockPrefWithCFPreferences(allocator, "magnification") catch null;
-            const needs_change = if (current_mag_value) |val| blk: {
-                defer val.deinit(allocator);
+            defer if (current_mag_value) |*v| v.deinit(allocator);
+            const has_shadow = currentHostHasShadow("magnification");
+            const needs_change = has_shadow or if (current_mag_value) |val| blk: {
                 const current_mag = switch (val) {
                     .boolean => |b| b,
                     else => break :blk true,
@@ -175,7 +179,7 @@ pub const Resource = struct {
                 break :blk current_mag != mag;
             } else true;
 
-            logger.debug("macos_dock: magnification requested={}, current={?}, needs_change={}", .{ mag, current_mag_value, needs_change });
+            logger.debug("macos_dock: magnification requested={}, current={?}, shadow={}, needs_change={}", .{ mag, current_mag_value, has_shadow, needs_change });
 
             if (needs_change) {
                 try updateDockPrefWithCFPreferences(allocator, "magnification", .{ .boolean = mag });
@@ -187,8 +191,9 @@ pub const Resource = struct {
 
         if (self.largesize) |size| {
             const current_size_value = readDockPrefWithCFPreferences(allocator, "largesize") catch null;
-            const needs_change = if (current_size_value) |val| blk: {
-                defer val.deinit(allocator);
+            defer if (current_size_value) |*v| v.deinit(allocator);
+            const has_shadow = currentHostHasShadow("largesize");
+            const needs_change = has_shadow or if (current_size_value) |val| blk: {
                 const current_size = switch (val) {
                     .integer => |i| i,
                     else => break :blk true,
@@ -196,7 +201,7 @@ pub const Resource = struct {
                 break :blk current_size != size;
             } else true;
 
-            logger.debug("macos_dock: largesize requested={d}, current={?}, needs_change={}", .{ size, current_size_value, needs_change });
+            logger.debug("macos_dock: largesize requested={d}, current={?}, shadow={}, needs_change={}", .{ size, current_size_value, has_shadow, needs_change });
 
             if (needs_change) {
                 try updateDockPrefWithCFPreferences(allocator, "largesize", .{ .integer = size });
@@ -669,7 +674,7 @@ pub const Resource = struct {
         if (domain == null) return error.OutOfMemory;
         defer c.CFRelease(domain);
 
-        const value_cf = c.CFPreferencesCopyValue(key_cf, domain, c.kCFPreferencesCurrentUser, c.kCFPreferencesCurrentHost);
+        const value_cf = c.CFPreferencesCopyValue(key_cf, domain, c.kCFPreferencesCurrentUser, c.kCFPreferencesAnyHost);
         if (value_cf == null) {
             // Key doesn't exist
             return null;
@@ -705,6 +710,29 @@ pub const Resource = struct {
         }
 
         return null;
+    }
+
+    /// Return true when the given key has any value set in the CurrentHost
+    /// (ByHost) domain. Such a value will shadow AnyHost at Dock runtime, so
+    /// the caller must force a write path to clean it up even if the AnyHost
+    /// value already matches the desired state.
+    fn currentHostHasShadow(key: []const u8) bool {
+        const c = @cImport({
+            @cInclude("CoreFoundation/CoreFoundation.h");
+        });
+
+        const key_cf = c.CFStringCreateWithCString(null, key.ptr, c.kCFStringEncodingUTF8);
+        if (key_cf == null) return false;
+        defer c.CFRelease(key_cf);
+
+        const domain = c.CFStringCreateWithCString(null, "com.apple.dock", c.kCFStringEncodingUTF8);
+        if (domain == null) return false;
+        defer c.CFRelease(domain);
+
+        const value_cf = c.CFPreferencesCopyValue(key_cf, domain, c.kCFPreferencesCurrentUser, c.kCFPreferencesCurrentHost);
+        if (value_cf == null) return false;
+        c.CFRelease(value_cf);
+        return true;
     }
 
     fn updateDockPrefWithCFPreferences(_: std.mem.Allocator, key: []const u8, value: plist.Value) !void {
@@ -743,9 +771,21 @@ pub const Resource = struct {
         if (domain == null) return error.OutOfMemory;
         defer c.CFRelease(domain);
 
-        c.CFPreferencesSetValue(key_cf, value_cf, domain, c.kCFPreferencesCurrentUser, c.kCFPreferencesCurrentHost);
+        c.CFPreferencesSetValue(key_cf, value_cf, domain, c.kCFPreferencesCurrentUser, c.kCFPreferencesAnyHost);
 
-        // Synchronize to ensure cache is updated and written to disk
+        // Clear any stale CurrentHost value for the same key so legacy ByHost
+        // residue cannot shadow the AnyHost value at runtime (Dock reads the
+        // CurrentHost domain first when a value exists there).
+        c.CFPreferencesSetValue(key_cf, null, domain, c.kCFPreferencesCurrentUser, c.kCFPreferencesCurrentHost);
+
+        // Synchronize to ensure cache is updated and written to disk.
+        // Both domains participate in the write path now: AnyHost holds the
+        // new value and CurrentHost has the stale shadow cleared, so a failure
+        // on either side means the Dock runtime could still see the old ByHost
+        // value. Treat both as hard failures instead of best-effort.
+        if (c.CFPreferencesSynchronize(domain, c.kCFPreferencesCurrentUser, c.kCFPreferencesAnyHost) == 0) {
+            return error.PreferencesSyncFailed;
+        }
         if (c.CFPreferencesSynchronize(domain, c.kCFPreferencesCurrentUser, c.kCFPreferencesCurrentHost) == 0) {
             return error.PreferencesSyncFailed;
         }


### PR DESCRIPTION
## Summary

- Fixes #3: `autohide`/`magnification`/etc. declared via `macos_dock` now actually take effect on machines that still carry ByHost (`CurrentHost`) residue. Dock reads the CurrentHost domain first at runtime, so writing AnyHost alone was not enough — the live Dock process kept using the stale shadow.
- Adds shadow-aware idempotency and a CurrentHost cleanup write path so the resource is self-healing, and fixes a latent use-after-free triggered by logging a freed plist value when `largesize` is stored as a string.
- Adds diagnostics to the `hola dock` exporter so users notice residue even from the read-only command, without polluting the exported DSL (warnings go to stderr, DSL goes to stdout).

## Commits

- `fix(dock): clear stale CurrentHost shadow so Dock reads AnyHost value` — the actual behavioral fix (shadow cleanup on write, `currentHostHasShadow` in `needs_change`, CurrentHost sync error propagation, UAF fix). Fixes #3.
- `feat(dock): warn on stale CurrentHost preference residue` — `hola dock` now reads both domains for comparison, warns on mismatch, falls back to CurrentHost when AnyHost is unset for legacy installs, and routes the final DSL to stdout.

## Test plan

- [x] `zig build` / `zig build test`
- [x] Repro scenario: `defaults write com.apple.dock autohide -bool false && defaults -currentHost write com.apple.dock autohide -bool false` (both already match target `autohide false`) → `hola provision` triggers `shadow=true, needs_change=true`, cleanup runs, `defaults -currentHost read com.apple.dock autohide` reports "does not exist".
- [x] Dock right-click menu flips from "Turn Hiding On" to "Turn Hiding Off" after provision when target is `autohide true`.
- [x] `hola dock > out 2> err` produces a clean DSL in stdout and warnings only in stderr.
- [x] Provision pretty TUI output unchanged — no stderr pollution (all resource logs go through `logger`, not `std.debug.print`).