### PR TITLE
feat(provision): surface friendly error details for script, ruby_block, template

### DIFF
--- a/src/base_resource.zig
+++ b/src/base_resource.zig
@@ -3,39 +3,55 @@ const mruby = @import("mruby.zig");
 pub const notification = @import("notification.zig");
 const builtin = @import("builtin");
 
-// --- Guard-error context ---------------------------------------------------
-// When an only_if/not_if block raises, we capture a friendly summary
-// (e.g. "only_if block raised: Errno::ENOENT: No such file or directory ...")
-// into a thread-local buffer so the top-level apply loop can show it to the
-// user instead of the raw Zig error name "MRubyException".
-const GUARD_ERROR_BUF_SIZE = 256;
-threadlocal var guard_error_buf: [GUARD_ERROR_BUF_SIZE]u8 = undefined;
-threadlocal var guard_error_len: usize = 0;
+// --- Provision error detail context ----------------------------------------
+// Whenever a piece of user Ruby raises during provisioning (a guard block,
+// the top-level DSL script, or the body of `ruby_block`), we capture a
+// friendly summary (e.g. "only_if block raised: Errno::ENOENT: No such
+// file or directory ...") into a thread-local buffer. The top-level apply
+// loop and the agent callback can then show it to the user instead of the
+// raw Zig error name "MRubyException".
+const PROVISION_ERROR_DETAIL_BUF_SIZE = 256;
+threadlocal var provision_error_detail_buf: [PROVISION_ERROR_DETAIL_BUF_SIZE]u8 = undefined;
+threadlocal var provision_error_detail_len: usize = 0;
 
-pub fn clearGuardError() void {
-    guard_error_len = 0;
+pub fn clearProvisionErrorDetail() void {
+    provision_error_detail_len = 0;
 }
 
-pub fn getGuardError() ?[]const u8 {
-    if (guard_error_len == 0) return null;
-    return guard_error_buf[0..guard_error_len];
+pub fn getProvisionErrorDetail() ?[]const u8 {
+    if (provision_error_detail_len == 0) return null;
+    return provision_error_detail_buf[0..provision_error_detail_len];
 }
 
-fn recordGuardError(mrb: *mruby.mrb_state, exc: mruby.mrb_value, guard_kind: []const u8) void {
+/// Capture a friendly summary of an mruby exception into the thread-local
+/// error detail buffer. If `prefix` is non-null the buffer stores
+/// "{prefix}: {ClassName}: {message}"; otherwise just "{ClassName}: {message}".
+pub fn recordProvisionException(mrb: *mruby.mrb_state, exc: mruby.mrb_value, prefix: ?[]const u8) void {
     var summary_buf: [200]u8 = undefined;
     mruby.zig_mrb_exc_summary(mrb, exc, &summary_buf, summary_buf.len);
     const summary = std.mem.sliceTo(&summary_buf, 0);
 
-    const written = std.fmt.bufPrint(
-        &guard_error_buf,
-        "{s} block raised: {s}",
-        .{ guard_kind, summary },
-    ) catch blk: {
-        const fallback = "guard block raised (message truncated)";
-        @memcpy(guard_error_buf[0..fallback.len], fallback);
-        break :blk guard_error_buf[0..fallback.len];
-    };
-    guard_error_len = written.len;
+    const written = if (prefix) |p|
+        std.fmt.bufPrint(
+            &provision_error_detail_buf,
+            "{s}: {s}",
+            .{ p, summary },
+        ) catch blk: {
+            const fallback = "provision error (message truncated)";
+            @memcpy(provision_error_detail_buf[0..fallback.len], fallback);
+            break :blk provision_error_detail_buf[0..fallback.len];
+        }
+    else
+        std.fmt.bufPrint(
+            &provision_error_detail_buf,
+            "{s}",
+            .{summary},
+        ) catch blk: {
+            const fallback = "provision error (message truncated)";
+            @memcpy(provision_error_detail_buf[0..fallback.len], fallback);
+            break :blk provision_error_detail_buf[0..fallback.len];
+        };
+    provision_error_detail_len = written.len;
 }
 
 /// Result of applying a resource
@@ -123,7 +139,7 @@ pub const CommonProps = struct {
             // Check for exceptions during call
             const exc = mruby.mrb_get_exception(mrb);
             if (mruby.mrb_test(exc)) {
-                recordGuardError(mrb, exc, "only_if");
+                recordProvisionException(mrb, exc, "only_if block raised");
                 mruby.mrb_print_error(mrb);
                 return error.MRubyException;
             }
@@ -149,7 +165,7 @@ pub const CommonProps = struct {
             // Check for exceptions during call
             const exc = mruby.mrb_get_exception(mrb);
             if (mruby.mrb_test(exc)) {
-                recordGuardError(mrb, exc, "not_if");
+                recordProvisionException(mrb, exc, "not_if block raised");
                 mruby.mrb_print_error(mrb);
                 return error.MRubyException;
             }

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -110,9 +110,9 @@ fn parseIso8601(s: []const u8) !i64 {
 }
 
 fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callback: ?[]const u8, endpoint: []const u8, tls_auth: TlsClientAuth) void {
-    // Start each task with a clean guard-error buffer so a previous task's
-    // guard message can't leak into this task's failure callback.
-    base_resource.clearGuardError();
+    // Start each task with a clean provision-error-detail buffer so a previous
+    // task's friendly error message can't leak into this task's failure callback.
+    base_resource.clearProvisionErrorDetail();
 
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch |err| {
         std.debug.print("[agent] failed to parse task: {}\n", .{err});
@@ -206,7 +206,7 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
     }) catch |err| {
         std.debug.print("[agent] provision failed: {}\n", .{err});
         if (callback_url) |cb| {
-            sendCallback(allocator, cb, data, "error", @errorName(err), base_resource.getGuardError(), null, endpoint, tls_auth);
+            sendCallback(allocator, cb, data, "error", @errorName(err), base_resource.getProvisionErrorDetail(), null, endpoint, tls_auth);
         }
         return;
     };

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -814,9 +814,9 @@ fn injectSecrets(mrb: *mruby.mrb_state, secrets_json: []const u8) !void {
 }
 
 pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
-    // Guard-error buffer is threadlocal; clear at entry so a prior invocation
-    // on this thread can't leak into this run.
-    base.clearGuardError();
+    // Provision error detail buffer is threadlocal; clear at entry so a prior
+    // invocation on this thread can't leak into this run.
+    base.clearProvisionErrorDetail();
 
     var runner = ProvisionRunner.init(allocator);
     defer runner.deinit();
@@ -917,8 +917,20 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     }
 
     // Load and execute user's recipe
-    // Use evalFile instead of evalString to preserve file path and line numbers in error messages
-    try mrb.evalFile(opts.script_path);
+    // Use evalFile instead of evalString to preserve file path and line numbers in error messages.
+    // On failure, capture the mruby exception summary (ClassName + message) so
+    // the agent callback / top-level caller can surface something friendlier
+    // than the bare "MRubyException" Zig error name. mrb_print_error() inside
+    // evalFile doesn't clear mrb->exc, so we can still read it here.
+    mrb.evalFile(opts.script_path) catch |err| {
+        if (err == error.MRubyException) {
+            const exc = mruby.mrb_get_exception(mrb_ptr);
+            if (mruby.mrb_test(exc)) {
+                base.recordProvisionException(mrb_ptr, exc, "script raised");
+            }
+        }
+        return err;
+    };
 
     // Record start time for timer
     const start_time = std.time.nanoTimestamp();
@@ -1172,7 +1184,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
 
     // Phase 1: Execute resources and collect notifications
     for (runner.resources.items) |*res| {
-        base.clearGuardError();
+        base.clearProvisionErrorDetail();
         try display.startResource(res.id.type_name, res.id.name);
         try display.update();
 
@@ -1219,8 +1231,8 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
         }
 
         const result = res.resource.apply() catch |err| {
-            const guard_msg = base.getGuardError();
-            const error_display = guard_msg orelse @errorName(err);
+            const detail_msg = base.getProvisionErrorDetail();
+            const error_display = detail_msg orelse @errorName(err);
             try display.resourceError(res.id.type_name, res.id.name, error_display);
             try display.update();
 
@@ -1232,7 +1244,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
                 .skipped = false,
                 .skip_reason = null,
                 .error_name = try allocator.dupe(u8, @errorName(err)),
-                .error_message = if (guard_msg) |m| try allocator.dupe(u8, m) else null,
+                .error_message = if (detail_msg) |m| try allocator.dupe(u8, m) else null,
                 .output = null,
             });
 

--- a/src/resources/ruby_block.zig
+++ b/src/resources/ruby_block.zig
@@ -180,6 +180,12 @@ pub const Resource = struct {
                 // Log the error message
                 logger.err("Ruby block execution failed: {s}", .{err_msg});
 
+                // Capture a friendly "ruby_block raised: ClassName: message"
+                // summary into the shared provision error-detail buffer so the
+                // top-level apply loop / agent callback can surface it instead
+                // of the raw Zig error name.
+                base.recordProvisionException(mrb, exc, "ruby_block raised");
+
                 // Also print to stderr for consistency
                 mruby.mrb_print_error(mrb);
                 return error.RubyBlockFailed;

--- a/src/resources/template.zig
+++ b/src/resources/template.zig
@@ -345,24 +345,21 @@ pub const Resource = struct {
 
         const result_val = mruby.mrb_load_string(mrb, code_with_null.ptr);
 
-        // Print any errors first
-        mruby.mrb_print_error(mrb);
-
-        // Try to convert result to string
-        // If it's an exception, mrb_str_to_cstr might fail or return error message
-        const result_cstr = mruby.mrb_str_to_cstr(mrb, result_val);
-        const result_str = std.mem.span(result_cstr);
-
-        // Check if result looks like an error (starts with error indicators)
-        // This is a heuristic - proper way would be to check mrb_type
-        if (result_str.len > 0 and
-            (std.mem.startsWith(u8, result_str, "SyntaxError") or
-                std.mem.startsWith(u8, result_str, "NameError") or
-                std.mem.startsWith(u8, result_str, "RuntimeError") or
-                std.mem.startsWith(u8, result_str, "TypeError")))
-        {
+        // Check for an exception directly instead of relying on a string-match
+        // heuristic over the result. When the ERB code raised, also capture a
+        // friendly "template raised: ClassName: message" summary into the
+        // shared provision error-detail buffer so the top-level apply loop /
+        // agent callback can surface it instead of the raw "TemplateRenderFailed".
+        const exc = mruby.mrb_get_exception(mrb);
+        if (mruby.mrb_test(exc)) {
+            base.recordProvisionException(mrb, exc, "template raised");
+            mruby.mrb_print_error(mrb);
             return error.TemplateRenderFailed;
         }
+
+        // Convert result to string
+        const result_cstr = mruby.mrb_str_to_cstr(mrb, result_val);
+        const result_str = std.mem.span(result_cstr);
 
         return try std.heap.c_allocator.dupe(u8, result_str);
     }


### PR DESCRIPTION
## Summary

Extend the friendly "ClassName: message" error surfacing (previously limited to `only_if` / `not_if` guards) to every user-Ruby execution path in provisioning:

- **Top-level provision script** (`evalFile`): `script raised: ClassName: message`
- **`ruby_block` body**: `ruby_block raised: ClassName: message`
- **`template` ERB rendering**: `template raised: ClassName: message`

The thread-local buffer is renamed from `guard_error_*` to the generic `provision_error_detail_*` to reflect the broader scope; the recorder becomes the public `recordProvisionException(mrb, exc, prefix: ?[]const u8)`.

As a side effect, `template` no longer uses a fragile string-prefix heuristic (`"SyntaxError"` / `"NameError"` / `"RuntimeError"` / `"TypeError"`) to detect ERB errors — it now checks `mrb_get_exception` directly, so any exception class (e.g. `NoMethodError`, `Errno::ENOENT`) is caught.

Stable error codes (`error_name` on resource results, `error` in the agent callback) are unchanged; this only enriches `error_message`.

## Test plan

- [x] `zig build test` passes
- [x] Manual: `hola provision` on a script with a top-level `NameError` — CLI output unchanged (`mrb_print_error` already shows Ruby backtrace)
- [x] Manual: `ruby_block` body raising `Errno::ENOENT` — CLI now shows `✗ ruby_block[name]: ruby_block raised: Errno::ENOENT: No such file or directory - open /tmp/...`
- [x] Manual: `only_if { File.read("/missing") }` — regression check, still shows `only_if block raised: Errno::ENOENT: ...`
- [x] Manual: `template` resource with ERB calling an undefined method — CLI now shows `✗ template[/path]: template raised: NoMethodError: undefined method '...' for Object`