### PR TITLE
fix(remote_file): do not fail download on cache persistence errors

### DIFF
--- a/src/resources/remote_file.zig
+++ b/src/resources/remote_file.zig
@@ -309,15 +309,22 @@ pub const Resource = struct {
                 }
             }
 
+            // ETag / Last-Modified caches are a download optimization only. A
+            // failure to persist them (e.g. an unwritable state dir) must not
+            // fail an already-successful download.
             if (self.use_etag) {
                 if (downloaded_etag) |etag| {
-                    try self.saveEtag(allocator, etag);
+                    self.saveEtag(allocator, etag) catch |err| {
+                        logger.warn("Failed to save etag cache for {s}: {}", .{ self.path, err });
+                    };
                 }
             }
 
             if (self.use_last_modified) {
                 if (downloaded_last_modified) |lm| {
-                    try self.saveLastModified(allocator, lm);
+                    self.saveLastModified(allocator, lm) catch |err| {
+                        logger.warn("Failed to save last-modified cache for {s}: {}", .{ self.path, err });
+                    };
                 }
             }
         }


### PR DESCRIPTION
## Summary

`remote_file` treats a failure to persist the ETag / Last-Modified cache as a fatal error, failing a download that has already completed successfully. These caches are only an optimization for conditional requests — losing them just means the next run re-downloads.

This PR downgrades cache persistence failures (e.g. an unwritable state directory) to warnings:

- `saveEtag` errors are caught and logged via `logger.warn`
- `saveLastModified` errors are caught and logged via `logger.warn`
- the resource continues and reports the download as successful

## Testing

- `zig build` passes
- `zig build test` passes