### PR TITLE
fix(execute): poll-based process supervision + guard timeouts to prevent hangs

### DIFF
--- a/src/base_resource.zig
+++ b/src/base_resource.zig
@@ -3,6 +3,14 @@ const mruby = @import("mruby.zig");
 pub const notification = @import("notification.zig");
 const builtin = @import("builtin");
 
+// Guards (only_if/not_if) run arbitrary shell commands; a stuck one (e.g.
+// `only_if "sleep 99999"`) must not hang provisioning forever. Bound them with
+// a hard timeout that escalates SIGTERM -> SIGKILL on the process group.
+const GUARD_TIMEOUT_S: u32 = 300;
+const GUARD_POLL_INTERVAL_MS: i64 = 50;
+const GUARD_TERM_GRACE_MS: i64 = 2000;
+const GUARD_REAP_GRACE_MS: i64 = 2000;
+
 // --- Provision error detail context ----------------------------------------
 // Whenever a resource can provide more context than the raw Zig error name,
 // capture that friendly summary into a thread-local buffer. The top-level
@@ -192,8 +200,10 @@ pub const CommonProps = struct {
         const temp_allocator = arena.allocator();
 
         var child = std.process.Child.init(&[_][]const u8{ "/bin/sh", "-c", command }, temp_allocator);
+        child.stdin_behavior = .Ignore;
         child.stdout_behavior = .Ignore;
         child.stderr_behavior = .Ignore;
+        child.pgid = 0; // own process group, so a timeout can signal the whole tree
 
         // Set user and/or group if specified (same logic as execute resource)
         if (user != null or group != null) {
@@ -240,12 +250,84 @@ pub const CommonProps = struct {
             }
         }
 
-        const term = try child.spawnAndWait();
+        try child.spawn();
+        // A pre-exec failure makes the forked child _exit(); reap it so the
+        // error path doesn't leave a zombie. stdio is .Ignore, so there are no
+        // parent-held pipes to close.
+        child.waitForSpawn() catch |err| {
+            reapGuardChild(child.id);
+            return err;
+        };
+
+        const term = waitGuardWithTimeout(child.id);
 
         return switch (term) {
             .Exited => |code| code == 0,
-            else => false,
+            else => false, // signalled / timed out / unknown => treat as non-zero
         };
+    }
+
+    fn termFromStatus(status: u32) std.process.Child.Term {
+        return if (std.posix.W.IFEXITED(status))
+            .{ .Exited = std.posix.W.EXITSTATUS(status) }
+        else if (std.posix.W.IFSIGNALED(status))
+            .{ .Signal = std.posix.W.TERMSIG(status) }
+        else if (std.posix.W.IFSTOPPED(status))
+            .{ .Stopped = std.posix.W.STOPSIG(status) }
+        else
+            .{ .Unknown = status };
+    }
+
+    /// Best-effort non-blocking reap for an already-dead child.
+    fn reapGuardChild(pid: std.posix.pid_t) void {
+        const deadline = std.time.milliTimestamp() + GUARD_REAP_GRACE_MS;
+        while (std.time.milliTimestamp() < deadline) {
+            const res = std.posix.waitpid(pid, std.posix.W.NOHANG);
+            if (res.pid != 0) return;
+            std.Thread.sleep(GUARD_POLL_INTERVAL_MS * std.time.ns_per_ms);
+        }
+    }
+
+    /// Wait for a guard child with a hard timeout. Guards ignore their stdio so
+    /// there are no pipes to drain: poll for exit, and if the deadline passes
+    /// escalate SIGTERM -> SIGKILL on the process group, then reap. Never blocks
+    /// indefinitely — if the child is unresponsive even to SIGKILL we abandon it.
+    fn waitGuardWithTimeout(pid: std.posix.pid_t) std.process.Child.Term {
+        const logger = @import("logger.zig");
+        const deadline = std.time.milliTimestamp() + @as(i64, GUARD_TIMEOUT_S) * std.time.ms_per_s;
+        var timed_out = false;
+        var kill_deadline_ms: ?i64 = null;
+        var give_up_deadline_ms: ?i64 = null;
+
+        while (true) {
+            const res = std.posix.waitpid(pid, std.posix.W.NOHANG);
+            if (res.pid != 0) return termFromStatus(res.status);
+
+            const now = std.time.milliTimestamp();
+            if (!timed_out) {
+                if (now >= deadline) {
+                    timed_out = true;
+                    logger.warn("guard: command timed out after {d}s; terminating", .{GUARD_TIMEOUT_S});
+                    std.posix.kill(-pid, std.posix.SIG.TERM) catch {};
+                    kill_deadline_ms = now + GUARD_TERM_GRACE_MS;
+                    give_up_deadline_ms = now + GUARD_TERM_GRACE_MS + GUARD_REAP_GRACE_MS;
+                }
+            } else {
+                if (kill_deadline_ms) |kd| {
+                    if (now >= kd) {
+                        kill_deadline_ms = null;
+                        std.posix.kill(-pid, std.posix.SIG.KILL) catch {};
+                    }
+                }
+                if (give_up_deadline_ms) |gd| {
+                    if (now >= gd) {
+                        logger.warn("guard: child {d} unresponsive after SIGKILL; abandoning", .{pid});
+                        return .{ .Unknown = 0 };
+                    }
+                }
+            }
+            std.Thread.sleep(GUARD_POLL_INTERVAL_MS * std.time.ns_per_ms);
+        }
     }
 
     /// Register blocks with GC to prevent collection

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -726,7 +726,7 @@ const ResourceBinding = struct {
 fn registerResourceBindings(mrb_ptr: *mruby.mrb_state, zig_module: *mruby.RClass) void {
     const bindings = [_]ResourceBinding{
         .{ .name = "add_file", .handler = zig_add_file_resource, .args_spec = mruby.MRB_ARGS_REQ(6) | mruby.MRB_ARGS_OPT(5) },
-        .{ .name = "add_execute", .handler = zig_add_execute_resource, .args_spec = mruby.MRB_ARGS_REQ(9) | mruby.MRB_ARGS_OPT(5) },
+        .{ .name = "add_execute", .handler = zig_add_execute_resource, .args_spec = mruby.MRB_ARGS_REQ(10) | mruby.MRB_ARGS_OPT(5) },
         .{ .name = "add_remote_file", .handler = zig_add_remote_file_resource, .args_spec = mruby.MRB_ARGS_REQ(12) | mruby.MRB_ARGS_OPT(15) },
         .{ .name = "add_template", .handler = zig_add_template_resource, .args_spec = mruby.MRB_ARGS_REQ(7) | mruby.MRB_ARGS_OPT(5) },
         .{ .name = "add_macos_dock", .handler = zig_add_macos_dock_resource, .args_spec = mruby.MRB_ARGS_REQ(1) | mruby.MRB_ARGS_OPT(10), .platform = .macos },

--- a/src/resources/execute.zig
+++ b/src/resources/execute.zig
@@ -5,6 +5,15 @@ const ansi = @import("../ansi_constants.zig");
 const logger = @import("../logger.zig");
 const AsyncExecutor = @import("../async_executor.zig").AsyncExecutor;
 
+const DEFAULT_TIMEOUT_S: u32 = 3600;
+const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
+const READ_BUFFER_SIZE: usize = 16 * 1024;
+const POLL_INTERVAL_MS: i64 = 50;
+const TERM_GRACE_MS: i64 = 2000;
+const PIPE_CLOSE_GRACE_MS: i64 = 5000;
+const POST_EXIT_PIPE_GRACE_MS: i64 = 1000;
+const REAP_GRACE_MS: i64 = 2000;
+
 /// Execute resource data structure
 pub const Resource = struct {
     // Resource-specific properties
@@ -16,6 +25,7 @@ pub const Resource = struct {
     environment: ?[]const u8, // Environment variables (future)
     live_stream: bool, // Whether to output command result to stdout
     creates: ?[]const u8, // Path to a file - skip execution if it exists
+    timeout_s: u32, // Hard timeout in seconds; 0 disables
     action: Action,
 
     // Common properties (guards, notifications, etc.)
@@ -112,6 +122,7 @@ pub const Resource = struct {
         term: std.process.Child.Term,
         stdout: []u8,
         stderr: []u8,
+        timed_out: bool,
         allocator: std.mem.Allocator,
 
         pub fn deinit(self: *const ExecuteResult) void {
@@ -126,7 +137,292 @@ pub const Resource = struct {
         user: ?[]const u8,
         group: ?[]const u8,
         environment: ?[]const u8,
+        timeout_s: u32,
     };
+
+    fn termFromStatus(status: u32) std.process.Child.Term {
+        return if (std.posix.W.IFEXITED(status))
+            .{ .Exited = std.posix.W.EXITSTATUS(status) }
+        else if (std.posix.W.IFSIGNALED(status))
+            .{ .Signal = std.posix.W.TERMSIG(status) }
+        else if (std.posix.W.IFSTOPPED(status))
+            .{ .Stopped = std.posix.W.STOPSIG(status) }
+        else
+            .{ .Unknown = status };
+    }
+
+    fn pollChildTerm(pid: std.posix.pid_t) ?std.process.Child.Term {
+        const result = std.posix.waitpid(pid, std.posix.W.NOHANG);
+        if (result.pid == 0) return null;
+        return termFromStatus(result.status);
+    }
+
+    fn closePipe(pipe: *?std.fs.File) void {
+        if (pipe.*) |*file| {
+            file.close();
+            pipe.* = null;
+        }
+    }
+
+    fn closeChildPipes(child: *std.process.Child) void {
+        closePipe(&child.stdin);
+        closePipe(&child.stdout);
+        closePipe(&child.stderr);
+    }
+
+    fn signalProcessGroup(pid: std.posix.pid_t, sig: u8) void {
+        std.posix.kill(-pid, sig) catch |err| {
+            if (err != error.ProcessNotFound) {
+                logger.warn("[execute] failed to signal process group {d}: {}", .{ pid, err });
+            }
+        };
+    }
+
+    /// Best-effort reap after SIGKILL so we don't leak a zombie. Polls for a
+    /// short grace period but never blocks indefinitely: a process stuck in
+    /// uninterruptible sleep must not hang the caller.
+    fn reapAfterKill(pid: std.posix.pid_t) void {
+        const deadline = std.time.milliTimestamp() + REAP_GRACE_MS;
+        while (std.time.milliTimestamp() < deadline) {
+            if (pollChildTerm(pid) != null) return;
+            std.Thread.sleep(POLL_INTERVAL_MS * std.time.ns_per_ms);
+        }
+        logger.warn("[execute] child {d} not reaped after SIGKILL; possible zombie", .{pid});
+    }
+
+    /// Cleanup helper for error paths: SIGKILL the group and reap, but only if
+    /// the child has not already been reaped. Reaping an already-reaped pid
+    /// would hit ECHILD, which std.posix.waitpid treats as unreachable (panic).
+    fn killAndReap(pid: std.posix.pid_t, child_running: *bool) void {
+        if (!child_running.*) return;
+        signalProcessGroup(pid, std.posix.SIG.KILL);
+        reapAfterKill(pid);
+        child_running.* = false;
+    }
+
+    fn appendOutputBounded(
+        allocator: std.mem.Allocator,
+        output: *std.ArrayList(u8),
+        bytes: []const u8,
+    ) !void {
+        if (output.items.len + bytes.len > MAX_OUTPUT_BYTES) return error.CommandOutputTooLarge;
+        try output.appendSlice(allocator, bytes);
+    }
+
+    fn drainPipe(
+        allocator: std.mem.Allocator,
+        file: std.fs.File,
+        output: *std.ArrayList(u8),
+    ) !bool {
+        var buf: [READ_BUFFER_SIZE]u8 = undefined;
+        const n = try file.read(&buf);
+        if (n == 0) return false;
+        try appendOutputBounded(allocator, output, buf[0..n]);
+        return true;
+    }
+
+    fn drainReadyPipe(
+        allocator: std.mem.Allocator,
+        pipe: *?std.fs.File,
+        output: *std.ArrayList(u8),
+        is_open: *bool,
+    ) !void {
+        if (!is_open.*) return;
+        const file = pipe.* orelse {
+            is_open.* = false;
+            return;
+        };
+
+        const still_open = try drainPipe(allocator, file, output);
+        if (!still_open) {
+            closePipe(pipe);
+            is_open.* = false;
+        }
+    }
+
+    fn buildPollTimeoutMs(
+        now: i64,
+        deadline_ms: ?i64,
+        kill_deadline_ms: ?i64,
+        close_deadline_ms: ?i64,
+        post_exit_pipe_deadline_ms: ?i64,
+    ) i32 {
+        var timeout = POLL_INTERVAL_MS;
+        if (deadline_ms) |deadline| timeout = @min(timeout, deadline - now);
+        if (kill_deadline_ms) |deadline| timeout = @min(timeout, deadline - now);
+        if (close_deadline_ms) |deadline| timeout = @min(timeout, deadline - now);
+        if (post_exit_pipe_deadline_ms) |deadline| timeout = @min(timeout, deadline - now);
+        return @intCast(@max(timeout, 0));
+    }
+
+    fn collectOutputAndWait(
+        child: *std.process.Child,
+        allocator: std.mem.Allocator,
+        timeout_s: u32,
+    ) !ExecuteResult {
+        var stdout = std.ArrayList(u8).empty;
+        defer stdout.deinit(allocator);
+        var stderr = std.ArrayList(u8).empty;
+        defer stderr.deinit(allocator);
+
+        try child.spawn();
+        // On a pre-exec failure (bad cwd, setpgid, etc.) the forked child
+        // reports the error and _exit()s. Close our pipe ends and reap it so
+        // the error path doesn't leak fds or leave a zombie.
+        child.waitForSpawn() catch |err| {
+            closeChildPipes(child);
+            reapAfterKill(child.id);
+            return err;
+        };
+
+        var stdout_open = child.stdout != null;
+        var stderr_open = child.stderr != null;
+        var child_running = true;
+        var term: ?std.process.Child.Term = null;
+        var timed_out = false;
+        var sent_kill = false;
+        var post_exit_pipe_deadline_ms: ?i64 = null;
+
+        const pid = child.id;
+        const deadline_ms: ?i64 = if (timeout_s == 0)
+            null
+        else
+            std.time.milliTimestamp() + @as(i64, timeout_s) * std.time.ms_per_s;
+        var kill_deadline_ms: ?i64 = null;
+        var close_deadline_ms: ?i64 = null;
+
+        while (child_running or stdout_open or stderr_open) {
+            const now = std.time.milliTimestamp();
+
+            // Reap the child FIRST so the timeout decision below sees accurate
+            // liveness in this same iteration. Otherwise a command that exits
+            // right as the deadline elapses could be flagged as timed out (and
+            // have its process group signaled) before we notice it already left.
+            if (child_running) {
+                if (pollChildTerm(pid)) |child_term| {
+                    term = child_term;
+                    child_running = false;
+                    if (stdout_open or stderr_open) {
+                        post_exit_pipe_deadline_ms = now + POST_EXIT_PIPE_GRACE_MS;
+                    }
+                }
+            }
+
+            // Drive the timeout/kill state machine only while the child is alive.
+            if (child_running and !timed_out) {
+                if (deadline_ms) |deadline| {
+                    if (now >= deadline) {
+                        timed_out = true;
+                        kill_deadline_ms = now + TERM_GRACE_MS;
+                        close_deadline_ms = now + PIPE_CLOSE_GRACE_MS;
+                        signalProcessGroup(pid, std.posix.SIG.TERM);
+                    }
+                }
+            } else if (child_running and !sent_kill) {
+                if (kill_deadline_ms) |deadline| {
+                    if (now >= deadline) {
+                        sent_kill = true;
+                        kill_deadline_ms = null; // done; keep it out of the poll-timeout calc
+                        signalProcessGroup(pid, std.posix.SIG.KILL);
+                    }
+                }
+            }
+
+            if (timed_out) {
+                if (close_deadline_ms) |deadline| {
+                    if (now >= deadline) {
+                        closeChildPipes(child);
+                        stdout_open = false;
+                        stderr_open = false;
+                        if (child_running) {
+                            // SIGKILL was already sent; reap to avoid a zombie.
+                            reapAfterKill(pid);
+                            child_running = false;
+                        }
+                        break;
+                    }
+                }
+            } else if (!child_running) {
+                // Child exited but a grandchild may still hold the pipes open.
+                // Drain briefly, then give up so we never block forever.
+                if (post_exit_pipe_deadline_ms) |deadline| {
+                    if (now >= deadline) {
+                        closeChildPipes(child);
+                        stdout_open = false;
+                        stderr_open = false;
+                        break;
+                    }
+                }
+            }
+
+            if (!stdout_open and !stderr_open) {
+                if (child_running) std.Thread.sleep(POLL_INTERVAL_MS * std.time.ns_per_ms);
+                continue;
+            }
+
+            const events: i16 = std.posix.POLL.IN;
+            var fds = [_]std.posix.pollfd{
+                .{
+                    .fd = if (stdout_open) child.stdout.?.handle else -1,
+                    .events = events,
+                    .revents = 0,
+                },
+                .{
+                    .fd = if (stderr_open) child.stderr.?.handle else -1,
+                    .events = events,
+                    .revents = 0,
+                },
+            };
+
+            // Once timed out, the main deadline is in the past; the close_deadline
+            // drives the poll cadence from here, so don't let the expired main
+            // deadline pin the poll timeout at 0 and spin the CPU.
+            const poll_timeout_ms = buildPollTimeoutMs(now, if (timed_out) null else deadline_ms, kill_deadline_ms, close_deadline_ms, post_exit_pipe_deadline_ms);
+            const ready = std.posix.poll(&fds, poll_timeout_ms) catch |err| {
+                killAndReap(pid, &child_running);
+                closeChildPipes(child);
+                return err;
+            };
+            if (ready == 0) continue;
+
+            if (stdout_open and fds[0].revents != 0) {
+                drainReadyPipe(allocator, &child.stdout, &stdout, &stdout_open) catch |err| {
+                    killAndReap(pid, &child_running);
+                    closeChildPipes(child);
+                    return err;
+                };
+            }
+            if (stderr_open and fds[1].revents != 0) {
+                drainReadyPipe(allocator, &child.stderr, &stderr, &stderr_open) catch |err| {
+                    killAndReap(pid, &child_running);
+                    closeChildPipes(child);
+                    return err;
+                };
+            }
+        }
+
+        // Safety net: every loop-exit path above already reaps the child, so
+        // child_running should be false here. Reap defensively without ever
+        // blocking indefinitely in case a future change leaves it running.
+        if (child_running) {
+            if (pollChildTerm(pid)) |child_term| {
+                term = child_term;
+            } else {
+                reapAfterKill(pid);
+            }
+        }
+
+        closeChildPipes(child);
+
+        const result_allocator = std.heap.page_allocator;
+        return ExecuteResult{
+            .term = term orelse .{ .Unknown = 0 },
+            .stdout = try result_allocator.dupe(u8, stdout.items),
+            .stderr = try result_allocator.dupe(u8, stderr.items),
+            .timed_out = timed_out,
+            .allocator = result_allocator,
+        };
+    }
 
     fn executeCommand(ctx: ExecuteContext) !ExecuteResult {
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
@@ -220,24 +516,12 @@ pub const Resource = struct {
         }
 
         // Capture output
+        child.stdin_behavior = .Ignore;
         child.stdout_behavior = .Pipe;
         child.stderr_behavior = .Pipe;
+        child.pgid = 0;
 
-        try child.spawn();
-
-        // Blocking wait in worker thread (main thread polls our status)
-        const stdout = try child.stdout.?.readToEndAlloc(temp_allocator, std.math.maxInt(usize));
-        const stderr = try child.stderr.?.readToEndAlloc(temp_allocator, std.math.maxInt(usize));
-        const term = try child.wait();
-
-        // Allocate result using page allocator (will be freed by caller)
-        const result_allocator = std.heap.page_allocator;
-        return ExecuteResult{
-            .term = term,
-            .stdout = try result_allocator.dupe(u8, stdout),
-            .stderr = try result_allocator.dupe(u8, stderr),
-            .allocator = result_allocator,
-        };
+        return try collectOutputAndWait(&child, temp_allocator, ctx.timeout_s);
     }
 
     fn applyRun(self: Resource) !?[]const u8 {
@@ -252,6 +536,7 @@ pub const Resource = struct {
             .user = self.user,
             .group = self.group,
             .environment = self.environment,
+            .timeout_s = self.timeout_s,
         };
 
         const result = try AsyncExecutor.executeWithContext(
@@ -277,7 +562,10 @@ pub const Resource = struct {
             break :blk if (code == 0) logger.Level.info else logger.Level.err;
         } else logger.Level.info;
 
-        const exit_msg = if (exit_code) |code| blk: {
+        const exit_msg = if (result.timed_out) blk: {
+            const msg = try std.fmt.allocPrint(allocator, " (timeout: {d}s)", .{self.timeout_s});
+            break :blk msg;
+        } else if (exit_code) |code| blk: {
             const msg = try std.fmt.allocPrint(allocator, " (exit: {d})", .{code});
             break :blk msg;
         } else try allocator.dupe(u8, "");
@@ -310,6 +598,11 @@ pub const Resource = struct {
                 showCommandOutput(stderr);
                 std.debug.print("{s}", .{ansi.ANSI.RESET});
             }
+        }
+
+        if (result.timed_out) {
+            logger.err("[execute] command timed out after {d}s", .{self.timeout_s});
+            return error.CommandTimedOut;
         }
 
         // Check exit status
@@ -349,7 +642,7 @@ pub const Resource = struct {
 pub const ruby_prelude = @embedFile("execute_resource.rb");
 
 /// Zig callback: called from Ruby to add an execute resource
-/// Format: add_execute(name, command, cwd, user, group, environment_array, live_stream, creates, action, only_if_block, not_if_block, ignore_failure, notifications_array, subscriptions_array)
+/// Format: add_execute(name, command, cwd, user, group, environment_array, live_stream, creates, action, timeout_s, only_if_block, not_if_block, ignore_failure, notifications_array, subscriptions_array)
 pub fn zigAddResource(
     mrb: *mruby.mrb_state,
     self: mruby.mrb_value,
@@ -367,14 +660,15 @@ pub fn zigAddResource(
     var live_stream_val: mruby.mrb_value = undefined;
     var creates_val: mruby.mrb_value = undefined;
     var action_val: mruby.mrb_value = undefined;
+    var timeout_val: mruby.mrb_int = DEFAULT_TIMEOUT_S;
     var only_if_val: mruby.mrb_value = undefined;
     var not_if_val: mruby.mrb_value = undefined;
     var ignore_failure_val: mruby.mrb_value = undefined;
     var notifications_val: mruby.mrb_value = undefined;
     var subscriptions_val: mruby.mrb_value = undefined;
 
-    // Get 5 strings + 1 array + 1 bool + 2 strings + 3 optional (2 blocks + 1 bool + 2 arrays)
-    _ = mruby.mrb_get_args(mrb, "SSSSSAoSS|oooAA", &name_val, &command_val, &cwd_val, &user_val, &group_val, &environment_val, &live_stream_val, &creates_val, &action_val, &only_if_val, &not_if_val, &ignore_failure_val, &notifications_val, &subscriptions_val);
+    // Get 5 strings + 1 array + 1 bool + 2 strings + timeout + common optional args.
+    _ = mruby.mrb_get_args(mrb, "SSSSSAoSSi|oooAA", &name_val, &command_val, &cwd_val, &user_val, &group_val, &environment_val, &live_stream_val, &creates_val, &action_val, &timeout_val, &only_if_val, &not_if_val, &ignore_failure_val, &notifications_val, &subscriptions_val);
 
     const name_cstr = mruby.mrb_str_to_cstr(mrb, name_val);
     const command_cstr = mruby.mrb_str_to_cstr(mrb, command_val);
@@ -418,6 +712,10 @@ pub fn zigAddResource(
         .nothing
     else
         .run;
+    const timeout_s: u32 = if (timeout_val <= 0)
+        0
+    else
+        @intCast(@min(timeout_val, @as(mruby.mrb_int, std.math.maxInt(u32))));
 
     // Parse environment array [[key, value], ...]
     var environment: ?[]const u8 = null;
@@ -466,6 +764,7 @@ pub fn zigAddResource(
         .environment = environment,
         .live_stream = live_stream,
         .creates = creates,
+        .timeout_s = timeout_s,
         .action = action,
         .common = common,
     }) catch return mruby.mrb_nil_value();

--- a/src/resources/execute_resource.rb
+++ b/src/resources/execute_resource.rb
@@ -12,6 +12,7 @@ class ExecuteResource
     @live_stream = false  # Default: don't output to stdout
     @creates = ""  # Path to file - skip execution if it exists
     @action = "run"
+    @timeout = 3600  # Seconds; 0 disables the hard timeout
     @only_if_proc = nil
     @not_if_proc = nil
     @ignore_failure = false
@@ -30,7 +31,7 @@ class ExecuteResource
     # Convert environment hash to array of [key, value] pairs
     environment_arg = @environment.map { |k, v| [k.to_s, v.to_s] }
 
-    ZigBackend.add_execute(@name, @command, @cwd, @user, @group, environment_arg, @live_stream, @creates, @action, only_if_arg, not_if_arg, @ignore_failure, notifications_arg, subscriptions_arg)
+    ZigBackend.add_execute(@name, @command, @cwd, @user, @group, environment_arg, @live_stream, @creates, @action, @timeout, only_if_arg, not_if_arg, @ignore_failure, notifications_arg, subscriptions_arg)
   end
 
   def command(value)


### PR DESCRIPTION
## Summary

Anti-hang/anti-deadlock hardening for command execution, split out from the HTTP-timeout PR (#21).

### `execute` resource (`src/resources/execute.zig`, `execute_resource.rb`, `src/provision.zig`)

The old path did `child.stdout.readToEndAlloc()` + `child.wait()`, which blocks forever when a command spawns a grandchild that inherits the stdout pipe (the pipe never reaches EOF). Replaced with a `poll()`-driven supervision loop:

- New `timeout` DSL option (default 3600s; `0` disables the hard deadline).
- Child runs in its own process group; on timeout we escalate `SIGTERM -> SIGKILL` across the whole group.
- The child is reaped **before** the timeout decision, so a command that exits right as the deadline elapses is not misreported as a timeout (and we never signal a recycled pid).
- Output is bounded at 10MB and pipes are drained incrementally.
- Cleanup/error paths kill+reap but never re-`waitpid` an already-reaped pid (that hits `ECHILD`, which Zig treats as `unreachable` -> panic).

### Guard commands (`src/base_resource.zig`)

`only_if`/`not_if` shell guards inherited stdin and used an unbounded `spawnAndWait()`, so `only_if "sleep 99999"` could hang provisioning forever. Now stdin is ignored, the guard runs in its own process group, and a 300s hard timeout escalates `SIGTERM -> SIGKILL` with a give-up cap so it never blocks even if the child ignores SIGKILL. A timed-out `only_if` skips the resource; a timed-out `not_if` lets it run.

## Review

This branch was reviewed with Codex across two rounds; the first round caught a timeout/reap ordering race and a double-reap panic, both fixed here. The second round confirmed no new issues in the working tree.

## Test

`zig fmt --check` and `zig ast-check` pass on both files. Full local build is blocked by an unrelated Xcode CLT/SDK linker issue; relying on CI for the full `zig build test`.