### PR TITLE
fix(display): show "(up to date)" only when resource state didn't change

### DIFF
--- a/src/modern_provision_display.zig
+++ b/src/modern_provision_display.zig
@@ -484,11 +484,17 @@ pub const ModernProvisionDisplay = struct {
         }
     }
 
-    /// Mark resource as updated
-    /// Mark resource as updated (or up to date)
+    /// Mark resource as updated. When skip_reason is set (e.g. "up to date"),
+    /// the action ran but did not change state; otherwise the resource was
+    /// actually modified.
     pub fn resourceUpdated(self: *Self, resource_type: []const u8, resource_name: []const u8, action: []const u8, skip_reason: ?[]const u8) !void {
-        _ = skip_reason; // Always show "up to date" for updated resources
         self.updated_count += 1;
+
+        const suffix: []const u8 = if (skip_reason) |reason|
+            try std.fmt.allocPrint(self.allocator, " ({s})", .{reason})
+        else
+            "";
+        defer if (skip_reason != null) self.allocator.free(suffix);
 
         if (!self.show_progress) {
             const total_digits = if (self.total_resources > 0) std.math.log10_int(self.total_resources) + 1 else 1;
@@ -499,7 +505,7 @@ pub const ModernProvisionDisplay = struct {
             while (i < padding) : (i += 1) {
                 padding_str[i] = ' ';
             }
-            std.debug.print("{s}\x1b[32m✓ [{s}{d}/{d}]  {s}[{s}] action {s} (up to date)\x1b[0m\n", .{ INDENT_RESOURCE, padding_str[0..padding], self.executed_count, self.total_resources, resource_type, resource_name, action });
+            std.debug.print("{s}\x1b[32m✓ [{s}{d}/{d}]  {s}[{s}] action {s}{s}\x1b[0m\n", .{ INDENT_RESOURCE, padding_str[0..padding], self.executed_count, self.total_resources, resource_type, resource_name, action, suffix });
             return;
         }
 
@@ -510,7 +516,7 @@ pub const ModernProvisionDisplay = struct {
 
             const base = try self.buildResourceMessage(resource_type, resource_name, "");
             defer self.allocator.free(base);
-            const message = try std.fmt.allocPrint(self.allocator, "{s} action {s} (up to date)", .{ base, action });
+            const message = try std.fmt.allocPrint(self.allocator, "{s} action {s}{s}", .{ base, action, suffix });
             defer self.allocator.free(message);
             // Add indentation and checkmark icon before the message
             const base_with_checkmark = try std.fmt.allocPrint(self.allocator, "{s}✓ {s}", .{ INDENT_RESOURCE, message });

--- a/src/resources/execute.zig
+++ b/src/resources/execute.zig
@@ -81,7 +81,7 @@ pub const Resource = struct {
                 return base.ApplyResult{
                     .was_updated = true,
                     .action = "run",
-                    .skip_reason = "up to date",
+                    .skip_reason = null,
                     .output = output,
                 };
             },


### PR DESCRIPTION
## Summary

- Previously `modern_provision_display.zig`'s `resourceUpdated` unconditionally appended the `(up to date)` suffix for every updated resource, ignoring the actual `skip_reason`. This made real state-changing updates (e.g., `link` retargeted to a different `to`, `file` content rewritten) display as `action X (up to date)`, which is misleading — the symlink / file content had just changed.
- Fix: show `(up to date)` only when `skip_reason != null`. When the resource really did change, display just `action X`.

## Test plan

- [x] `zig build` passes
- [ ] CI checks pass
- [ ] Manually verified with a `link` resource whose `to` target changes between runs: first run shows `action create`, second run (with new `to`) now shows `action create` (the symlink is updated) instead of the previous misleading `action create (up to date)`.