### PR TITLE
fix(ci): build linux-aarch64 against glibc to match deps ABI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           - name: linux-x86_64
             triple: x86_64-linux-gnu
           - name: linux-aarch64
-            triple: aarch64-linux-musl
+            triple: aarch64-linux-gnu
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,7 +49,7 @@ jobs:
           - name: linux-x86_64
             triple: x86_64-linux-gnu
           - name: linux-aarch64
-            triple: aarch64-linux-musl
+            triple: aarch64-linux-gnu
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

- hola-deps v0.1.2 publishes the aarch64 tarball built on `ubuntu-22.04-arm` (glibc), but the hola CI cross-compiled with target `aarch64-linux-musl`.
- The musl/glibc `struct _IO_FILE` layout mismatch makes `mrb_close` SEGV on production aarch64 hosts **after** `provision` completes successfully.
- x86_64 was unaffected because target `x86_64-linux-gnu` already matched the deps build (Ubuntu x86_64 runner is also glibc).
- Switching the target triple to `aarch64-linux-gnu` aligns linked libc ABI with the precompiled mruby/libcurl in hola-deps.

## Test plan

- [ ] CI publishes a new nightly with all three platforms
- [ ] Download the new `hola-linux-aarch64` and run `hola provision` on a production aarch64 host; confirm no SEGV after `provision complete`
- [ ] x86_64 + macOS unchanged