### PR TITLE
feat(agent): log WebSocket connected on first frame received

### DIFF
--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -398,12 +398,17 @@ const WsContext = struct {
     default_callback: ?[]const u8,
     endpoint: []const u8,
     tls_auth: TlsClientAuth,
+    first_frame: bool = true,
 };
 
 fn wsWriteCallback(ptr: [*]const u8, size: usize, nmemb: usize, userdata: *anyopaque) callconv(.c) usize {
     const ctx: *WsContext = @ptrCast(@alignCast(userdata));
     const total = size * nmemb;
     if (total == 0) return 0;
+    if (ctx.first_frame) {
+        std.debug.print("[agent] WebSocket connected, receiving frames\n", .{});
+        ctx.first_frame = false;
+    }
     handleWsMessage(ctx.allocator, ptr[0..total], ctx.default_callback, ctx.endpoint, ctx.tls_auth);
     return total;
 }


### PR DESCRIPTION
## Summary

- The ws path used to be silent between `[agent] node=..., connecting to wss://...` and the first task frame, so operators couldn't tell idle-but-healthy from stuck-mid-handshake from frames-being-silently-dropped.
- Adds a one-shot `[agent] WebSocket connected, receiving frames` the first time libcurl's write callback fires.
- Cheap to leave on (one bool flip per connection); avoids needing `CURLOPT_VERBOSE` just to confirm a handshake succeeded.

## Test plan

- [ ] `hola agent --mode ws ...` against a reachable hub shows the new log line after the existing "connecting" line
- [ ] `hola agent --mode ws ...` against an unreachable / TLS-broken hub still shows the existing error path with no spurious "connected" line
- [ ] watch mode unaffected (only ws path is touched)