### PR TITLE
fix(dock): honor autohide / magnification booleans (#12)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -233,6 +233,12 @@ fn printVersion() !void {
     , .{});
 }
 
+comptime {
+    if (builtin.os.tag == .macos) {
+        _ = @import("resources/macos_dock.zig");
+    }
+}
+
 test "simple test" {
     const gpa = std.testing.allocator;
     var list: std.ArrayList(i32) = .empty;

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -729,7 +729,7 @@ fn registerResourceBindings(mrb_ptr: *mruby.mrb_state, zig_module: *mruby.RClass
         .{ .name = "add_execute", .handler = zig_add_execute_resource, .args_spec = mruby.MRB_ARGS_REQ(4) | mruby.MRB_ARGS_OPT(4) },
         .{ .name = "add_remote_file", .handler = zig_add_remote_file_resource, .args_spec = mruby.MRB_ARGS_REQ(9) | mruby.MRB_ARGS_OPT(4) },
         .{ .name = "add_template", .handler = zig_add_template_resource, .args_spec = mruby.MRB_ARGS_REQ(5) | mruby.MRB_ARGS_OPT(4) },
-        .{ .name = "add_macos_dock", .handler = zig_add_macos_dock_resource, .args_spec = mruby.MRB_ARGS_REQ(1) | mruby.MRB_ARGS_OPT(9), .platform = .macos },
+        .{ .name = "add_macos_dock", .handler = zig_add_macos_dock_resource, .args_spec = mruby.MRB_ARGS_REQ(1) | mruby.MRB_ARGS_OPT(10), .platform = .macos },
         .{ .name = "add_directory", .handler = zig_add_directory_resource, .args_spec = mruby.MRB_ARGS_REQ(1) | mruby.MRB_ARGS_OPT(7) },
         .{ .name = "add_link", .handler = zig_add_link_resource, .args_spec = mruby.MRB_ARGS_REQ(2) | mruby.MRB_ARGS_OPT(5) },
         .{ .name = "add_route", .handler = zig_add_route_resource, .args_spec = mruby.MRB_ARGS_REQ(5) | mruby.MRB_ARGS_OPT(4) },

--- a/src/resources/macos_dock.zig
+++ b/src/resources/macos_dock.zig
@@ -5,6 +5,8 @@ const plist = @import("../plist.zig");
 const logger = @import("../logger.zig");
 const builtin = @import("builtin");
 
+extern fn zig_mrb_nil_p(val: mruby.mrb_value) c_int;
+
 comptime {
     if (builtin.os.tag != .macos) {
         @compileError("macos_dock resource is only available on macOS");
@@ -868,20 +870,25 @@ pub fn zigAddResource(
     var notifications_val: mruby.mrb_value = undefined;
     var subscriptions_val: mruby.mrb_value = undefined;
 
-    // Format: A|iSbbioooAA
+    // Format: A|iSooioooAA
     // A: required array (apps)
     // |: optional args start
     // i: optional integer (tilesize)
     // S: optional string (orientation)
-    // b: optional boolean (autohide)
-    // b: optional boolean (magnification)
+    // o: optional object (autohide — accept nil/true/false to preserve tri-state)
+    // o: optional object (magnification — same as autohide)
     // i: optional integer (largesize)
     // o: optional object (only_if)
     // o: optional object (not_if)
     // o: optional object (ignore_failure)
     // A: optional array (notifications)
     // A: optional array (subscriptions)
-    _ = mruby.mrb_get_args(mrb, "A|iSbbioooAA", &apps_val, &tilesize_val, &orientation_val, &autohide_val, &magnification_val, &largesize_val, &only_if_val, &not_if_val, &ignore_failure_val, &notifications_val, &subscriptions_val);
+    //
+    // Note: format `b` would write a single `mrb_bool` (u8) into the variable's
+    // first byte and leave the remaining 7 bytes as stack garbage; pairing that
+    // with our `mrb_value` slot caused boolean detection to fail almost every
+    // time and silently dropped `autohide` / `magnification` settings (issue #12).
+    _ = mruby.mrb_get_args(mrb, "A|iSooioooAA", &apps_val, &tilesize_val, &orientation_val, &autohide_val, &magnification_val, &largesize_val, &only_if_val, &not_if_val, &ignore_failure_val, &notifications_val, &subscriptions_val);
 
     // Parse apps array
     var apps = std.ArrayList([]const u8).initCapacity(allocator, 0) catch std.ArrayList([]const u8).empty;
@@ -908,21 +915,8 @@ pub fn zigAddResource(
         }
     }
 
-    // For boolean values in mruby word boxing:
-    // - nil:   0xAAAAAAAAAAAAAAAA
-    // - false: 0xAAAAAAAAAAAAAA00
-    // - true:  0xAAAAAAAAAAAAAA01
-    var autohide: ?bool = null;
-    // Check if the upper bits match the boolean pattern
-    if ((autohide_val.w & 0xFFFFFFFFFFFFFF00) == 0xAAAAAAAAAAAAAA00) {
-        // It's a boolean, check the last byte
-        autohide = (autohide_val.w & 0x01) != 0;
-    }
-
-    var magnification: ?bool = null;
-    if ((magnification_val.w & 0xFFFFFFFFFFFFFF00) == 0xAAAAAAAAAAAAAA00) {
-        magnification = (magnification_val.w & 0x01) != 0;
-    }
+    const autohide: ?bool = if (zig_mrb_nil_p(autohide_val) != 0) null else mruby.mrb_test(autohide_val);
+    const magnification: ?bool = if (zig_mrb_nil_p(magnification_val) != 0) null else mruby.mrb_test(magnification_val);
 
     var largesize: ?i64 = null;
     if (mruby.mrb_test(largesize_val)) {

--- a/src/resources/macos_dock.zig
+++ b/src/resources/macos_dock.zig
@@ -939,3 +939,64 @@ pub fn zigAddResource(
 
     return mruby.mrb_nil_value();
 }
+
+// Test-only bridge: mruby C ABI expects `fn(mrb, self) mrb_value`, but
+// `zigAddResource` needs an extra resources slice + allocator. Stash them in
+// threadlocal vars so the test can call back into `zigAddResource`.
+threadlocal var test_collected: ?*std.ArrayList(Resource) = null;
+threadlocal var test_allocator: ?std.mem.Allocator = null;
+
+fn testAddMacosDockCallback(mrb: *mruby.mrb_state, self: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    const collected = test_collected orelse @panic("test_collected not set");
+    const alloc = test_allocator orelse @panic("test_allocator not set");
+    return zigAddResource(mrb, self, collected, alloc);
+}
+
+test "zigAddResource: autohide/magnification tri-state parsing (regression for issue #12)" {
+    const allocator = std.testing.allocator;
+
+    var collected: std.ArrayList(Resource) = .empty;
+    defer {
+        for (collected.items) |res| res.deinit(allocator);
+        collected.deinit(allocator);
+    }
+
+    test_collected = &collected;
+    test_allocator = allocator;
+    defer {
+        test_collected = null;
+        test_allocator = null;
+    }
+
+    var state = try mruby.State.init();
+    defer state.deinit();
+    const mrb_ptr = state.mrb orelse return error.MRubyNotInitialized;
+
+    const zig_module = mruby.mrb_define_module(mrb_ptr, "ZigBackend");
+    mruby.mrb_define_module_function(
+        mrb_ptr,
+        zig_module,
+        "add_macos_dock",
+        testAddMacosDockCallback,
+        mruby.MRB_ARGS_REQ(1) | mruby.MRB_ARGS_OPT(10),
+    );
+
+    // Case 1: autohide=true, magnification=false — both bools must round-trip.
+    try state.evalString("ZigBackend.add_macos_dock([], 50, 'bottom', true, false, 64, nil, nil, false, [], [])");
+    try std.testing.expectEqual(@as(usize, 1), collected.items.len);
+    try std.testing.expectEqual(@as(?bool, true), collected.items[0].autohide);
+    try std.testing.expectEqual(@as(?bool, false), collected.items[0].magnification);
+
+    // Case 2: autohide=nil, magnification=nil — DSL leaves them unset; tri-state
+    // must preserve null so applyConfigure skips the CFPreferences write.
+    try state.evalString("ZigBackend.add_macos_dock([], 50, 'bottom', nil, nil, 64, nil, nil, false, [], [])");
+    try std.testing.expectEqual(@as(usize, 2), collected.items.len);
+    try std.testing.expectEqual(@as(?bool, null), collected.items[1].autohide);
+    try std.testing.expectEqual(@as(?bool, null), collected.items[1].magnification);
+
+    // Case 3: autohide=false, magnification=true — false must NOT collapse to nil.
+    try state.evalString("ZigBackend.add_macos_dock([], 50, 'bottom', false, true, 64, nil, nil, false, [], [])");
+    try std.testing.expectEqual(@as(usize, 3), collected.items.len);
+    try std.testing.expectEqual(@as(?bool, false), collected.items[2].autohide);
+    try std.testing.expectEqual(@as(?bool, true), collected.items[2].magnification);
+}


### PR DESCRIPTION
## Summary

Fix issue #12: `macos_dock` silently dropped `autohide true` / `magnification` under `hola provision`, so the Dock never actually engaged auto-hide. On a clean system, `defaults read com.apple.dock autohide` reported the key as missing because we never called `updateDockPrefWithCFPreferences` for it.

### Root cause (two layers)

**1. Type/contract mismatch with `mrb_get_args`.** mruby format `b` writes a 1-byte `mrb_bool` and only touches that single byte (see `deps/mruby/src/class.c:1535-1542`, `deps/mruby/include/mruby/value.h:35-47`). The buggy code declared the slot as an 8-byte `mrb_value` and passed its address to a `b` slot — so 7 of the 8 bytes were never written by mruby and stayed as whatever was on the stack.

**2. The "magic bit pattern" was Zig's Debug fill, misread as mruby's protocol.** The old code probed the upper 7 bytes against `0xAAAAAAAAAAAAAA00` to recover a tri-state boolean. That pattern is **Zig's Debug-mode `undefined` fill** (a debugger aid — `0xAA` is intentionally conspicuous in memory dumps), not mruby's representation. The actual mruby word boxing on 64-bit is `MRB_Qnil=0 / MRB_Qfalse=4 / MRB_Qtrue=12` (`deps/mruby/include/mruby/boxing_word.h:26-31`). The author observed `0xAA` in a debugger and reverse-engineered it as if it were the contract.

The result: in Debug, `undefined` is filled with `0xAA` so the bit-pattern check accidentally matched and the resource appeared to work. In ReleaseFast there is no fill, the upper bytes are real stack garbage, the bit check failed almost every time, the boolean degraded to `nil`, and `apply()`'s `if (self.autohide) |hide|` short-circuited — no write, key stays absent, Dock never auto-hides.

### Fix

Switch the format slots from `b` to `o` and decode the tri-state with `zig_mrb_nil_p` + `mrb_test`, matching the canonical pattern already used by `remote_file.zig` and `ruby_block.zig`. This ignores stack contents entirely and reads the actual mruby boxed value.

### Companion changes

- **Regression test** (`zigAddResource: autohide/magnification tri-state parsing`) drives the production parser through a real mruby interpreter via a threadlocal bridge and asserts that `true` / `false` / `nil` all round-trip. `main.zig` gets a comptime `_ = @import("resources/macos_dock.zig")` so Zig 0.15.2's test discovery actually pulls the file in.
- **Arity realignment** in `provision.zig`: `add_macos_dock` was registered as `MRB_ARGS_OPT(9)` while the format string and call site already use 10 optional args — bumped to `OPT(10)` so registry, format, and call site stop drifting.

## Test plan

- [x] `zig build test` → 3/3 passed
- [x] Reverted the fix locally (format back to `b` + magic-byte check); regression test failed with `expected null, found false`, confirming it pins the real bug
- [x] **Reproduced the bug under `-Doptimize=ReleaseFast` on a clean system**: deleted `com.apple.dock` autohide pref, ran buggy `hola provision { autohide true }` — `defaults read` still reports "does not exist"; ran the fixed binary on the same clean state — `defaults read` returns `1`
- [x] `autohide false` returns `0`; rerunning the same config reports `up to date` (idempotent)

Fixes #12