### PR TITLE
feat(provision): wrap guard exceptions with friendly error message

### DIFF
--- a/src/base_resource.zig
+++ b/src/base_resource.zig
@@ -3,6 +3,41 @@ const mruby = @import("mruby.zig");
 pub const notification = @import("notification.zig");
 const builtin = @import("builtin");
 
+// --- Guard-error context ---------------------------------------------------
+// When an only_if/not_if block raises, we capture a friendly summary
+// (e.g. "only_if block raised: Errno::ENOENT: No such file or directory ...")
+// into a thread-local buffer so the top-level apply loop can show it to the
+// user instead of the raw Zig error name "MRubyException".
+const GUARD_ERROR_BUF_SIZE = 256;
+threadlocal var guard_error_buf: [GUARD_ERROR_BUF_SIZE]u8 = undefined;
+threadlocal var guard_error_len: usize = 0;
+
+pub fn clearGuardError() void {
+    guard_error_len = 0;
+}
+
+pub fn getGuardError() ?[]const u8 {
+    if (guard_error_len == 0) return null;
+    return guard_error_buf[0..guard_error_len];
+}
+
+fn recordGuardError(mrb: *mruby.mrb_state, exc: mruby.mrb_value, guard_kind: []const u8) void {
+    var summary_buf: [200]u8 = undefined;
+    mruby.zig_mrb_exc_summary(mrb, exc, &summary_buf, summary_buf.len);
+    const summary = std.mem.sliceTo(&summary_buf, 0);
+
+    const written = std.fmt.bufPrint(
+        &guard_error_buf,
+        "{s} block raised: {s}",
+        .{ guard_kind, summary },
+    ) catch blk: {
+        const fallback = "guard block raised (message truncated)";
+        @memcpy(guard_error_buf[0..fallback.len], fallback);
+        break :blk guard_error_buf[0..fallback.len];
+    };
+    guard_error_len = written.len;
+}
+
 /// Result of applying a resource
 pub const ApplyResult = struct {
     was_updated: bool,
@@ -88,6 +123,7 @@ pub const CommonProps = struct {
             // Check for exceptions during call
             const exc = mruby.mrb_get_exception(mrb);
             if (mruby.mrb_test(exc)) {
+                recordGuardError(mrb, exc, "only_if");
                 mruby.mrb_print_error(mrb);
                 return error.MRubyException;
             }
@@ -113,6 +149,7 @@ pub const CommonProps = struct {
             // Check for exceptions during call
             const exc = mruby.mrb_get_exception(mrb);
             if (mruby.mrb_test(exc)) {
+                recordGuardError(mrb, exc, "not_if");
                 mruby.mrb_print_error(mrb);
                 return error.MRubyException;
             }

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -110,6 +110,10 @@ fn parseIso8601(s: []const u8) !i64 {
 }
 
 fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callback: ?[]const u8, endpoint: []const u8, tls_auth: TlsClientAuth) void {
+    // Start each task with a clean guard-error buffer so a previous task's
+    // guard message can't leak into this task's failure callback.
+    base_resource.clearGuardError();
+
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch |err| {
         std.debug.print("[agent] failed to parse task: {}\n", .{err});
         return;

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -3,6 +3,7 @@ const clap = @import("clap");
 const http = @import("../http.zig");
 const provision_cmd = @import("provision.zig");
 const provision = @import("../provision.zig");
+const base_resource = @import("../base_resource.zig");
 const node_info = @import("../node_info.zig");
 
 const params = clap.parseParamsComptime(
@@ -201,7 +202,7 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
     }) catch |err| {
         std.debug.print("[agent] provision failed: {}\n", .{err});
         if (callback_url) |cb| {
-            sendCallback(allocator, cb, data, "error", @errorName(err), null, endpoint, tls_auth);
+            sendCallback(allocator, cb, data, "error", @errorName(err), base_resource.getGuardError(), null, endpoint, tls_auth);
         }
         return;
     };
@@ -209,11 +210,11 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
 
     std.debug.print("[agent] provision complete\n", .{});
     if (callback_url) |cb| {
-        sendCallback(allocator, cb, data, "ok", null, &prov_result, endpoint, tls_auth);
+        sendCallback(allocator, cb, data, "ok", null, null, &prov_result, endpoint, tls_auth);
     }
 }
 
-fn buildCallbackBody(allocator: std.mem.Allocator, event_data: []const u8, status: []const u8, err_msg: ?[]const u8, prov_result: ?*const provision.ProvisionResult) ![]const u8 {
+fn buildCallbackBody(allocator: std.mem.Allocator, event_data: []const u8, status: []const u8, err_msg: ?[]const u8, err_detail: ?[]const u8, prov_result: ?*const provision.ProvisionResult) ![]const u8 {
     // Use arena for all intermediate JSON allocations; only the final string is duped to caller's allocator.
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
@@ -231,6 +232,9 @@ fn buildCallbackBody(allocator: std.mem.Allocator, event_data: []const u8, statu
     try result.put("status", .{ .string = status });
     if (err_msg) |msg| {
         try result.put("error", .{ .string = msg });
+    }
+    if (err_detail) |detail| {
+        try result.put("error_message", .{ .string = detail });
     }
 
     if (prov_result) |pr| {
@@ -255,6 +259,9 @@ fn buildCallbackBody(allocator: std.mem.Allocator, event_data: []const u8, statu
             }
             if (rr.error_name) |en| {
                 try res_obj.put("error", .{ .string = en });
+            }
+            if (rr.error_message) |em| {
+                try res_obj.put("error_message", .{ .string = em });
             }
             if (rr.output) |o| {
                 try res_obj.put("output", .{ .string = o });
@@ -307,8 +314,8 @@ fn cloneJsonValue(allocator: std.mem.Allocator, value: std.json.Value) !std.json
     };
 }
 
-fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_data: []const u8, status: []const u8, err_msg: ?[]const u8, prov_result: ?*const provision.ProvisionResult, endpoint: []const u8, tls_auth: TlsClientAuth) void {
-    const body = buildCallbackBody(allocator, event_data, status, err_msg, prov_result) catch |err| {
+fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_data: []const u8, status: []const u8, err_msg: ?[]const u8, err_detail: ?[]const u8, prov_result: ?*const provision.ProvisionResult, endpoint: []const u8, tls_auth: TlsClientAuth) void {
+    const body = buildCallbackBody(allocator, event_data, status, err_msg, err_detail, prov_result) catch |err| {
         std.debug.print("[agent] failed to build callback body: {}\n", .{err});
         return;
     };
@@ -675,7 +682,7 @@ test "buildCallbackBody with ProvisionResult" {
         \\{"id":"task-1","url":"https://example.com/script.rb","callback":"https://example.com/done","secrets":{"api_key":"sk-123"}}
     ;
 
-    const body = try buildCallbackBody(allocator, event_data, "ok", null, &prov_result);
+    const body = try buildCallbackBody(allocator, event_data, "ok", null, null, &prov_result);
     defer allocator.free(body);
 
     // Verify key fields exist in the JSON output

--- a/src/mruby.zig
+++ b/src/mruby.zig
@@ -48,6 +48,10 @@ extern fn zig_mrb_get_exception(mrb: *mrb_state) mrb_value;
 pub const mrb_get_exception = zig_mrb_get_exception;
 pub extern fn mrb_raise(mrb: *mrb_state, class: *RClass, msg: [*c]const u8) noreturn;
 
+// Format "ClassName: message" for an exception value into buf. Safe to call
+// while mrb->exc is set (no Ruby-level callbacks).
+pub extern fn zig_mrb_exc_summary(mrb: *mrb_state, exc: mrb_value, buf: [*c]u8, buflen: usize) void;
+
 // Block/Proc handling
 pub extern fn mrb_yield(mrb: *mrb_state, b: mrb_value, arg: mrb_value) mrb_value;
 pub extern fn mrb_yield_argv(mrb: *mrb_state, b: mrb_value, argc: mrb_int, argv: [*c]const mrb_value) mrb_value;

--- a/src/mruby_helpers.c
+++ b/src/mruby_helpers.c
@@ -3,6 +3,9 @@
 #include <mruby/value.h>
 #include <mruby/string.h>
 #include <mruby/hash.h>
+#include <mruby/variable.h>
+#include <mruby/class.h>
+#include <mruby/error.h>
 #include <stdio.h>
 
 #ifdef __linux__
@@ -155,4 +158,28 @@ mrb_value zig_mrb_get_exception(mrb_state *mrb) {
 // Helper to convert object pointer to mrb_value
 mrb_value zig_mrb_obj_value(void *obj) {
     return mrb_obj_value(obj);
+}
+
+// Safely format "ClassName: message" for an exception value into buf.
+// Reads the message directly from struct RException->mesg so it works
+// while mrb->exc is set (no Ruby-level callbacks).
+void zig_mrb_exc_summary(mrb_state *mrb, mrb_value exc, char *buf, size_t buflen) {
+    if (buflen == 0) return;
+    buf[0] = '\0';
+    if (mrb_type(exc) != MRB_TT_EXCEPTION) {
+        snprintf(buf, buflen, "(not an exception)");
+        return;
+    }
+    struct RClass *klass = mrb_obj_class(mrb, exc);
+    const char *class_name = mrb_class_name(mrb, klass);
+    struct RException *rexc = mrb_exc_ptr(exc);
+    if (rexc->mesg && rexc->mesg->tt == MRB_TT_STRING) {
+        mrb_value mesg = mrb_obj_value(rexc->mesg);
+        snprintf(buf, buflen, "%s: %.*s",
+                 class_name,
+                 (int)RSTRING_LEN(mesg),
+                 RSTRING_PTR(mesg));
+    } else {
+        snprintf(buf, buflen, "%s", class_name);
+    }
 }

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -1165,6 +1165,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
 
     // Phase 1: Execute resources and collect notifications
     for (runner.resources.items) |*res| {
+        base.clearGuardError();
         try display.startResource(res.id.type_name, res.id.name);
         try display.update();
 
@@ -1211,7 +1212,8 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
         }
 
         const result = res.resource.apply() catch |err| {
-            try display.resourceError(res.id.type_name, res.id.name, @errorName(err));
+            const error_display = base.getGuardError() orelse @errorName(err);
+            try display.resourceError(res.id.type_name, res.id.name, error_display);
             try display.update();
 
             try resource_results.append(allocator, .{
@@ -1221,9 +1223,10 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
                 .was_updated = false,
                 .skipped = false,
                 .skip_reason = null,
-                .error_name = try allocator.dupe(u8, @errorName(err)),
+                .error_name = try allocator.dupe(u8, error_display),
                 .output = null,
             });
+            base.clearGuardError();
 
             // Check if this resource has ignore_failure set
             if (res.resource.shouldIgnoreFailure()) {

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -33,6 +33,7 @@ pub const ResourceResult = struct {
     skipped: bool,
     skip_reason: ?[]const u8,
     error_name: ?[]const u8,
+    error_message: ?[]const u8 = null,
     output: ?[]const u8,
 };
 
@@ -51,6 +52,7 @@ pub const ProvisionResult = struct {
             allocator.free(rr.action);
             if (rr.skip_reason) |sr| allocator.free(sr);
             if (rr.error_name) |en| allocator.free(en);
+            if (rr.error_message) |em| allocator.free(em);
             if (rr.output) |o| allocator.free(o);
         }
         self.resource_results.deinit(allocator);
@@ -926,6 +928,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
             allocator.free(rr.action);
             if (rr.skip_reason) |sr| allocator.free(sr);
             if (rr.error_name) |en| allocator.free(en);
+            if (rr.error_message) |em| allocator.free(em);
             if (rr.output) |o| allocator.free(o);
         }
         resource_results.deinit(allocator);
@@ -1212,7 +1215,8 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
         }
 
         const result = res.resource.apply() catch |err| {
-            const error_display = base.getGuardError() orelse @errorName(err);
+            const guard_msg = base.getGuardError();
+            const error_display = guard_msg orelse @errorName(err);
             try display.resourceError(res.id.type_name, res.id.name, error_display);
             try display.update();
 
@@ -1223,10 +1227,10 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
                 .was_updated = false,
                 .skipped = false,
                 .skip_reason = null,
-                .error_name = try allocator.dupe(u8, error_display),
+                .error_name = try allocator.dupe(u8, @errorName(err)),
+                .error_message = if (guard_msg) |m| try allocator.dupe(u8, m) else null,
                 .output = null,
             });
-            base.clearGuardError();
 
             // Check if this resource has ignore_failure set
             if (res.resource.shouldIgnoreFailure()) {

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -814,6 +814,10 @@ fn injectSecrets(mrb: *mruby.mrb_state, secrets_json: []const u8) !void {
 }
 
 pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
+    // Guard-error buffer is threadlocal; clear at entry so a prior invocation
+    // on this thread can't leak into this run.
+    base.clearGuardError();
+
     var runner = ProvisionRunner.init(allocator);
     defer runner.deinit();
 


### PR DESCRIPTION
## Summary

Ruby `only_if` / `not_if` blocks that raise an exception used to surface as a bare `MRubyException` in the CLI output and agent callback, with no hint of the actual Ruby error (class + message). This PR wraps guard exceptions with a friendly message while keeping the stable error code intact for programmatic consumers.

Three commits:

1. **`feat(provision): wrap guard exceptions with class and message`** — `shouldRun()` catches guard exceptions, formats them as `only_if block raised: Errno::ENOENT: No such file or directory - open /foo` via a new `zig_mrb_exc_summary` C helper (reads `mrb_exc_ptr(exc)->mesg` directly since mruby stores the exception message on the struct, not as an instance variable), and stashes the text in a threadlocal buffer for later retrieval.

2. **`fix(provision): separate stable error_name from friendly error_message`** — response from review: `ResourceResult.error_name` was semantically a stable machine-readable code (e.g. `"MRubyException"`); tests / webhooks switching on that name would break if we repurposed it as free-form text. Added a separate `error_message` field to both the top-level `ProvisionResult` JSON and per-resource entries. `error_name` stays the stable `@errorName(err)`, `error_message` carries the friendly text.

3. **`fix(provision): clear guard-error buffer at task/run entry`** — response from review: the threadlocal guard buffer could leak across agent tasks (task A raises in `only_if`, task B later fails during script download before reaching the resource loop — would see task A's text). Added `clearGuardError()` at `handleTaskJson()` and `provision.run()` entry points to isolate tasks.

## Test plan

- [x] `zig build` passes locally
- [x] Manual: running a provision script with `only_if { File.open("/nonexistent") }` produces `execute[guard-boom]: only_if block raised: Errno::ENOENT: No such file or directory - open /nonexistent` in the CLI and in the agent callback's `error_message`, while `error` stays `"MRubyException"`.
- [ ] CI checks pass

## Notes

- Not included in this PR: there is no automated coverage for "two consecutive agent tasks, first fails in guard, second fails in script download" — the cross-task leak regression is only caught by code-path review today. Worth a follow-up integration test.