### PR TITLE
fix(node-info): free EC2 IMDS response headers

### DIFF
--- a/src/node_info.zig
+++ b/src/node_info.zig
@@ -531,8 +531,8 @@ fn getEc2InfoIMDSv2(allocator: std.mem.Allocator) !?Ec2Info {
         .timeout_ms = 2000,
     };
 
-    const token_response = try client.request(token_request);
-    defer allocator.free(token_response.body);
+    var token_response = try client.request(token_request);
+    defer token_response.deinit();
 
     logger.debug("EC2: Token response status={d}, body_len={d}", .{ token_response.status, token_response.body.len });
 
@@ -563,8 +563,8 @@ fn getEc2InfoIMDSv2(allocator: std.mem.Allocator) !?Ec2Info {
         .timeout_ms = 2000,
     };
 
-    const doc_response = try client.request(doc_request);
-    defer allocator.free(doc_response.body);
+    var doc_response = try client.request(doc_request);
+    defer doc_response.deinit();
 
     logger.debug("EC2: Identity document response status={d}, body_len={d}", .{ doc_response.status, doc_response.body.len });
 
@@ -607,8 +607,8 @@ fn getEc2InfoIMDSv1(allocator: std.mem.Allocator) !?Ec2Info {
         .timeout_ms = 2000,
     };
 
-    const doc_response = try client.request(doc_request);
-    defer allocator.free(doc_response.body);
+    var doc_response = try client.request(doc_request);
+    defer doc_response.deinit();
 
     if (doc_response.status != 200) {
         return error.DocumentRequestFailed;


### PR DESCRIPTION
## Problem

Running a full provision and inspecting the GeneralPurposeAllocator leak report at exit showed **150 leaked allocations** — all originating from a single site, the HTTP response-header dup in `headerCallback` (`src/http/client.zig:554-555`).

## Root cause

`node_info.zig` gathers EC2 instance metadata over IMDS. The IMDSv2 token request, the IMDSv2 identity-document request, and the IMDSv1 fallback each did:

```zig
const token_response = try client.request(token_request);
defer allocator.free(token_response.body);   // frees body only
```

`Response` owns **both** its `body` and its `headers` map (`Response.deinit()` frees both). Freeing only `.body` leaks every duplicated header key/value. Each IMDS response carries ~20-35 headers, and node_info issues several requests, which is what inflated a single logical leak into ~150 GPA entries.

For the short-lived `provision` CLI this is harmless (the process exits and the OS reclaims everything), but the `agent` daemon rebuilds the node object on every task, so these header strings accumulate over the daemon's lifetime.

## Fix

Call `Response.deinit()` instead of freeing only the body at the three IMDS request sites, so headers and body are released together. (All other `client.request`/`client.get` consumers already call `deinit()`.)

## Verification

On an aarch64-linux-musl build, GPA leak reports for a full `provision` run dropped from **150 to 0**; the run still exits cleanly.