### PR TITLE
fix(provision): suppress Zig stack trace on script failure

### DIFF
--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -249,11 +249,17 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
     const effective_secrets_bag = fetched_secrets_bag orelse res.args.@"secrets-bag";
 
     var result = runScript(allocator, script_path_or_url, use_pretty_output, effective_data_bag, effective_secrets_bag, tls_auth) catch |err| {
+        if (err == error.MRubyException) {
+            if (logger.getLogPath()) |log_path| {
+                std.debug.print("\nLog file: {s}\n", .{log_path});
+            }
+            std.process.exit(1);
+        }
         std.debug.print("Provision failed: {}\n", .{err});
         if (logger.getLogPath()) |log_path| {
             std.debug.print("Log file: {s}\n", .{log_path});
         }
-        return err;
+        std.process.exit(1);
     };
     defer result.deinit(allocator);
 }


### PR DESCRIPTION
## Summary

When a provision script raises a Ruby exception (NoMethodError, SyntaxError, uncaught `Errno::ENOENT` in a guard, etc.), mruby already prints a clean Ruby-side backtrace via `mrb_print_error`. Previously we then returned `error.MRubyException` all the way back to `main()`, which made Zig's runtime dump its own error-return-trace on top — noisy frames like `evalFile → run → dispatchCommand → main` that have zero value to a DSL author.

This change replaces `return err` at the top-level provision catch with `std.process.exit(1)`, so the Zig trace is never produced. For `error.MRubyException` specifically we also drop the redundant `Provision failed: error.MRubyException` line, since the mruby trace above it is enough.

## Before / After

**Before**
```
trace (most recent call last):
	[1] /tmp/foo.rb:1
/tmp/foo.rb:2:in initialize: undefined method 'source_inline' for TemplateResource (NoMethodError)
Provision failed: error.MRubyException
Log file: ~/.local/state/hola/logs/hola-20260421.log
error: MRubyException
/Users/.../src/mruby.zig:204:13: ...in evalFile
/Users/.../src/provision.zig:915:5: ...in run
/Users/.../src/commands/provision.zig:170:12: ...in runScript
/Users/.../src/commands/provision.zig:256:9: ...in run
/Users/.../src/main.zig:97:9: ...in dispatchCommand
/Users/.../src/main.zig:56:9: ...in main
```

**After**
```
trace (most recent call last):
	[1] /tmp/foo.rb:1
/tmp/foo.rb:2:in initialize: undefined method 'source_inline' for TemplateResource (NoMethodError)

Log file: ~/.local/state/hola/logs/hola-20260421.log
```

## Scope

Narrow fix — only `src/commands/provision.zig`, 7 lines. Exit code unchanged (still 1 on failure). Happy-path behavior untouched.

## Test plan

- [x] Ruby `NoMethodError` (unknown DSL method) — Zig trace gone, mruby trace + log path shown
- [x] Ruby `SyntaxError` (missing `end`) — same
- [x] Uncaught exception inside an `only_if` guard — same
- [x] Successful provision — exit 0, summary unchanged

## Follow-ups (out of scope)

- The resource-apply layer still surfaces raw Zig error names (e.g. `execute[foo]: MRubyException`). Next step is to wrap guard / apply exceptions into DSL-friendly messages like `only_if block raised: Errno::ENOENT`.
- Chef-ism detection (`include_recipe`, `platform?`, `node[:x]`, ...) — planned for a later PR.