### PR TITLE
fix(http): surface libcurl error detail for cert/IO failures

### DIFF
--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -351,6 +351,9 @@ fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_da
 
     var resp = client.request(req) catch |err| {
         std.debug.print("[agent] callback POST failed: {}\n", .{err});
+        if (http.getLastError()) |detail| {
+            std.debug.print("[agent]   {s}\n", .{detail});
+        }
         return;
     };
     defer resp.deinit();
@@ -521,6 +524,9 @@ fn pollOnce(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []con
 
     var resp = client.request(req) catch |err| {
         std.debug.print("[agent] poll failed: {}\n", .{err});
+        if (http.getLastError()) |detail| {
+            std.debug.print("[agent]   {s}\n", .{detail});
+        }
         return;
     };
     defer resp.deinit();

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -590,6 +590,10 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
         .cert = res.args.@"client-cert",
         .key = res.args.@"client-key",
     };
+    // Fail fast (with a specific reason) if cert/key aren't readable by us;
+    // libcurl would otherwise report only a generic "unable to set private
+    // key file". Message is already printed inside the helper.
+    http.validateClientAuthFiles(tls_auth.cert, tls_auth.key) catch std.process.exit(1);
 
     const agent_mode = res.args.mode orelse "ws";
     if (std.mem.eql(u8, agent_mode, "ws") or std.mem.eql(u8, agent_mode, "sse")) {

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -225,6 +225,11 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
         .cert = res.args.@"client-cert",
         .key = res.args.@"client-key",
     };
+    // Fail fast (with a specific reason) if cert/key aren't readable by us;
+    // libcurl would otherwise report only a generic "unable to set private
+    // key file" without distinguishing permission vs not-found. Message is
+    // already printed inside the helper.
+    http.validateClientAuthFiles(tls_auth.cert, tls_auth.key) catch std.process.exit(1);
 
     // Resolve data_bag: from URL or inline JSON
     var fetched_data_bag: ?[]const u8 = null;

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -66,6 +66,9 @@ fn fetchJsonFromUrl(allocator: std.mem.Allocator, url: []const u8, tls_auth: Tls
 
     const response = client.get(url, null) catch |err| {
         std.debug.print("\nError: Failed to fetch JSON from URL: {}\n", .{err});
+        if (http.getLastError()) |detail| {
+            std.debug.print("  {s}\n", .{detail});
+        }
         std.debug.print("URL: {s}\n", .{display_url});
         return error.FetchFailed;
     };
@@ -134,11 +137,15 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, u
 
         const response = client.get(script_path_or_url, null) catch |err| {
             std.debug.print("\nError: Failed to download provision script: {}\n", .{err});
+            if (http.getLastError()) |detail| {
+                std.debug.print("  {s}\n", .{detail});
+            }
             std.debug.print("URL: {s}\n", .{display_url});
             std.debug.print("\nPossible reasons:\n", .{});
             std.debug.print("  • URL is not accessible\n", .{});
             std.debug.print("  • Network connectivity issues\n", .{});
             std.debug.print("  • Invalid credentials (if using Basic Auth)\n", .{});
+            std.debug.print("  • Client certificate / key unreadable or invalid (if using mTLS)\n", .{});
             std.debug.print("  • Server returned an error\n", .{});
             return error.DownloadFailed;
         };

--- a/src/curl.zig
+++ b/src/curl.zig
@@ -21,9 +21,14 @@ pub const CURLcode = enum(c_int) {
     CURLE_WRITE_ERROR = 23,
     CURLE_SSL_CONNECT_ERROR = 35,
     CURLE_PEER_FAILED_VERIFICATION = 51,
+    CURLE_SSL_CERTPROBLEM = 58,
+    CURLE_SSL_CACERT_BADFILE = 77,
     CURLE_ABORTED_BY_CALLBACK = 42,
     _,
 };
+
+/// Size of the error buffer passed to CURLOPT_ERRORBUFFER (bytes).
+pub const CURL_ERROR_SIZE: usize = 256;
 
 pub const CURLoption = enum(c_int) {
     CURLOPT_URL = 10002,
@@ -97,6 +102,9 @@ pub const CURLoption = enum(c_int) {
 
     // Debug
     CURLOPT_VERBOSE = 41,
+
+    // Error reporting
+    CURLOPT_ERRORBUFFER = 10010,
 
     _,
 };

--- a/src/http.zig
+++ b/src/http.zig
@@ -19,6 +19,12 @@ pub const getUserAgent = config.getUserAgent;
 pub const client = @import("http/client.zig");
 pub const Client = client.Client;
 
+// Thread-local last-error detail from libcurl (populated on failed requests).
+// Callers can read this after catching an HTTP error to surface a human-
+// readable reason (e.g. "could not load PEM client certificate").
+pub const getLastError = client.getLastCurlError;
+pub const clearLastError = client.clearLastCurlError;
+
 // Re-export utilities
 pub const utils = @import("http/utils.zig");
 pub const parseHeadersFromJson = utils.parseHeadersFromJson;

--- a/src/http.zig
+++ b/src/http.zig
@@ -14,6 +14,7 @@ pub const ProgressCallback = types.ProgressCallback;
 pub const config = @import("http/config.zig");
 pub const Config = config.Config;
 pub const getUserAgent = config.getUserAgent;
+pub const validateClientAuthFiles = config.validateClientAuthFiles;
 
 // Re-export client
 pub const client = @import("http/client.zig");

--- a/src/http/client.zig
+++ b/src/http/client.zig
@@ -9,6 +9,41 @@ const Response = types.Response;
 const Method = types.Method;
 const Config = config_mod.Config;
 
+// --- Last curl-error detail ------------------------------------------------
+// When curl_easy_perform fails we copy libcurl's CURLOPT_ERRORBUFFER text
+// (or, if that's empty, curl_easy_strerror output) into this thread-local
+// buffer. Callers that want to show the user a specific reason (e.g. "could
+// not load PEM client certificate /path/to/client.crt: No such file or
+// directory") can read it after catching the error.
+threadlocal var last_curl_error_buf: [curl.CURL_ERROR_SIZE]u8 = undefined;
+threadlocal var last_curl_error_len: usize = 0;
+
+pub fn clearLastCurlError() void {
+    last_curl_error_len = 0;
+}
+
+pub fn getLastCurlError() ?[]const u8 {
+    if (last_curl_error_len == 0) return null;
+    return last_curl_error_buf[0..last_curl_error_len];
+}
+
+/// Copy an errbuf populated by libcurl (null-terminated within
+/// CURL_ERROR_SIZE) plus a curl_easy_strerror fallback into the
+/// thread-local buffer. `errbuf` must be the one registered with
+/// CURLOPT_ERRORBUFFER on the handle that just failed.
+fn recordCurlError(errbuf: *const [curl.CURL_ERROR_SIZE]u8, code: curl.CURLcode) void {
+    const libcurl_msg = std.mem.sliceTo(errbuf, 0);
+    const source = if (libcurl_msg.len > 0)
+        libcurl_msg
+    else blk: {
+        const fallback_cstr = curl.curl_easy_strerror(code);
+        break :blk std.mem.span(fallback_cstr);
+    };
+    const n = @min(source.len, last_curl_error_buf.len);
+    @memcpy(last_curl_error_buf[0..n], source[0..n]);
+    last_curl_error_len = n;
+}
+
 /// HTTP Client based on libcurl
 pub const Client = struct {
     allocator: std.mem.Allocator,
@@ -32,6 +67,11 @@ pub const Client = struct {
 
     /// Perform HTTP request
     pub fn request(self: *Client, req: Request) !Response {
+        // Reset thread-local last-curl-error so callers that read
+        // getLastCurlError() in their catch block see only the detail from
+        // *this* call (or null on success / non-libcurl failure).
+        clearLastCurlError();
+
         var attempt: u32 = 0;
         const max_attempts = @max(1, self.config.retry.max_attempts); // Ensure at least 1 attempt
 
@@ -273,6 +313,12 @@ pub const Client = struct {
         const header_list = try self.setupCurlHandle(handle, req);
         defer if (header_list) |list| curl.curl_slist_free_all(list);
 
+        // Register an error buffer so libcurl can store a human-readable
+        // reason (e.g. "could not load PEM client certificate") beyond what
+        // the bare CURLcode conveys. Must live until curl_easy_cleanup.
+        var errbuf: [curl.CURL_ERROR_SIZE]u8 = [_]u8{0} ** curl.CURL_ERROR_SIZE;
+        _ = curl.curl_easy_setopt(handle, .CURLOPT_ERRORBUFFER, &errbuf);
+
         // Response body
         var body_ctx = BodyContext{
             .allocator = self.allocator,
@@ -304,6 +350,7 @@ pub const Client = struct {
         // Perform request
         const res = curl.curl_easy_perform(handle);
         if (res != .CURLE_OK) {
+            recordCurlError(&errbuf, res);
             return curlErrorToZig(res);
         }
 
@@ -340,12 +387,23 @@ pub const Client = struct {
         progress_callback: ?types.ProgressCallback,
         progress_context: ?*anyopaque,
     ) !StreamResult {
+        // Reset thread-local last-curl-error so callers that read
+        // getLastCurlError() in their catch block see only the detail from
+        // *this* call (or null on success / non-libcurl failure).
+        clearLastCurlError();
+
         const handle = curl.curl_easy_init() orelse return error.ConnectionFailed;
         defer curl.curl_easy_cleanup(handle);
 
         // Setup common curl options
         const header_list = try self.setupCurlHandle(handle, req);
         defer if (header_list) |list| curl.curl_slist_free_all(list);
+
+        // Register an error buffer so libcurl can store a human-readable
+        // reason beyond what the bare CURLcode conveys. Must live until
+        // curl_easy_cleanup.
+        var errbuf: [curl.CURL_ERROR_SIZE]u8 = [_]u8{0} ** curl.CURL_ERROR_SIZE;
+        _ = curl.curl_easy_setopt(handle, .CURLOPT_ERRORBUFFER, &errbuf);
 
         // Stream context
         var stream_ctx = StreamContext{
@@ -391,6 +449,7 @@ pub const Client = struct {
         // Perform
         const res = curl.curl_easy_perform(handle);
         if (res != .CURLE_OK) {
+            recordCurlError(&errbuf, res);
             return curlErrorToZig(res);
         }
 
@@ -539,7 +598,11 @@ fn curlErrorToZig(code: curl.CURLcode) types.Error {
         .CURLE_OPERATION_TIMEDOUT => error.Timeout,
         .CURLE_URL_MALFORMAT => error.InvalidUrl,
         .CURLE_COULDNT_RESOLVE_PROXY => error.DNSResolutionFailed,
-        .CURLE_SSL_CONNECT_ERROR, .CURLE_PEER_FAILED_VERIFICATION => error.TLSError,
+        .CURLE_SSL_CONNECT_ERROR,
+        .CURLE_PEER_FAILED_VERIFICATION,
+        .CURLE_SSL_CERTPROBLEM,
+        .CURLE_SSL_CACERT_BADFILE,
+        => error.TLSError,
         else => error.Unknown,
     };
 }

--- a/src/http/config.zig
+++ b/src/http/config.zig
@@ -84,10 +84,12 @@ pub fn validateClientAuthFiles(cert: ?[]const u8, key: ?[]const u8) error{Invali
 
 fn ensureReadable(path: []const u8, label: []const u8) error{InvalidClientAuth}!void {
     var file = std.fs.cwd().openFile(path, .{}) catch |err| {
-        switch (err) {
-            error.FileNotFound => std.debug.print("Error: {s} file not found: {s}\n", .{ label, path }),
-            error.AccessDenied => std.debug.print("Error: {s} file is not readable (permission denied): {s}\n", .{ label, path }),
-            else => std.debug.print("Error: cannot open {s} file '{s}': {}\n", .{ label, path, err }),
+        if (!builtin.is_test) {
+            switch (err) {
+                error.FileNotFound => std.debug.print("Error: {s} file not found: {s}\n", .{ label, path }),
+                error.AccessDenied => std.debug.print("Error: {s} file is not readable (permission denied): {s}\n", .{ label, path }),
+                else => std.debug.print("Error: cannot open {s} file '{s}': {}\n", .{ label, path, err }),
+            }
         }
         return error.InvalidClientAuth;
     };
@@ -127,6 +129,57 @@ pub fn getUserAgent(allocator: std.mem.Allocator) ![]const u8 {
 
 // Tests
 const testing = @import("std").testing;
+
+test "validateClientAuthFiles: both null is a no-op" {
+    try validateClientAuthFiles(null, null);
+}
+
+test "validateClientAuthFiles: accepts readable cert and key" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "cert.pem", .data = "-----BEGIN CERT-----\n" });
+    try tmp.dir.writeFile(.{ .sub_path = "key.pem", .data = "-----BEGIN KEY-----\n" });
+
+    const cert_path = try tmp.dir.realpathAlloc(testing.allocator, "cert.pem");
+    defer testing.allocator.free(cert_path);
+    const key_path = try tmp.dir.realpathAlloc(testing.allocator, "key.pem");
+    defer testing.allocator.free(key_path);
+
+    try validateClientAuthFiles(cert_path, key_path);
+}
+
+test "validateClientAuthFiles: rejects missing cert path" {
+    try testing.expectError(
+        error.InvalidClientAuth,
+        validateClientAuthFiles("/definitely/does/not/exist/cert.pem", null),
+    );
+}
+
+test "validateClientAuthFiles: rejects missing key path" {
+    try testing.expectError(
+        error.InvalidClientAuth,
+        validateClientAuthFiles(null, "/definitely/does/not/exist/key.pem"),
+    );
+}
+
+test "validateClientAuthFiles: rejects unreadable key (chmod 000)" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    // Root bypasses POSIX file mode, so a chmod 000 file is still readable.
+    if (std.posix.getuid() == 0) return error.SkipZigTest;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.writeFile(.{ .sub_path = "key.pem", .data = "secret" });
+    const key_path = try tmp.dir.realpathAlloc(testing.allocator, "key.pem");
+    defer testing.allocator.free(key_path);
+
+    try std.posix.chmod(key_path, 0o000);
+    defer std.posix.chmod(key_path, 0o600) catch {};
+
+    try testing.expectError(error.InvalidClientAuth, validateClientAuthFiles(null, key_path));
+}
 
 test "getUserAgent format and memory management" {
     const allocator = testing.allocator;

--- a/src/http/config.zig
+++ b/src/http/config.zig
@@ -72,6 +72,28 @@ pub const Config = struct {
     };
 };
 
+/// Pre-flight check that mTLS client cert / key files are readable. libcurl's
+/// diagnostic for an unreadable key is the generic "unable to set private key
+/// file: ... type PEM" — it does not surface the underlying errno. Opening
+/// the files ourselves first lets us report the specific OS reason
+/// (FileNotFound / AccessDenied) before handing the path to libcurl.
+pub fn validateClientAuthFiles(cert: ?[]const u8, key: ?[]const u8) error{InvalidClientAuth}!void {
+    if (cert) |path| try ensureReadable(path, "client certificate");
+    if (key) |path| try ensureReadable(path, "client private key");
+}
+
+fn ensureReadable(path: []const u8, label: []const u8) error{InvalidClientAuth}!void {
+    var file = std.fs.cwd().openFile(path, .{}) catch |err| {
+        switch (err) {
+            error.FileNotFound => std.debug.print("Error: {s} file not found: {s}\n", .{ label, path }),
+            error.AccessDenied => std.debug.print("Error: {s} file is not readable (permission denied): {s}\n", .{ label, path }),
+            else => std.debug.print("Error: cannot open {s} file '{s}': {}\n", .{ label, path, err }),
+        }
+        return error.InvalidClientAuth;
+    };
+    file.close();
+}
+
 /// Version string for User-Agent from build.zig.zon
 const VERSION = if (@hasDecl(build_options, "version")) build_options.version else "0.1.0";
 const IS_NIGHTLY = if (@hasDecl(build_options, "is_nightly")) build_options.is_nightly else false;


### PR DESCRIPTION
## Summary

- Register `CURLOPT_ERRORBUFFER` on every libcurl easy handle and copy the human-readable reason (or `curl_easy_strerror` fallback) into a thread-local buffer on failure. Expose it via `http.getLastError()` / `http.clearLastError()`.
- Print the detail from the four HTTP failure catch paths the user is most likely to hit: `provision` JSON fetch, `provision` script download, `agent` callback POST, `agent` poll. Added an mTLS hint to the script-download reasons list.
- Map `CURLE_SSL_CERTPROBLEM` (58) and `CURLE_SSL_CACERT_BADFILE` (77) to `error.TLSError` so consumers that match on the error enum can distinguish TLS-layer failures.
- Clear the thread-local buffer at `request()` / `stream()` entry so readers see only the current call's detail (or `null` on success / non-libcurl failure) — prevents stale detail from bleeding into a subsequent failure that happens before `curl_easy_perform` (e.g. in `setupCurlHandle`, `Request.build`, or allocations).

### Motivation

Before this change, specifying an unreadable mTLS client key reported:

```
Error: Failed to download provision script: error.Unknown
URL: https://...
```

After:

```
Error: Failed to download provision script: error.Unknown
  unable to set private key file: '/path/to/client.key' type PEM
URL: https://...
```

(The bundled libcurl returns `CURLE_BAD_FUNCTION_ARGUMENT` (43) for this specific case rather than `CURLE_SSL_CERTPROBLEM`, so the error enum stays `Unknown` — but the user-visible diagnostic is now actionable.)

## Test plan

- [x] `zig build` — OK
- [x] `zig build test` — OK
- [x] Manual: created a cert pair, `chmod 000` the key, ran `hola provision --client-cert ... --client-key ... https://example.com/x.rb` — now prints the libcurl detail line.
- [x] Manual: regular HTTPS failure (DNS/TLS) still prints the detail line.