### PR TITLE
fix(ci): build linux-aarch64 against musl to match musl-compiled deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           - name: linux-x86_64
             triple: x86_64-linux-gnu
           - name: linux-aarch64
-            triple: aarch64-linux-gnu
+            triple: aarch64-linux-musl
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,7 +49,7 @@ jobs:
           - name: linux-x86_64
             triple: x86_64-linux-gnu
           - name: linux-aarch64
-            triple: aarch64-linux-gnu
+            triple: aarch64-linux-musl
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Problem

Production aarch64 hosts crash with heap corruption (`malloc(): invalid size`, `Fatal glibc error: sysmalloc assertion failed`) during `provision` — both in the WS agent's in-memory script fetch and in plain local provisioning of file resources.

## Root cause

PR #16 (`37fbe44`) switched the aarch64 build from `aarch64-linux-musl` to `aarch64-linux-gnu` on the premise that `hola-deps` ships glibc aarch64 binaries. That premise is wrong. Inspecting `hola-deps` v0.1.2:

- `libcrypto.a` embeds compiler string `/data/aarch64-linux-musl/bin/aarch64-linux-musl-cc`
- `libmruby.a` is tagged `aarch64-linux-musl`
- the deps build workflow sets `CC: musl-gcc` for the whole `make`
- undefined symbols are musl-style (`sigsetjmp`, `sscanf`), not glibc (`__sigsetjmp`, `__isoc99_sscanf`)

So the aarch64 deps are **musl**. Linking them into a **glibc** binary mismatches libc struct layouts (`FILE`, `sigjmp_buf`, etc.) and corrupts the heap. x86_64 is unaffected because its mruby happens to be gnu-built, matching the gnu binary.

`OPENSSL_armcap=0` did not stop the crash (it still aborts in a pure local provision with no TLS), confirming the corruption is the systemic musl-deps × glibc-binary mismatch, not just OpenSSL armcap's `sigsetjmp` probing.

## Fix

Restore the aarch64 triple to `aarch64-linux-musl` (reverting PR #16, restoring `608c2bc`) so the binary's libc matches the deps.

## Verification

- Builds with the exact CI command: `zig build -Doptimize=ReleaseSmall -Dstrip=true -Dcpu=baseline -Dtarget=aarch64-linux-musl` (CI runs on `macos-latest` cross-compiling — local pass ⇒ CI pass).
- The resulting static musl binary runs `provision _bootstrap.rb` cleanly on the production aarch64 host (no heap corruption).

The `src/linux_aarch64_shims.S` sigsetjmp shim is guarded `abi == .gnu`, so it goes inert under musl; left in place for a minimal diff.