### PR TITLE
fix(provision): close mruby state after resource teardown

### DIFF
--- a/src/provision.zig
+++ b/src/provision.zig
@@ -818,14 +818,20 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     // invocation on this thread can't leak into this run.
     base.clearProvisionErrorDetail();
 
+    // Initialize the mruby interpreter before the runner so it outlives the
+    // resources. Resource teardown (CommonProps.deinit) calls
+    // mrb_gc_unregister on the mrb state for only_if/not_if guard blocks, so
+    // the state must still be alive when runner.deinit() runs. Defers execute
+    // LIFO: registering mrb.deinit() first makes runner.deinit() (and resource
+    // teardown) run before the mruby state is closed.
+    var mrb = try mruby.State.init();
+    defer mrb.deinit();
+
     var runner = ProvisionRunner.init(allocator);
     defer runner.deinit();
 
     current_runner = &runner;
     defer current_runner = null;
-
-    var mrb = try mruby.State.init();
-    defer mrb.deinit();
 
     // Register Zig functions in mruby
     const mrb_ptr = mrb.mrb orelse return error.MRubyNotInitialized;


### PR DESCRIPTION
## Problem

`hola-agent` reproducibly crashed with SIGSEGV on the aarch64-musl build right after printing `Provisioning completed successfully!`:

```
hola-agent.service: Main process exited, code=killed, status=11/SEGV
```

## Root cause

Use-after-free of the mruby interpreter state during provision teardown.

`CommonProps.deinit` (`src/base_resource.zig`) calls `mrb_gc_unregister(self.mrb_state, block)` to release `only_if`/`not_if` guard blocks, so the mruby state must outlive the resources. In `provision.run()` the defers were registered as:

```zig
var runner = ProvisionRunner.init(allocator);
defer runner.deinit();   // registered first  -> runs LAST
...
var mrb = try mruby.State.init();
defer mrb.deinit();      // registered later  -> runs FIRST
```

Defers execute LIFO, so `mrb.deinit()` (`mrb_close`) ran **before** `runner.deinit()`. Tearing down any resource that carried a guard block then dereferenced the already-freed `mrb_state` → UAF, crashing inside `mrb_gc_unregister`.

This only crashed on aarch64-musl, not x86_64-glibc: musl reclaims freed memory more aggressively, so the UAF that glibc happened to tolerate became a hard SIGSEGV. The original "ARM-only" symptom was an allocator difference, not a CPU-architecture one.

## Fix

Initialize the mruby state before the runner so the runner (and its resources) tear down first, while the interpreter is still alive. Minimal reorder of the two declarations + defers.

## Verification

Reproduced and verified on an aarch64-linux-musl host (Debian, glibc host but musl-target static binary, matching CI/prod):

| Build config | Before | After |
|---|---|---|
| Debug, musl | crash (UAF / stack-trace storm) | exit 0, 3/3 |
| ReleaseSmall + strip + musl (= CI/prod) | SIGSEGV (139) | exit 0, 3/3 |

Provisioning completes and the process exits cleanly across repeated runs.