### PR TITLE
feat(provision): surface detailed failure reasons with credential-safe URL redaction

### DIFF
--- a/src/base_resource.zig
+++ b/src/base_resource.zig
@@ -4,13 +4,11 @@ pub const notification = @import("notification.zig");
 const builtin = @import("builtin");
 
 // --- Provision error detail context ----------------------------------------
-// Whenever a piece of user Ruby raises during provisioning (a guard block,
-// the top-level DSL script, or the body of `ruby_block`), we capture a
-// friendly summary (e.g. "only_if block raised: Errno::ENOENT: No such
-// file or directory ...") into a thread-local buffer. The top-level apply
-// loop and the agent callback can then show it to the user instead of the
-// raw Zig error name "MRubyException".
-const PROVISION_ERROR_DETAIL_BUF_SIZE = 256;
+// Whenever a resource can provide more context than the raw Zig error name,
+// capture that friendly summary into a thread-local buffer. The top-level
+// apply loop and the agent callback can then show details like the raised Ruby
+// exception, failed URL, HTTP status, or checksum mismatch.
+const PROVISION_ERROR_DETAIL_BUF_SIZE = 1024;
 threadlocal var provision_error_detail_buf: [PROVISION_ERROR_DETAIL_BUF_SIZE]u8 = undefined;
 threadlocal var provision_error_detail_len: usize = 0;
 
@@ -23,6 +21,21 @@ pub fn getProvisionErrorDetail() ?[]const u8 {
     return provision_error_detail_buf[0..provision_error_detail_len];
 }
 
+pub fn recordProvisionErrorDetailSlice(detail: []const u8) void {
+    const n = @min(detail.len, provision_error_detail_buf.len);
+    @memcpy(provision_error_detail_buf[0..n], detail[0..n]);
+    provision_error_detail_len = n;
+}
+
+pub fn recordProvisionErrorDetail(comptime fmt: []const u8, args: anytype) void {
+    const written = std.fmt.bufPrint(&provision_error_detail_buf, fmt, args) catch blk: {
+        const fallback = "provision error (message truncated)";
+        @memcpy(provision_error_detail_buf[0..fallback.len], fallback);
+        break :blk provision_error_detail_buf[0..fallback.len];
+    };
+    provision_error_detail_len = written.len;
+}
+
 /// Capture a friendly summary of an mruby exception into the thread-local
 /// error detail buffer. If `prefix` is non-null the buffer stores
 /// "{prefix}: {ClassName}: {message}"; otherwise just "{ClassName}: {message}".
@@ -32,21 +45,13 @@ pub fn recordProvisionException(mrb: *mruby.mrb_state, exc: mruby.mrb_value, pre
     const summary = std.mem.sliceTo(&summary_buf, 0);
 
     const written = if (prefix) |p|
-        std.fmt.bufPrint(
-            &provision_error_detail_buf,
-            "{s}: {s}",
-            .{ p, summary },
-        ) catch blk: {
+        std.fmt.bufPrint(&provision_error_detail_buf, "{s}: {s}", .{ p, summary }) catch blk: {
             const fallback = "provision error (message truncated)";
             @memcpy(provision_error_detail_buf[0..fallback.len], fallback);
             break :blk provision_error_detail_buf[0..fallback.len];
         }
     else
-        std.fmt.bufPrint(
-            &provision_error_detail_buf,
-            "{s}",
-            .{summary},
-        ) catch blk: {
+        std.fmt.bufPrint(&provision_error_detail_buf, "{s}", .{summary}) catch blk: {
             const fallback = "provision error (message truncated)";
             @memcpy(provision_error_detail_buf[0..fallback.len], fallback);
             break :blk provision_error_detail_buf[0..fallback.len];

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -29,19 +29,6 @@ const parsers = .{
 
 /// Return a display-safe URL with password masked as "***".
 /// If the URL has no password or parsing fails, returns the original string.
-fn maskUrlPassword(allocator: std.mem.Allocator, url: []const u8) []const u8 {
-    const uri = std.Uri.parse(url) catch return url;
-    if (uri.password == null) return url;
-    const user_part = if (uri.user) |u| u.percent_encoded else "";
-    const host_part = if (uri.host) |h| h.percent_encoded else "";
-    return std.fmt.allocPrint(allocator, "{s}://{s}:***@{s}{s}", .{
-        uri.scheme,
-        user_part,
-        host_part,
-        uri.path.percent_encoded,
-    }) catch url;
-}
-
 const TlsClientAuth = struct {
     cert: ?[]const u8 = null,
     key: ?[]const u8 = null,
@@ -194,8 +181,8 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
     };
     defer if (secrets_json) |s| allocator.free(s);
 
-    const display_url = maskUrlPassword(allocator, url);
-    defer if (display_url.ptr != url.ptr) allocator.free(display_url);
+    var url_buf: [512]u8 = undefined;
+    const display_url = http.maskUrlPassword(url, &url_buf);
     std.debug.print("[agent] task={s} action={s} provisioning: {s}\n", .{ task_id, action_name, display_url });
 
     // Only pass mTLS credentials if script URL matches agent endpoint origin
@@ -375,8 +362,8 @@ fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []c
     };
     defer if (ws_endpoint.ptr != endpoint.ptr) allocator.free(ws_endpoint);
 
-    const display_endpoint = maskUrlPassword(allocator, ws_endpoint);
-    defer if (display_endpoint.ptr != ws_endpoint.ptr) allocator.free(display_endpoint);
+    var endpoint_buf: [512]u8 = undefined;
+    const display_endpoint = http.maskUrlPassword(ws_endpoint, &endpoint_buf);
     std.debug.print("[agent] node={s}, connecting to {s}\n", .{ node_name, display_endpoint });
 
     var backoff_ms: u64 = INITIAL_BACKOFF_MS;
@@ -494,8 +481,8 @@ fn handleWsMessage(allocator: std.mem.Allocator, msg: []const u8, default_callba
 // -- Watch (polling) mode --
 
 fn runWatchMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, interval_s: u32, default_callback: ?[]const u8, tls_auth: TlsClientAuth) void {
-    const display_endpoint = maskUrlPassword(allocator, endpoint);
-    defer if (display_endpoint.ptr != endpoint.ptr) allocator.free(display_endpoint);
+    var endpoint_buf: [512]u8 = undefined;
+    const display_endpoint = http.maskUrlPassword(endpoint, &endpoint_buf);
     std.debug.print("[agent] watch mode, node={s}, polling {s} every {d}s\n", .{ node_name, display_endpoint, interval_s });
 
     while (true) {

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -312,7 +312,8 @@ fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_da
     };
     defer allocator.free(body);
 
-    std.debug.print("[agent] callback POST {s}\n", .{callback_url});
+    var callback_url_buf: [512]u8 = undefined;
+    std.debug.print("[agent] callback POST {s}\n", .{http.maskUrlPassword(callback_url, &callback_url_buf)});
 
     // Use mTLS if callback host matches endpoint host
     const use_tls_auth = originMatches(callback_url, endpoint);
@@ -339,7 +340,8 @@ fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_da
     var resp = client.request(req) catch |err| {
         std.debug.print("[agent] callback POST failed: {}\n", .{err});
         if (http.getLastError()) |detail| {
-            std.debug.print("[agent]   {s}\n", .{detail});
+            var detail_buf: [1024]u8 = undefined;
+            std.debug.print("[agent]   {s}\n", .{http.redactPassword(callback_url, detail, &detail_buf)});
         }
         return;
     };
@@ -517,7 +519,8 @@ fn pollOnce(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []con
     var resp = client.request(req) catch |err| {
         std.debug.print("[agent] poll failed: {}\n", .{err});
         if (http.getLastError()) |detail| {
-            std.debug.print("[agent]   {s}\n", .{detail});
+            var detail_buf: [1024]u8 = undefined;
+            std.debug.print("[agent]   {s}\n", .{http.redactPassword(endpoint, detail, &detail_buf)});
         }
         return;
     };

--- a/src/commands/apply.zig
+++ b/src/commands/apply.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const clap = @import("clap");
 const git = @import("../git.zig");
+const http = @import("../http.zig");
 const apply_module = @import("../apply.zig");
 const logger = @import("../logger.zig");
 const dotfiles_paths = @import("../dotfiles_paths.zig");
@@ -29,7 +30,8 @@ fn cloneRepository(
     is_github: bool,
     display_name: []const u8,
 ) !void {
-    std.debug.print("[clone] {s} -> {s}\n", .{ url, dest });
+    var url_buf: [512]u8 = undefined;
+    std.debug.print("[clone] {s} -> {s}\n", .{ http.maskUrlPassword(url, &url_buf), dest });
 
     var client = try git.Client.init();
     defer client.deinit();
@@ -41,7 +43,8 @@ fn cloneRepository(
 
     client.clone(allocator, url, dest, clone_options) catch |err| {
         std.debug.print("\n\x1b[31mError: Failed to clone repository\x1b[0m\n", .{});
-        std.debug.print("Repository: {s}\n", .{url});
+        var repo_buf: [512]u8 = undefined;
+        std.debug.print("Repository: {s}\n", .{http.maskUrlPassword(url, &repo_buf)});
         std.debug.print("Destination: {s}\n", .{dest});
         std.debug.print("\nPossible reasons:\n", .{});
         std.debug.print("  • Repository does not exist or is private\n", .{});
@@ -163,7 +166,8 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
         if (!dry_run) {
             try cloneRepository(allocator, repo_url, clone_dest, res.args.branch, false, "repository");
         } else {
-            std.debug.print("[dry-run] Would clone {s} to {s}\n", .{ repo_url, clone_dest });
+            var url_buf: [512]u8 = undefined;
+            std.debug.print("[dry-run] Would clone {s} to {s}\n", .{ http.maskUrlPassword(repo_url, &url_buf), clone_dest });
         }
     }
 

--- a/src/commands/git_clone.zig
+++ b/src/commands/git_clone.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const clap = @import("clap");
 const git = @import("../git.zig");
+const http = @import("../http.zig");
 
 const params = clap.parseParamsComptime(
     \\-h, --help            Show help for git-clone
@@ -47,7 +48,8 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
     std.debug.print("[clone] -> {s}\n", .{destination});
     try client.clone(allocator, url, destination, options);
     if (options.show_progress) std.debug.print("\n", .{});
-    std.debug.print("[done] {s} -> {s}\n", .{ url, destination });
+    var url_buf: [512]u8 = undefined;
+    std.debug.print("[done] {s} -> {s}\n", .{ http.maskUrlPassword(url, &url_buf), destination });
 }
 
 fn printHelp(reason: ?[]const u8) !void {

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -58,7 +58,8 @@ fn fetchJsonFromUrl(allocator: std.mem.Allocator, url: []const u8, tls_auth: Tls
     const response = client.get(url, null) catch |err| {
         std.debug.print("\nError: Failed to fetch JSON from URL: {}\n", .{err});
         if (http.getLastError()) |detail| {
-            std.debug.print("  {s}\n", .{detail});
+            var detail_buf: [1024]u8 = undefined;
+            std.debug.print("  {s}\n", .{http.redactPassword(url, detail, &detail_buf)});
         }
         std.debug.print("URL: {s}\n", .{display_url});
         return error.FetchFailed;
@@ -120,7 +121,8 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, u
         const response = client.get(script_path_or_url, null) catch |err| {
             std.debug.print("\nError: Failed to download provision script: {}\n", .{err});
             if (http.getLastError()) |detail| {
-                std.debug.print("  {s}\n", .{detail});
+                var detail_buf: [1024]u8 = undefined;
+                std.debug.print("  {s}\n", .{http.redactPassword(script_path_or_url, detail, &detail_buf)});
             }
             std.debug.print("URL: {s}\n", .{display_url});
             std.debug.print("\nPossible reasons:\n", .{});

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -35,22 +35,13 @@ const TlsClientAuth = struct {
 /// Fetch JSON content from a URL, using optional mTLS credentials.
 /// Returns the response body as an owned slice that the caller must free.
 fn fetchJsonFromUrl(allocator: std.mem.Allocator, url: []const u8, tls_auth: TlsClientAuth) ![]const u8 {
-    const uri = std.Uri.parse(url) catch |err| {
+    _ = std.Uri.parse(url) catch |err| {
         std.debug.print("Error: Invalid URL: {}\n", .{err});
         return error.FetchFailed;
     };
 
-    const display_url = if (uri.password != null) display_blk: {
-        const user_part = if (uri.user) |u| u.percent_encoded else "";
-        const host_part = if (uri.host) |h| h.percent_encoded else "";
-        break :display_blk std.fmt.allocPrint(allocator, "{s}://{s}:***@{s}{s}", .{
-            uri.scheme,
-            user_part,
-            host_part,
-            uri.path.percent_encoded,
-        }) catch return error.FetchFailed;
-    } else url;
-    defer if (uri.password != null) allocator.free(display_url);
+    var url_buf: [512]u8 = undefined;
+    const display_url = http.maskUrlPassword(url, &url_buf);
 
     std.debug.print("[fetch] Fetching JSON from {s}\n", .{display_url});
 
@@ -96,22 +87,13 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, u
     };
 
     const script_path = if (is_url) blk: {
-        const uri = std.Uri.parse(script_path_or_url) catch |err| {
+        _ = std.Uri.parse(script_path_or_url) catch |err| {
             std.debug.print("Error: Invalid URL: {}\n", .{err});
             return error.InvalidUrl;
         };
 
-        const display_url = if (uri.password != null) display_blk: {
-            const user_part = if (uri.user) |u| u.percent_encoded else "";
-            const host_part = if (uri.host) |h| h.percent_encoded else "";
-            break :display_blk try std.fmt.allocPrint(allocator, "{s}://{s}:***@{s}{s}", .{
-                uri.scheme,
-                user_part,
-                host_part,
-                uri.path.percent_encoded,
-            });
-        } else script_path_or_url;
-        defer if (uri.password != null) allocator.free(display_url);
+        var url_buf: [512]u8 = undefined;
+        const display_url = http.maskUrlPassword(script_path_or_url, &url_buf);
 
         std.debug.print("[fetch] Downloading provision script from {s}\n", .{display_url});
 

--- a/src/git.zig
+++ b/src/git.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const logger = @import("logger.zig");
+const url_utils = @import("http/utils.zig");
 
 const c = @cImport({
     @cInclude("git2.h");
@@ -78,7 +79,14 @@ fn cloneInternal(allocator: std.mem.Allocator, url: []const u8, destination: []c
     var repo_ptr: ?*c.git_repository = null;
     const code = c.git_clone(&repo_ptr, url_c.ptr, destination_c.ptr, &clone_opts);
     if (code != 0) {
-        logLibGit2Error(code);
+        const err_ptr = c.git_error_last();
+        if (err_ptr != null and err_ptr.*.message != null) {
+            const msg = std.mem.span(@as([*:0]const u8, @ptrCast(err_ptr.*.message)));
+            var msg_buf: [1024]u8 = undefined;
+            logger.err("libgit2 clone ({d}): {s}", .{ code, url_utils.redactPassword(url, msg, &msg_buf) });
+        } else {
+            logger.err("libgit2 clone failed ({d})", .{code});
+        }
         return Error.CloneFailed;
     }
 
@@ -86,7 +94,8 @@ fn cloneInternal(allocator: std.mem.Allocator, url: []const u8, destination: []c
         defer c.git_repository_free(repo);
     }
 
-    logger.info("Cloned {s} -> {s}", .{ url, destination });
+    var url_buf: [512]u8 = undefined;
+    logger.info("Cloned {s} -> {s}", .{ url_utils.maskUrlPassword(url, &url_buf), destination });
 }
 
 fn check(code: c_int, err: Error) Error!void {

--- a/src/http.zig
+++ b/src/http.zig
@@ -34,6 +34,7 @@ pub const formatSizeBuf = utils.formatSizeBuf;
 pub const formatSizeRange = utils.formatSizeRange;
 pub const slugifyPath = utils.slugifyPath;
 pub const calculateSha256 = utils.calculateSha256;
+pub const maskUrlPassword = utils.maskUrlPassword;
 
 // Re-export download module
 pub const download = struct {

--- a/src/http.zig
+++ b/src/http.zig
@@ -35,6 +35,7 @@ pub const formatSizeRange = utils.formatSizeRange;
 pub const slugifyPath = utils.slugifyPath;
 pub const calculateSha256 = utils.calculateSha256;
 pub const maskUrlPassword = utils.maskUrlPassword;
+pub const redactPassword = utils.redactPassword;
 
 // Re-export download module
 pub const download = struct {

--- a/src/http/download/downloader.zig
+++ b/src/http/download/downloader.zig
@@ -179,9 +179,10 @@ pub fn downloadFileWithClient(
         var url_buf: [512]u8 = undefined;
         const display_url = utils.maskUrlPassword(url, &url_buf);
         if (http_client.getLastCurlError()) |curl_detail| {
+            var detail_buf: [1024]u8 = undefined;
             recordLastDownloadError(
                 "download {s} failed: {s}: {s}",
-                .{ display_url, @errorName(err), curl_detail },
+                .{ display_url, @errorName(err), utils.redactPassword(url, curl_detail, &detail_buf) },
             );
         } else {
             recordLastDownloadError(

--- a/src/http/download/downloader.zig
+++ b/src/http/download/downloader.zig
@@ -236,10 +236,10 @@ pub fn downloadFileWithClient(
     // Note: Non-HTTP protocols (SFTP, S3) return status=0 on success
     const is_http = stream_result.status > 0;
     if (is_http and (stream_result.status < 200 or stream_result.status >= 300)) {
-        // Log error with status code
-        logger.err("Download failed with HTTP status {d} for URL: {s}", .{ stream_result.status, url });
         var url_buf: [512]u8 = undefined;
         const display_url = utils.maskUrlPassword(url, &url_buf);
+        // Log error with status code
+        logger.err("Download failed with HTTP status {d} for URL: {s}", .{ stream_result.status, display_url });
         recordLastDownloadError("download {s} returned HTTP status {d}", .{ display_url, stream_result.status });
         // Error or unexpected status code
         // Temp file will be cleaned up by defer automatically

--- a/src/http/download/downloader.zig
+++ b/src/http/download/downloader.zig
@@ -3,6 +3,29 @@ const http_client = @import("../client.zig");
 const types = @import("../types.zig");
 const Task = @import("task.zig").Task;
 const logger = @import("../../logger.zig");
+const utils = @import("../utils.zig");
+
+const LAST_DOWNLOAD_ERROR_BUF_SIZE = 1024;
+threadlocal var last_download_error_buf: [LAST_DOWNLOAD_ERROR_BUF_SIZE]u8 = undefined;
+threadlocal var last_download_error_len: usize = 0;
+
+pub fn clearLastDownloadError() void {
+    last_download_error_len = 0;
+}
+
+pub fn getLastDownloadError() ?[]const u8 {
+    if (last_download_error_len == 0) return null;
+    return last_download_error_buf[0..last_download_error_len];
+}
+
+fn recordLastDownloadError(comptime fmt: []const u8, args: anytype) void {
+    const written = std.fmt.bufPrint(&last_download_error_buf, fmt, args) catch blk: {
+        const fallback = "download failed (message truncated)";
+        @memcpy(last_download_error_buf[0..fallback.len], fallback);
+        break :blk last_download_error_buf[0..fallback.len];
+    };
+    last_download_error_len = written.len;
+}
 
 /// Options for single file download
 pub const Options = struct {
@@ -70,6 +93,8 @@ pub fn downloadFileWithClient(
     dest_path: []const u8,
     opts: Options,
 ) !Result {
+    clearLastDownloadError();
+
     // Build request
     var req = types.Request.init(.GET, url);
     defer req.deinit();
@@ -150,7 +175,22 @@ pub fn downloadFileWithClient(
     };
 
     // Stream to file and get response status and headers
-    var stream_result = try client.stream(req, streamToFile, &ctx, opts.progress_callback, opts.progress_context);
+    var stream_result = client.stream(req, streamToFile, &ctx, opts.progress_callback, opts.progress_context) catch |err| {
+        var url_buf: [512]u8 = undefined;
+        const display_url = utils.maskUrlPassword(url, &url_buf);
+        if (http_client.getLastCurlError()) |curl_detail| {
+            recordLastDownloadError(
+                "download {s} failed: {s}: {s}",
+                .{ display_url, @errorName(err), curl_detail },
+            );
+        } else {
+            recordLastDownloadError(
+                "download {s} failed: {s}",
+                .{ display_url, @errorName(err) },
+            );
+        }
+        return err;
+    };
     var cleanup_headers = true;
     defer if (cleanup_headers) {
         var it = stream_result.headers.iterator();
@@ -198,6 +238,9 @@ pub fn downloadFileWithClient(
     if (is_http and (stream_result.status < 200 or stream_result.status >= 300)) {
         // Log error with status code
         logger.err("Download failed with HTTP status {d} for URL: {s}", .{ stream_result.status, url });
+        var url_buf: [512]u8 = undefined;
+        const display_url = utils.maskUrlPassword(url, &url_buf);
+        recordLastDownloadError("download {s} returned HTTP status {d}", .{ display_url, stream_result.status });
         // Error or unexpected status code
         // Temp file will be cleaned up by defer automatically
         // For resume mode, explicitly delete the corrupted file
@@ -261,9 +304,13 @@ pub fn downloadTask(
         task.temp_path,
         opts,
     ) catch |err| {
-        const err_msg = try std.fmt.allocPrint(allocator, "Download failed: {}", .{err});
-        defer allocator.free(err_msg);
-        try task.setError(allocator, err_msg);
+        const err_msg_owned = if (getLastDownloadError()) |detail|
+            allocator.dupe(u8, detail) catch null
+        else
+            std.fmt.allocPrint(allocator, "Download failed: {s}", .{@errorName(err)}) catch null;
+        defer if (err_msg_owned) |msg| allocator.free(msg);
+        const err_msg = err_msg_owned orelse "Download failed";
+        task.setError(allocator, err_msg) catch {};
         return err;
     };
 
@@ -326,6 +373,10 @@ pub fn verifyChecksum(_: std.mem.Allocator, file_path: []const u8, expected: []c
     // Compare
     if (!std.mem.eql(u8, &hex, expected)) {
         logger.err("Checksum mismatch: expected {s}, got {s}", .{ expected, hex });
+        recordLastDownloadError(
+            "checksum mismatch for {s}: expected SHA256 {s}, got {s}",
+            .{ file_path, expected, &hex },
+        );
         return error.ChecksumMismatch;
     }
 }

--- a/src/http/download/manager.zig
+++ b/src/http/download/manager.zig
@@ -4,6 +4,7 @@ const config_mod = @import("../config.zig");
 const Task = @import("task.zig").Task;
 const downloader = @import("downloader.zig");
 const logger = @import("../../logger.zig");
+const utils = @import("../utils.zig");
 
 // Thread-local storage for current Manager (for use in remote_file resource)
 threadlocal var current_manager: ?*Manager = null;
@@ -271,12 +272,14 @@ fn processTask(mgr: *Manager, task_index: usize) void {
     ) catch |err| {
         const err_msg_owned = if (downloader.getLastDownloadError()) |detail|
             mgr.allocator.dupe(u8, detail) catch null
-        else
-            std.fmt.allocPrint(
+        else blk: {
+            var url_buf: [512]u8 = undefined;
+            break :blk std.fmt.allocPrint(
                 mgr.allocator,
                 "Download failed: {s} - {s}",
-                .{ @errorName(err), task.url },
+                .{ @errorName(err), utils.maskUrlPassword(task.url, &url_buf) },
             ) catch null;
+        };
         defer if (err_msg_owned) |msg| mgr.allocator.free(msg);
         const err_msg = err_msg_owned orelse "Unknown error";
 

--- a/src/http/download/manager.zig
+++ b/src/http/download/manager.zig
@@ -269,12 +269,16 @@ fn processTask(mgr: *Manager, task_index: usize) void {
         task.temp_path,
         opts,
     ) catch |err| {
-        const err_msg = std.fmt.allocPrint(
-            mgr.allocator,
-            "Download failed: {} - {s}",
-            .{ err, task.url },
-        ) catch "Unknown error";
-        defer if (err != error.OutOfMemory) mgr.allocator.free(err_msg);
+        const err_msg_owned = if (downloader.getLastDownloadError()) |detail|
+            mgr.allocator.dupe(u8, detail) catch null
+        else
+            std.fmt.allocPrint(
+                mgr.allocator,
+                "Download failed: {s} - {s}",
+                .{ @errorName(err), task.url },
+            ) catch null;
+        defer if (err_msg_owned) |msg| mgr.allocator.free(msg);
+        const err_msg = err_msg_owned orelse "Unknown error";
 
         logger.err("Task {d} download failed: {s}", .{ task_index, err_msg });
         task.setError(mgr.allocator, err_msg) catch {};
@@ -290,12 +294,16 @@ fn processTask(mgr: *Manager, task_index: usize) void {
     // Verify checksum if provided
     if (task.checksum) |expected_checksum| {
         downloader.verifyChecksum(mgr.allocator, task.temp_path, expected_checksum) catch |err| {
-            const err_msg = std.fmt.allocPrint(
-                mgr.allocator,
-                "Checksum verification failed: {}",
-                .{err},
-            ) catch "Checksum mismatch";
-            defer if (err != error.OutOfMemory) mgr.allocator.free(err_msg);
+            const err_msg_owned = if (downloader.getLastDownloadError()) |detail|
+                mgr.allocator.dupe(u8, detail) catch null
+            else
+                std.fmt.allocPrint(
+                    mgr.allocator,
+                    "Checksum verification failed: {s}",
+                    .{@errorName(err)},
+                ) catch null;
+            defer if (err_msg_owned) |msg| mgr.allocator.free(msg);
+            const err_msg = err_msg_owned orelse "Checksum mismatch";
 
             logger.err("Task {d} checksum failed: {s}", .{ task_index, err_msg });
             task.setError(mgr.allocator, err_msg) catch {};

--- a/src/http/download/task.zig
+++ b/src/http/download/task.zig
@@ -78,15 +78,19 @@ pub const Task = struct {
     }
 
     pub fn setError(self: *Task, allocator: std.mem.Allocator, err_msg: []const u8) !void {
-        // Free old error if exists
-        if (self.error_message.load(.acquire)) |old_msg| {
-            allocator.free(std.mem.span(old_msg));
-        }
+        // Allocate the new message first. On OOM still mark .failed so the task
+        // never stays stuck in .downloading (callers may swallow the error).
+        const msg_z = allocator.dupeZ(u8, err_msg) catch |err| {
+            self.status.store(.failed, .release);
+            return err;
+        };
 
-        // Allocate new error message
-        const msg_z = try allocator.dupeZ(u8, err_msg);
+        // Publish the message before flipping status to .failed, so a reader
+        // that observes .failed always sees the message (release/acquire pairs).
+        const old = self.error_message.load(.acquire);
         self.error_message.store(msg_z.ptr, .release);
         self.status.store(.failed, .release);
+        if (old) |old_msg| allocator.free(std.mem.span(old_msg));
     }
 
     pub fn getError(self: *const Task, allocator: std.mem.Allocator) ?[]const u8 {

--- a/src/http/utils.zig
+++ b/src/http/utils.zig
@@ -1,5 +1,32 @@
 const std = @import("std");
 
+/// Mask the password in a URL's `user:password@` userinfo for safe display or
+/// logging. Writes `scheme://user:***@rest` into `buf` (no allocation) and
+/// returns that slice. When the URL has no userinfo password, the original URL
+/// is copied into `buf` unchanged. Falls back to a truncated copy if `buf` is
+/// too small. `buf` should be at least as large as the URL to avoid truncation.
+pub fn maskUrlPassword(url: []const u8, buf: []u8) []const u8 {
+    const scheme_pos = std.mem.indexOf(u8, url, "://") orelse return copyUrl(url, buf);
+    const auth_start = scheme_pos + 3;
+    const path_start = std.mem.indexOfScalarPos(u8, url, auth_start, '/') orelse url.len;
+    const at_rel = std.mem.indexOfScalar(u8, url[auth_start..path_start], '@') orelse return copyUrl(url, buf);
+    const at_pos = auth_start + at_rel;
+    const colon_rel = std.mem.indexOfScalar(u8, url[auth_start..at_pos], ':') orelse return copyUrl(url, buf);
+    const password_start = auth_start + colon_rel + 1;
+
+    return std.fmt.bufPrint(
+        buf,
+        "{s}***{s}",
+        .{ url[0..password_start], url[at_pos..] },
+    ) catch copyUrl(url, buf);
+}
+
+fn copyUrl(value: []const u8, buf: []u8) []const u8 {
+    const n = @min(value.len, buf.len);
+    @memcpy(buf[0..n], value[0..n]);
+    return buf[0..n];
+}
+
 /// Parse HTTP headers from JSON string
 /// Returns a HashMap that caller must deinit
 pub fn parseHeadersFromJson(allocator: std.mem.Allocator, json_str: []const u8) !std.StringHashMap([]const u8) {

--- a/src/http/utils.zig
+++ b/src/http/utils.zig
@@ -3,28 +3,100 @@ const std = @import("std");
 /// Mask the password in a URL's `user:password@` userinfo for safe display or
 /// logging. Writes `scheme://user:***@rest` into `buf` (no allocation) and
 /// returns that slice. When the URL has no userinfo password, the original URL
-/// is copied into `buf` unchanged. Falls back to a truncated copy if `buf` is
-/// too small. `buf` should be at least as large as the URL to avoid truncation.
+/// is copied into `buf` unchanged. If `buf` is too small the masked form is
+/// truncated — the raw password is never emitted.
 pub fn maskUrlPassword(url: []const u8, buf: []u8) []const u8 {
-    const scheme_pos = std.mem.indexOf(u8, url, "://") orelse return copyUrl(url, buf);
+    const ui = findUserinfoPassword(url) orelse return copyUrl(url, buf);
+    // Build "<scheme>://<user>:***<@host/path...>" piece by piece. We never fall
+    // back to copying the raw URL, which would leak the password when buf is
+    // too small (truncating the masked form keeps the password out).
+    var n: usize = 0;
+    n += copyChunk(buf, n, url[0..ui.password_start]);
+    n += copyChunk(buf, n, "***");
+    n += copyChunk(buf, n, url[ui.at_pos..]);
+    return buf[0..n];
+}
+
+/// Copy `text` into `buf`, replacing every occurrence of the password carried in
+/// `url`'s `user:password@` userinfo with `***`. Use this to scrub credentials a
+/// library error message may have echoed back. Returns `text` unchanged when
+/// `url` carries no password.
+pub fn redactPassword(url: []const u8, text: []const u8, buf: []u8) []const u8 {
+    const ui = findUserinfoPassword(url) orelse return text;
+    const password = url[ui.password_start..ui.at_pos];
+    if (password.len == 0) return text;
+
+    var n: usize = 0;
+    var i: usize = 0;
+    while (i < text.len and n < buf.len) {
+        if (std.mem.startsWith(u8, text[i..], password)) {
+            n += copyChunk(buf, n, "***");
+            i += password.len;
+        } else {
+            n += copyChunk(buf, n, text[i .. i + 1]);
+            i += 1;
+        }
+    }
+    return buf[0..n];
+}
+
+const UserinfoPassword = struct { password_start: usize, at_pos: usize };
+
+fn findUserinfoPassword(url: []const u8) ?UserinfoPassword {
+    const scheme_pos = std.mem.indexOf(u8, url, "://") orelse return null;
     const auth_start = scheme_pos + 3;
     const path_start = std.mem.indexOfScalarPos(u8, url, auth_start, '/') orelse url.len;
-    const at_rel = std.mem.indexOfScalar(u8, url[auth_start..path_start], '@') orelse return copyUrl(url, buf);
+    const at_rel = std.mem.indexOfScalar(u8, url[auth_start..path_start], '@') orelse return null;
     const at_pos = auth_start + at_rel;
-    const colon_rel = std.mem.indexOfScalar(u8, url[auth_start..at_pos], ':') orelse return copyUrl(url, buf);
-    const password_start = auth_start + colon_rel + 1;
+    const colon_rel = std.mem.indexOfScalar(u8, url[auth_start..at_pos], ':') orelse return null;
+    return .{ .password_start = auth_start + colon_rel + 1, .at_pos = at_pos };
+}
 
-    return std.fmt.bufPrint(
-        buf,
-        "{s}***{s}",
-        .{ url[0..password_start], url[at_pos..] },
-    ) catch copyUrl(url, buf);
+/// Copy `src` into `buf` at `offset`, truncating to fit. Returns bytes written.
+fn copyChunk(buf: []u8, offset: usize, src: []const u8) usize {
+    if (offset >= buf.len) return 0;
+    const n = @min(src.len, buf.len - offset);
+    @memcpy(buf[offset..][0..n], src[0..n]);
+    return n;
 }
 
 fn copyUrl(value: []const u8, buf: []u8) []const u8 {
     const n = @min(value.len, buf.len);
     @memcpy(buf[0..n], value[0..n]);
     return buf[0..n];
+}
+
+test "maskUrlPassword masks password with ample buffer" {
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "https://user:***@example.com/path",
+        maskUrlPassword("https://user:secret@example.com/path", &buf),
+    );
+}
+
+test "maskUrlPassword leaves a URL without userinfo unchanged" {
+    var buf: [128]u8 = undefined;
+    const url = "https://example.com/path?token=abc";
+    try std.testing.expectEqualStrings(url, maskUrlPassword(url, &buf));
+}
+
+test "maskUrlPassword never leaks the password when buffer is too small" {
+    var buf: [24]u8 = undefined;
+    const out = maskUrlPassword("https://user:supersecretpassword@example.com/very/long/path", &buf);
+    try std.testing.expect(std.mem.indexOf(u8, out, "supersecretpassword") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "***") != null);
+    try std.testing.expect(std.mem.startsWith(u8, out, "https://user:***"));
+}
+
+test "redactPassword scrubs the url password echoed in arbitrary text" {
+    var buf: [128]u8 = undefined;
+    const out = redactPassword(
+        "https://user:tok3n@host/repo.git",
+        "failed to connect to https://user:tok3n@host/repo.git",
+        &buf,
+    );
+    try std.testing.expect(std.mem.indexOf(u8, out, "tok3n") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "***") != null);
 }
 
 /// Parse HTTP headers from JSON string

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -1227,6 +1227,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
 
                     const msg = try std.fmt.allocPrint(allocator, "Download failed for {s}: {s}", .{ resource_id, err_msg });
                     defer allocator.free(msg);
+                    base.recordProvisionErrorDetailSlice(msg);
                     try display.showInfo(msg);
                     return error.DownloadFailed;
                 }

--- a/src/resources/git.zig
+++ b/src/resources/git.zig
@@ -3,6 +3,7 @@ const mruby = @import("../mruby.zig");
 const base = @import("../base_resource.zig");
 const logger = @import("../logger.zig");
 const git_client = @import("../git.zig");
+const http = @import("../http.zig");
 const AsyncExecutor = @import("../async_executor.zig").AsyncExecutor;
 
 const c = @cImport({
@@ -264,7 +265,8 @@ pub const Resource = struct {
         if (ctx) |c_ctx| {
             const retry_count = c_ctx.retries.fetchAdd(1, .monotonic);
             if (retry_count >= 3) {
-                logger.warn("[git] authentication failed after 3 attempts for: {s}", .{url_str});
+                var url_buf: [512]u8 = undefined;
+                logger.warn("[git] authentication failed after 3 attempts for: {s}", .{http.maskUrlPassword(url_str, &url_buf)});
                 return c.GIT_EAUTH;
             }
         }
@@ -450,8 +452,17 @@ pub const Resource = struct {
         const err = c.git_error_last();
         if (err == null or err.*.message == null) return;
         const msg = std.mem.span(err.*.message);
+
+        // Redact credentials before this detail reaches the user / agent
+        // callback: the repository URL may be `https://user:token@host/repo`,
+        // and libgit2's message can echo the same credentialed URL back.
+        var repo_buf: [1024]u8 = undefined;
+        const safe_repo = http.maskUrlPassword(repository, &repo_buf);
+        var msg_buf: [1024]u8 = undefined;
+        const safe_msg = http.redactPassword(repository, msg, &msg_buf);
+
         var buf: [1024]u8 = undefined;
-        detail.set(std.fmt.bufPrint(&buf, "{s} of {s} failed: {s}", .{ operation, repository, msg }) catch msg);
+        detail.set(std.fmt.bufPrint(&buf, "{s} of {s} failed: {s}", .{ operation, safe_repo, safe_msg }) catch safe_msg);
     }
 
     const CloneContext = struct {
@@ -514,11 +525,14 @@ pub const Resource = struct {
         restoreEffectiveUser(user_ctx);
 
         if (code != 0) {
+            var repo_buf: [512]u8 = undefined;
+            const safe_repo = http.maskUrlPassword(self.repository, &repo_buf);
             const err = c.git_error_last();
             if (err != null) {
-                logger.err("[git] clone failed for {s}: {s}", .{ self.repository, std.mem.span(err.*.message) });
+                var msg_buf: [1024]u8 = undefined;
+                logger.err("[git] clone failed for {s}: {s}", .{ safe_repo, http.redactPassword(self.repository, std.mem.span(err.*.message), &msg_buf) });
             } else {
-                logger.err("[git] clone failed for {s} (error code: {})", .{ self.repository, code });
+                logger.err("[git] clone failed for {s} (error code: {})", .{ safe_repo, code });
             }
             return error.GitCloneFailed;
         }
@@ -595,11 +609,14 @@ pub const Resource = struct {
                     if (set_code != 0) {
                         const err = c.git_error_last();
                         if (err != null) {
-                            logger.err("[git] failed to update remote URL: {s}", .{std.mem.span(err.*.message)});
+                            var msg_buf: [1024]u8 = undefined;
+                            logger.err("[git] failed to update remote URL: {s}", .{http.redactPassword(self.repository, std.mem.span(err.*.message), &msg_buf)});
                         }
                         return error.RemoteSetUrlFailed;
                     }
-                    logger.info("[git] updated remote '{s}' URL: {s} -> {s}", .{ self.remote, current_url, self.repository });
+                    var old_url_buf: [512]u8 = undefined;
+                    var new_url_buf: [512]u8 = undefined;
+                    logger.info("[git] updated remote '{s}' URL: {s} -> {s}", .{ self.remote, http.maskUrlPassword(current_url, &old_url_buf), http.maskUrlPassword(self.repository, &new_url_buf) });
                     // Re-lookup remote to pick up the new URL
                     c.git_remote_free(r);
                     remote = null;

--- a/src/resources/git.zig
+++ b/src/resources/git.zig
@@ -646,7 +646,8 @@ pub const Resource = struct {
         if (code != 0) {
             const err = c.git_error_last();
             if (err != null) {
-                const err_msg = std.mem.span(err.*.message);
+                var msg_buf: [1024]u8 = undefined;
+                const err_msg = http.redactPassword(self.repository, std.mem.span(err.*.message), &msg_buf);
                 logger.err("[git] fetch failed: {s} (code: {})", .{ err_msg, code });
             } else {
                 logger.err("[git] fetch failed (code: {})", .{code});

--- a/src/resources/git.zig
+++ b/src/resources/git.zig
@@ -421,18 +421,54 @@ pub const Resource = struct {
     }
 
     /// Context for async clone operation
+    /// Carries a libgit2 failure reason from a background worker thread back to
+    /// the caller. Thread-local error buffers don't cross threads, mirroring
+    /// remote_file's RemoteFileErrorDetail.
+    const GitErrorDetail = struct {
+        buffer: [1024]u8 = undefined,
+        len: usize = 0,
+
+        fn set(self: *GitErrorDetail, detail: []const u8) void {
+            const n = @min(detail.len, self.buffer.len);
+            @memcpy(self.buffer[0..n], detail[0..n]);
+            self.len = n;
+        }
+
+        fn get(self: *const GitErrorDetail) ?[]const u8 {
+            if (self.len == 0) return null;
+            return self.buffer[0..self.len];
+        }
+    };
+
+    /// Capture libgit2's current error (git_error_last) into `detail`, prefixed
+    /// with the operation and repository, so the caller can surface the real
+    /// reason instead of a bare Zig error name. No-op when libgit2 recorded no
+    /// error (e.g. a non-libgit2 failure such as OOM). Safe to use from an
+    /// errdefer on a freshly spawned worker thread, where git_error_last starts
+    /// null and is only set by an actual libgit2 failure.
+    fn captureGitError(detail: *GitErrorDetail, operation: []const u8, repository: []const u8) void {
+        const err = c.git_error_last();
+        if (err == null or err.*.message == null) return;
+        const msg = std.mem.span(err.*.message);
+        var buf: [1024]u8 = undefined;
+        detail.set(std.fmt.bufPrint(&buf, "{s} of {s} failed: {s}", .{ operation, repository, msg }) catch msg);
+    }
+
     const CloneContext = struct {
         resource: Resource,
         allocator: std.mem.Allocator,
+        error_detail: *GitErrorDetail,
     };
 
     /// Async wrapper for clone operation (runs in background thread)
     fn cloneRepositoryAsync(ctx: CloneContext) !void {
-        return cloneRepositoryImpl(ctx.resource, ctx.allocator);
+        return cloneRepositoryImpl(ctx.resource, ctx.allocator, ctx.error_detail);
     }
 
     /// Actual clone implementation
-    fn cloneRepositoryImpl(self: Resource, allocator: std.mem.Allocator) !void {
+    fn cloneRepositoryImpl(self: Resource, allocator: std.mem.Allocator, error_detail: *GitErrorDetail) !void {
+        errdefer captureGitError(error_detail, "clone", self.repository);
+
         // Initialize libgit2 in this thread
         var git = try git_client.Client.init();
         defer git.deinit();
@@ -480,8 +516,7 @@ pub const Resource = struct {
         if (code != 0) {
             const err = c.git_error_last();
             if (err != null) {
-                const err_msg = std.mem.span(err.*.message);
-                logger.err("[git] clone failed for {s}: {s}", .{ self.repository, err_msg });
+                logger.err("[git] clone failed for {s}: {s}", .{ self.repository, std.mem.span(err.*.message) });
             } else {
                 logger.err("[git] clone failed for {s} (error code: {})", .{ self.repository, code });
             }
@@ -500,11 +535,16 @@ pub const Resource = struct {
 
     /// Clone repository with async execution (doesn't block spinner)
     fn cloneRepository(self: Resource, allocator: std.mem.Allocator) !void {
+        var error_detail = GitErrorDetail{};
         const ctx = CloneContext{
             .resource = self,
             .allocator = allocator,
+            .error_detail = &error_detail,
         };
-        return AsyncExecutor.executeWithContext(CloneContext, void, ctx, cloneRepositoryAsync);
+        AsyncExecutor.executeWithContext(CloneContext, void, ctx, cloneRepositoryAsync) catch |err| {
+            if (error_detail.get()) |msg| base.recordProvisionErrorDetailSlice(msg);
+            return err;
+        };
     }
 
     /// Context for async fetch and update operation
@@ -512,15 +552,18 @@ pub const Resource = struct {
         resource: Resource,
         allocator: std.mem.Allocator,
         repo: *c.git_repository,
+        error_detail: *GitErrorDetail,
     };
 
     /// Async wrapper for fetch operation (runs in background thread)
     fn fetchAndUpdateAsync(ctx: FetchContext) !bool {
-        return fetchAndUpdateImpl(ctx.resource, ctx.allocator, ctx.repo);
+        return fetchAndUpdateImpl(ctx.resource, ctx.allocator, ctx.repo, ctx.error_detail);
     }
 
     /// Actual fetch and update implementation
-    fn fetchAndUpdateImpl(self: Resource, allocator: std.mem.Allocator, repo: *c.git_repository) !bool {
+    fn fetchAndUpdateImpl(self: Resource, allocator: std.mem.Allocator, repo: *c.git_repository, error_detail: *GitErrorDetail) !bool {
+        errdefer captureGitError(error_detail, "fetch", self.repository);
+
         // Initialize libgit2 in this thread
         var git = try git_client.Client.init();
         defer git.deinit();
@@ -808,12 +851,17 @@ pub const Resource = struct {
             const repo_nonnull = repo orelse return error.OpenRepoFailed;
             defer c.git_repository_free(repo_nonnull);
 
+            var fetch_error_detail = GitErrorDetail{};
             const fetch_ctx = FetchContext{
                 .resource = self,
                 .allocator = allocator,
                 .repo = repo_nonnull,
+                .error_detail = &fetch_error_detail,
             };
-            was_updated = try AsyncExecutor.executeWithContext(FetchContext, bool, fetch_ctx, fetchAndUpdateAsync);
+            was_updated = AsyncExecutor.executeWithContext(FetchContext, bool, fetch_ctx, fetchAndUpdateAsync) catch |err| {
+                if (fetch_error_detail.get()) |msg| base.recordProvisionErrorDetailSlice(msg);
+                return err;
+            };
         }
 
         // Update submodules if enabled

--- a/src/resources/remote_file.zig
+++ b/src/resources/remote_file.zig
@@ -620,10 +620,11 @@ pub const Resource = struct {
         }
 
         if (http.getLastError()) |detail| {
+            var detail_buf: [1024]u8 = undefined;
             return std.fmt.bufPrint(
                 buf,
                 "remote_file[{s}] {s} failed: {s}: {s}",
-                .{ self.path, operation, @errorName(err), detail },
+                .{ self.path, operation, @errorName(err), http.redactPassword(self.source, detail, &detail_buf) },
             ) catch fallbackRemoteFileFailure(buf, self.path, operation, err);
         }
 

--- a/src/resources/remote_file.zig
+++ b/src/resources/remote_file.zig
@@ -278,9 +278,10 @@ pub const Resource = struct {
                     return err;
                 };
                 if (!retry.downloaded) {
+                    var source_buf: [512]u8 = undefined;
                     base.recordProvisionErrorDetail(
                         "remote_file[{s}] conditional download returned not modified, but destination does not exist: {s}",
-                        .{ self.path, self.source },
+                        .{ self.path, http.maskUrlPassword(self.source, &source_buf) },
                     );
                     return error.HttpError;
                 }

--- a/src/resources/remote_file.zig
+++ b/src/resources/remote_file.zig
@@ -14,6 +14,26 @@ const DownloadOutcome = struct {
     last_modified: ?[]const u8 = null,
 };
 
+const RemoteFileErrorDetail = struct {
+    buffer: [1024]u8 = undefined,
+    len: usize = 0,
+
+    fn clear(self: *RemoteFileErrorDetail) void {
+        self.len = 0;
+    }
+
+    fn set(self: *RemoteFileErrorDetail, detail: []const u8) void {
+        const n = @min(detail.len, self.buffer.len);
+        @memcpy(self.buffer[0..n], detail[0..n]);
+        self.len = n;
+    }
+
+    fn get(self: *const RemoteFileErrorDetail) ?[]const u8 {
+        if (self.len == 0) return null;
+        return self.buffer[0..self.len];
+    }
+};
+
 /// Remote file resource data structure
 pub const Resource = struct {
     // Resource-specific properties
@@ -218,33 +238,50 @@ pub const Resource = struct {
                 allocator: std.mem.Allocator,
                 previous_etag: ?[]const u8,
                 previous_last_modified: ?[]const u8,
+                error_detail: *RemoteFileErrorDetail,
             };
+            var error_detail = RemoteFileErrorDetail{};
             const download_ctx = DownloadContext{
                 .resource = self,
                 .allocator = allocator,
                 .previous_etag = previous_etag,
                 .previous_last_modified = previous_last_modified,
+                .error_detail = &error_detail,
             };
             const downloadAsync = struct {
                 fn run(ctx: DownloadContext) !DownloadOutcome {
-                    const outcome = try ctx.resource.downloadDirect(ctx.allocator, ctx.previous_etag, ctx.previous_last_modified);
-                    return outcome;
+                    return ctx.resource.downloadDirect(ctx.allocator, ctx.previous_etag, ctx.previous_last_modified) catch |err| {
+                        ctx.resource.copyRemoteFileFailure(ctx.error_detail, "download", err);
+                        return err;
+                    };
                 }
             }.run;
 
-            var outcome = try AsyncExecutor.executeWithContext(DownloadContext, DownloadOutcome, download_ctx, downloadAsync);
+            var outcome = AsyncExecutor.executeWithContext(DownloadContext, DownloadOutcome, download_ctx, downloadAsync) catch |err| {
+                self.recordRemoteFileFailure("download", err, error_detail.get());
+                return err;
+            };
 
             // If server reported not modified but we have no local file, fall back to unconditional download
             if (!outcome.downloaded and !local_exists) {
                 logger.debug("Server returned not_modified but local file doesn't exist, retrying without conditions", .{});
+                error_detail.clear();
                 const retry_ctx = DownloadContext{
                     .resource = self,
                     .allocator = allocator,
                     .previous_etag = null,
                     .previous_last_modified = null,
+                    .error_detail = &error_detail,
                 };
-                const retry = try AsyncExecutor.executeWithContext(DownloadContext, DownloadOutcome, retry_ctx, downloadAsync);
+                const retry = AsyncExecutor.executeWithContext(DownloadContext, DownloadOutcome, retry_ctx, downloadAsync) catch |err| {
+                    self.recordRemoteFileFailure("download retry", err, error_detail.get());
+                    return err;
+                };
                 if (!retry.downloaded) {
+                    base.recordProvisionErrorDetail(
+                        "remote_file[{s}] conditional download returned not modified, but destination does not exist: {s}",
+                        .{ self.path, self.source },
+                    );
                     return error.HttpError;
                 }
                 outcome = retry;
@@ -266,6 +303,7 @@ pub const Resource = struct {
                 const actual_checksum = try http.calculateSha256(allocator, self.path);
                 defer allocator.free(actual_checksum);
                 if (!std.mem.eql(u8, actual_checksum, expected_checksum)) {
+                    self.recordChecksumMismatch(expected_checksum, actual_checksum);
                     return error.ChecksumMismatch;
                 }
             }
@@ -430,6 +468,7 @@ pub const Resource = struct {
             defer allocator.free(actual_checksum);
             if (!std.mem.eql(u8, actual_checksum, expected_checksum)) {
                 std.fs.cwd().deleteFile(temp_path) catch {};
+                self.recordChecksumMismatch(expected_checksum, actual_checksum);
                 return error.ChecksumMismatch;
             }
         }
@@ -546,7 +585,70 @@ pub const Resource = struct {
             else => return err,
         };
     }
+
+    fn copyRemoteFileFailure(self: Resource, detail: *RemoteFileErrorDetail, operation: []const u8, err: anyerror) void {
+        var buf: [1024]u8 = undefined;
+        const message = self.formatRemoteFileFailure(&buf, operation, err);
+        detail.set(message);
+    }
+
+    fn recordRemoteFileFailure(self: Resource, operation: []const u8, err: anyerror, detail: ?[]const u8) void {
+        if (detail) |message| {
+            base.recordProvisionErrorDetailSlice(message);
+            return;
+        }
+
+        var buf: [1024]u8 = undefined;
+        const message = self.formatRemoteFileFailure(&buf, operation, err);
+        base.recordProvisionErrorDetailSlice(message);
+    }
+
+    fn formatRemoteFileFailure(self: Resource, buf: []u8, operation: []const u8, err: anyerror) []const u8 {
+        if (base.getProvisionErrorDetail()) |detail| {
+            const n = @min(detail.len, buf.len);
+            @memcpy(buf[0..n], detail[0..n]);
+            return buf[0..n];
+        }
+
+        if (http.download.downloader.getLastDownloadError()) |detail| {
+            return std.fmt.bufPrint(
+                buf,
+                "remote_file[{s}] {s} failed: {s}",
+                .{ self.path, operation, detail },
+            ) catch fallbackRemoteFileFailure(buf, self.path, operation, err);
+        }
+
+        if (http.getLastError()) |detail| {
+            return std.fmt.bufPrint(
+                buf,
+                "remote_file[{s}] {s} failed: {s}: {s}",
+                .{ self.path, operation, @errorName(err), detail },
+            ) catch fallbackRemoteFileFailure(buf, self.path, operation, err);
+        }
+
+        return fallbackRemoteFileFailure(buf, self.path, operation, err);
+    }
+
+    fn recordChecksumMismatch(self: Resource, expected: []const u8, actual: []const u8) void {
+        base.recordProvisionErrorDetail(
+            "remote_file[{s}] checksum mismatch: expected SHA256 {s}, got {s}",
+            .{ self.path, expected, actual },
+        );
+    }
 };
+
+fn fallbackRemoteFileFailure(buf: []u8, path: []const u8, operation: []const u8, err: anyerror) []const u8 {
+    return std.fmt.bufPrint(
+        buf,
+        "remote_file[{s}] {s} failed: {s}",
+        .{ path, operation, @errorName(err) },
+    ) catch blk: {
+        const fallback = "remote_file failed (message truncated)";
+        const n = @min(fallback.len, buf.len);
+        @memcpy(buf[0..n], fallback[0..n]);
+        break :blk buf[0..n];
+    };
+}
 
 /// Ruby prelude for remote_file resource
 pub const ruby_prelude = @embedFile("remote_file_resource.rb");


### PR DESCRIPTION
## Summary

Surface the *real* reason a provision/resource failed — masked URL, libcurl error, HTTP status, checksum mismatch, raised Ruby exception, libgit2 clone/fetch reason — to the user and the agent callback, instead of a bare Zig error name. All URL/credential surfaces are redacted so `https://user:token@host/...` never leaks.

## What changed

**Error detail surfacing**
- Thread-local provision error-detail buffers at the resource / download-manager / remote_file layers; the apply loop and agent callback show the real reason.
- The async download/clone run on spawned worker threads, so detail is bridged back to the caller via per-call structs (`RemoteFileErrorDetail`, `GitErrorDetail`) since thread-locals don't cross threads.
- `git` resource: `clone`/`fetch` failures now report `clone/fetch of <repo> failed: <libgit2 reason>` (e.g. "exists and is not an empty directory", auth/network) via an `errdefer captureGitError`.

**Credential redaction (defense in depth)**
- `maskUrlPassword(url, buf)` (shared `http` helper): masks `user:password@`; rewritten so a too-small buffer truncates the *masked* form and never emits the raw password (+ unit tests).
- `redactPassword(url, text, buf)`: scrubs a URL's password from arbitrary library error strings (libcurl/libgit2) that may echo a credentialed URL.
- Applied to every URL/error sink: provision error detail, agent callback + poll output, download logs, remote_file detail, git resource logs, and the standalone `hola git-clone` / `hola apply --repo` command output.

**Correctness**
- `Task.setError` now marks `.failed` even if the error-message allocation OOMs (previously it could leave a task stuck `.downloading`), publishing the message before flipping status so readers that observe `.failed` always see the message.
- Unified the download OOM-handling path so an allocation failure no longer masks the original download error; extracted a shared URL-masking helper (removed 3 divergent copies).

## Verification

- `zig build test` (incl. new `maskUrlPassword`/`redactPassword` unit tests), `aarch64-linux-musl` cross-compile (production target), and `zig fmt --check` all pass.
- End-to-end: a credentialed `git` clone into a non-empty dir surfaces `clone of https://user:***@host/... failed: ...` with the password absent from both stdout and the log file; fetch-failure surfacing verified with a local repo.
- Reviewed across five Codex passes; converged with no remaining in-scope findings.

## Deferred (separate PR)

A pre-existing use-after-free in `src/provision.zig`: the predownload worker thread can outlive an early error `return` before `thread.join()`, so `download_mgr`/`progress_ctx`/`display` may be deinit'd while the worker still uses them. Out of scope for this error-reporting change; tracked for a dedicated fix.