### PR TITLE
fix(http): enforce request timeouts to prevent hangs

### DIFF
--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -57,6 +57,8 @@ fn originMatches(url_a: []const u8, url_b: []const u8) bool {
 const INITIAL_BACKOFF_MS: u64 = 1000;
 const MAX_BACKOFF_MS: u64 = 30_000;
 const DEFAULT_WATCH_INTERVAL: u32 = 10;
+const AGENT_CALLBACK_TIMEOUT_S: u32 = 60;
+const AGENT_POLL_TIMEOUT_S: u32 = 60;
 
 // -- Shared task handling --
 
@@ -318,6 +320,7 @@ fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_da
     // Use mTLS if callback host matches endpoint host
     const use_tls_auth = originMatches(callback_url, endpoint);
     const cfg = http.Config{
+        .max_timeout_s = AGENT_CALLBACK_TIMEOUT_S,
         .client_cert = if (use_tls_auth) tls_auth.cert else null,
         .client_key = if (use_tls_auth) tls_auth.key else null,
         .retry = .{ .max_attempts = 3, .initial_backoff_ms = 1000 },
@@ -507,6 +510,7 @@ fn runWatchMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: [
 
 fn pollOnce(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8, tls_auth: TlsClientAuth) void {
     const cfg = http.Config{
+        .max_timeout_s = AGENT_POLL_TIMEOUT_S,
         .client_cert = tls_auth.cert,
         .client_key = tls_auth.key,
     };

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -32,6 +32,8 @@ const TlsClientAuth = struct {
     key: ?[]const u8 = null,
 };
 
+const PROVISION_FETCH_TIMEOUT_S: u32 = 300;
+
 /// Fetch JSON content from a URL, using optional mTLS credentials.
 /// Returns the response body as an owned slice that the caller must free.
 fn fetchJsonFromUrl(allocator: std.mem.Allocator, url: []const u8, tls_auth: TlsClientAuth) ![]const u8 {
@@ -46,6 +48,7 @@ fn fetchJsonFromUrl(allocator: std.mem.Allocator, url: []const u8, tls_auth: Tls
     std.debug.print("[fetch] Fetching JSON from {s}\n", .{display_url});
 
     const cfg = http.Config{
+        .max_timeout_s = PROVISION_FETCH_TIMEOUT_S,
         .client_cert = tls_auth.cert,
         .client_key = tls_auth.key,
     };
@@ -109,6 +112,7 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, u
         temp_file_path = temp_file;
 
         const cfg = http.Config{
+            .max_timeout_s = PROVISION_FETCH_TIMEOUT_S,
             .client_cert = tls_auth.cert,
             .client_key = tls_auth.key,
         };

--- a/src/http/config.zig
+++ b/src/http/config.zig
@@ -11,10 +11,10 @@ pub const Config = struct {
     timeout_ms: u32 = 30000,
 
     /// Maximum total timeout in seconds for the entire request
-    /// Set to 0 to disable total timeout (default, relies on low_speed_limit protection)
-    /// Primary timeout mechanism is low_speed_limit + low_speed_time
-    /// Only set this if you need a hard deadline regardless of download speed
-    max_timeout_s: u32 = 0,
+    /// Set to 0 to disable total timeout.
+    /// This is a hard deadline regardless of transfer speed; low_speed_limit
+    /// still handles stalled transfers earlier.
+    max_timeout_s: u32 = 1800,
 
     /// Low speed limit in bytes/second (abort if speed drops below this)
     /// Set to 0 to disable low speed detection


### PR DESCRIPTION
## Summary

Part of the anti-hang/anti-deadlock hardening, split out into its own PR. Bounds HTTP requests so a stalled or hung connection can no longer block the agent or provisioning indefinitely.

- **`src/http/config.zig`**: `max_timeout_s` now defaults to a 30-minute hard ceiling instead of `0` (no total deadline). `low_speed_limit` still aborts stalled transfers earlier; this is the backstop for connections that keep trickling just above the low-speed threshold.
- **`src/commands/agent.zig`**: the callback POST and watch-mode poll get an explicit 60s total timeout.
- **`src/commands/provision.zig`**: the remote script (JSON/file) fetch gets an explicit 300s total timeout.

## Notes

A separate follow-up is worth doing: `max_timeout_s` is applied per retry attempt, so with the default retry policy the effective wall-clock ceiling is roughly 3x the configured value (e.g. agent 60s -> ~183s). Bounded, not an indefinite hang, but worth tightening with a cross-retry deadline later.

## Test

`zig fmt --check` and `zig ast-check` pass. Full local build is blocked by an unrelated Xcode CLT/SDK linker issue; relying on CI for the full `zig build test`.