### PR TITLE
fix(agent): detect dead WebSocket streams with opt-in app-level heartbeat

### DIFF
--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -14,6 +14,7 @@ const params = clap.parseParamsComptime(
     \\-c, --callback <URL>       Default callback URL (overridden by event)
     \\    --client-cert <PATH>   Client certificate for mTLS
     \\    --client-key <PATH>    Client private key for mTLS
+    \\    --ws-heartbeat         Enable app-level heartbeat (30s ping / 90s idle teardown; hub must auto-reply "pong")
     \\<endpoint>                  Endpoint URL
     \\
 );
@@ -365,7 +366,7 @@ fn sendCallback(allocator: std.mem.Allocator, callback_url: []const u8, event_da
 
 // -- WebSocket mode --
 
-fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8, tls_auth: TlsClientAuth) void {
+fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8, tls_auth: TlsClientAuth, heartbeat: bool) void {
     // Convert http(s) URL to ws(s) URL
     const ws_endpoint = blk: {
         if (std.mem.startsWith(u8, endpoint, "https://")) {
@@ -383,7 +384,7 @@ fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []c
 
     var backoff_ms: u64 = INITIAL_BACKOFF_MS;
     while (true) {
-        wsConnect(allocator, ws_endpoint, node_name, default_callback, tls_auth) catch {
+        wsConnect(allocator, ws_endpoint, node_name, default_callback, tls_auth, heartbeat) catch {
             std.debug.print("[agent] reconnecting in {d}ms...\n", .{backoff_ms});
             std.Thread.sleep(backoff_ms * std.time.ns_per_ms);
             backoff_ms = @min(backoff_ms * 2, MAX_BACKOFF_MS);
@@ -395,7 +396,7 @@ fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []c
     }
 }
 
-fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8, tls_auth: TlsClientAuth) !void {
+fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8, tls_auth: TlsClientAuth, heartbeat: bool) !void {
     const curl = @import("../curl.zig");
     const handle = curl.curl_easy_init() orelse return error.ConnectionFailed;
     defer curl.curl_easy_cleanup(handle);
@@ -518,11 +519,11 @@ fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []co
         }
 
         const now = std.time.milliTimestamp();
-        if (now - last_rx > WS_IDLE_TIMEOUT_MS) {
+        if (heartbeat and now - last_rx > WS_IDLE_TIMEOUT_MS) {
             std.debug.print("[agent] no data for {d}s, assuming dead connection\n", .{@divTrunc(now - last_rx, 1000)});
             return error.ConnectionFailed;
         }
-        if (now - last_ping >= WS_PING_INTERVAL_MS) {
+        if (heartbeat and now - last_ping >= WS_PING_INTERVAL_MS) {
             var sent: usize = 0;
             const send_rc = curl.curl_ws_send(handle, "ping", 4, &sent, 0, curl.CURLWS_TEXT);
             if (send_rc != .CURLE_OK and send_rc != .CURLE_AGAIN) {
@@ -678,9 +679,11 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
     // key file". Message is already printed inside the helper.
     http.validateClientAuthFiles(tls_auth.cert, tls_auth.key) catch std.process.exit(1);
 
+    const ws_heartbeat = res.args.@"ws-heartbeat" != 0;
+
     const agent_mode = res.args.mode orelse "ws";
     if (std.mem.eql(u8, agent_mode, "ws") or std.mem.eql(u8, agent_mode, "sse")) {
-        runSseMode(allocator, endpoint, node_name, default_callback, tls_auth);
+        runSseMode(allocator, endpoint, node_name, default_callback, tls_auth, ws_heartbeat);
     } else if (std.mem.eql(u8, agent_mode, "watch")) {
         runWatchMode(allocator, endpoint, node_name, interval, default_callback, tls_auth);
     } else {
@@ -710,6 +713,11 @@ fn printHelp(reason: ?[]const u8) !void {
         \\  -c, --callback URL       Default callback URL (overridden by event payload)
         \\      --client-cert PATH   Client certificate for mTLS (PEM)
         \\      --client-key PATH    Client private key for mTLS (PEM)
+        \\      --ws-heartbeat       Enable app-level heartbeat: send "ping" every 30s and drop
+        \\                           the connection after 90s without any inbound data. Requires
+        \\                           the hub to auto-reply "pong" (e.g. Durable Object
+        \\                           setWebSocketAutoResponse). Off by default: without it, dead
+        \\                           connections are only detected by TCP keepalive / send errors.
         \\
         \\Task JSON Format:
         \\  {"url": "https://r2.example.com/task.rb", "callback": "https://example.com/done", ...}

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -56,6 +56,16 @@ fn originMatches(url_a: []const u8, url_b: []const u8) bool {
 
 const INITIAL_BACKOFF_MS: u64 = 1000;
 const MAX_BACKOFF_MS: u64 = 30_000;
+/// Application-level heartbeat: send "ping" this often; the hub's Durable
+/// Object auto-responds "pong" (setWebSocketAutoResponse), proving the full
+/// agent -> edge -> DO path is alive, not just the TCP hop to the proxy.
+const WS_PING_INTERVAL_MS: i64 = 30_000;
+/// If nothing (pong, task, control frame) arrives for this long, the stream
+/// is considered dead and we reconnect.
+const WS_IDLE_TIMEOUT_MS: i64 = 90_000;
+const WS_POLL_TIMEOUT_MS: i32 = 1_000;
+const WS_RECV_CHUNK_SIZE: usize = 4096;
+const WS_MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
 const DEFAULT_WATCH_INTERVAL: u32 = 10;
 const AGENT_CALLBACK_TIMEOUT_S: u32 = 60;
 const AGENT_POLL_TIMEOUT_S: u32 = 60;
@@ -385,26 +395,6 @@ fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []c
     }
 }
 
-const WsContext = struct {
-    allocator: std.mem.Allocator,
-    default_callback: ?[]const u8,
-    endpoint: []const u8,
-    tls_auth: TlsClientAuth,
-    first_frame: bool = true,
-};
-
-fn wsWriteCallback(ptr: [*]const u8, size: usize, nmemb: usize, userdata: *anyopaque) callconv(.c) usize {
-    const ctx: *WsContext = @ptrCast(@alignCast(userdata));
-    const total = size * nmemb;
-    if (total == 0) return 0;
-    if (ctx.first_frame) {
-        std.debug.print("[agent] WebSocket connected, receiving frames\n", .{});
-        ctx.first_frame = false;
-    }
-    handleWsMessage(ctx.allocator, ptr[0..total], ctx.default_callback, ctx.endpoint, ctx.tls_auth);
-    return total;
-}
-
 fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8, tls_auth: TlsClientAuth) !void {
     const curl = @import("../curl.zig");
     const handle = curl.curl_easy_init() orelse return error.ConnectionFailed;
@@ -417,11 +407,11 @@ fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []co
     // Bound the connection/handshake phase so a stalled connect can't hang forever.
     _ = curl.curl_easy_setopt(handle, .CURLOPT_CONNECTTIMEOUT, @as(c_long, 15));
 
-    // TCP keepalive: without it, a silently dead connection (NAT timeout,
-    // network change, peer power loss) leaves curl_easy_perform blocked on
-    // recv forever and the reconnect loop never triggers. With these probes
-    // the kernel detects the dead peer within a few minutes and perform
-    // returns an error, triggering reconnect.
+    // TCP keepalive detects a dead network path (NAT timeout, network change,
+    // peer power loss) within a few minutes. It cannot detect a logically dead
+    // stream behind a live intermediary (e.g. a CDN edge that keeps answering
+    // probes after the upstream is gone) — that's what the application-level
+    // ping/idle-timeout in the receive loop below is for.
     _ = curl.curl_easy_setopt(handle, .CURLOPT_TCP_KEEPALIVE, @as(c_long, 1));
     _ = curl.curl_easy_setopt(handle, .CURLOPT_TCP_KEEPIDLE, @as(c_long, 60));
     _ = curl.curl_easy_setopt(handle, .CURLOPT_TCP_KEEPINTVL, @as(c_long, 15));
@@ -454,17 +444,99 @@ fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []co
     }
     defer if (headers) |h| curl.curl_slist_free_all(h);
 
-    // Write callback receives WebSocket text frame payloads
-    var ctx = WsContext{ .allocator = allocator, .default_callback = default_callback, .endpoint = endpoint, .tls_auth = tls_auth };
-    _ = curl.curl_easy_setopt(handle, .CURLOPT_WRITEFUNCTION, @as(curl.WriteCallback, @ptrCast(&wsWriteCallback)));
-    _ = curl.curl_easy_setopt(handle, .CURLOPT_WRITEDATA, @as(*anyopaque, @ptrCast(&ctx)));
+    // Connect-only WebSocket mode: perform() completes the handshake and
+    // returns; we then drive the connection with curl_ws_recv/curl_ws_send.
+    // The previous write-callback mode blocked inside perform() forever, so
+    // it could neither send heartbeats nor notice a stream that went silent.
+    _ = curl.curl_easy_setopt(handle, .CURLOPT_CONNECT_ONLY, @as(c_long, 2));
 
-    // Perform WebSocket connection (blocks until closed)
     const rc = curl.curl_easy_perform(handle);
     if (rc != .CURLE_OK) {
         const err_msg = curl.curl_easy_strerror(rc);
         std.debug.print("[agent] WebSocket error: {s}\n", .{std.mem.span(err_msg)});
         return error.ConnectionFailed;
+    }
+
+    var sockfd: curl.curl_socket_t = curl.CURL_SOCKET_BAD;
+    if (curl.curl_easy_getinfo(handle, .CURLINFO_ACTIVESOCKET, &sockfd) != .CURLE_OK or sockfd == curl.CURL_SOCKET_BAD) {
+        std.debug.print("[agent] failed to get WebSocket socket\n", .{});
+        return error.ConnectionFailed;
+    }
+
+    std.debug.print("[agent] WebSocket connected, receiving frames\n", .{});
+
+    // Reassembly buffer: a message may span multiple recv chunks and frames.
+    var msg_buf = std.ArrayList(u8).empty;
+    defer msg_buf.deinit(allocator);
+
+    var last_rx: i64 = std.time.milliTimestamp();
+    var last_ping: i64 = last_rx;
+
+    while (true) {
+        // Drain everything curl has buffered before waiting in poll: with TLS,
+        // decrypted data can sit in curl's buffers while the socket itself is
+        // not readable.
+        drain: while (true) {
+            var chunk: [WS_RECV_CHUNK_SIZE]u8 = undefined;
+            var nread: usize = 0;
+            var meta: ?*const curl.curl_ws_frame = null;
+            const recv_rc = curl.curl_ws_recv(handle, &chunk, chunk.len, &nread, &meta);
+            if (recv_rc == .CURLE_AGAIN) break :drain;
+            if (recv_rc != .CURLE_OK) {
+                std.debug.print("[agent] WebSocket recv error: {s}\n", .{std.mem.span(curl.curl_easy_strerror(recv_rc))});
+                return error.ConnectionFailed;
+            }
+            last_rx = std.time.milliTimestamp();
+
+            const m = meta orelse continue :drain;
+            const flags: c_uint = @bitCast(m.flags);
+            if (flags & curl.CURLWS_CLOSE != 0) return; // clean close, caller reconnects
+            if (flags & curl.CURLWS_PING != 0) {
+                var sent: usize = 0;
+                _ = curl.curl_ws_send(handle, &chunk, nread, &sent, 0, curl.CURLWS_PONG);
+                continue :drain;
+            }
+            if (flags & curl.CURLWS_PONG != 0) continue :drain;
+
+            if (msg_buf.items.len + nread > WS_MAX_MESSAGE_SIZE) {
+                std.debug.print("[agent] WebSocket message exceeds {d} bytes, reconnecting\n", .{WS_MAX_MESSAGE_SIZE});
+                return error.ConnectionFailed;
+            }
+            try msg_buf.appendSlice(allocator, chunk[0..nread]);
+
+            // Message complete: frame fully consumed and no continuation follows.
+            if (m.bytesleft == 0 and (flags & curl.CURLWS_CONT) == 0) {
+                if (!std.mem.eql(u8, msg_buf.items, "pong")) {
+                    handleWsMessage(allocator, msg_buf.items, default_callback, endpoint, tls_auth);
+                }
+                msg_buf.clearRetainingCapacity();
+                // A task can run for minutes inside handleWsMessage; don't
+                // count that time as idle or we'd tear down a live connection.
+                last_rx = std.time.milliTimestamp();
+                last_ping = last_rx;
+            }
+        }
+
+        const now = std.time.milliTimestamp();
+        if (now - last_rx > WS_IDLE_TIMEOUT_MS) {
+            std.debug.print("[agent] no data for {d}s, assuming dead connection\n", .{@divTrunc(now - last_rx, 1000)});
+            return error.ConnectionFailed;
+        }
+        if (now - last_ping >= WS_PING_INTERVAL_MS) {
+            var sent: usize = 0;
+            const send_rc = curl.curl_ws_send(handle, "ping", 4, &sent, 0, curl.CURLWS_TEXT);
+            if (send_rc != .CURLE_OK and send_rc != .CURLE_AGAIN) {
+                std.debug.print("[agent] WebSocket ping failed: {s}\n", .{std.mem.span(curl.curl_easy_strerror(send_rc))});
+                return error.ConnectionFailed;
+            }
+            last_ping = now;
+        }
+
+        var pfds = [_]std.posix.pollfd{.{ .fd = sockfd, .events = std.posix.POLL.IN, .revents = 0 }};
+        _ = std.posix.poll(&pfds, WS_POLL_TIMEOUT_MS) catch |err| {
+            std.debug.print("[agent] poll failed: {}\n", .{err});
+            return error.ConnectionFailed;
+        };
     }
 }
 

--- a/src/curl.zig
+++ b/src/curl.zig
@@ -24,6 +24,7 @@ pub const CURLcode = enum(c_int) {
     CURLE_SSL_CERTPROBLEM = 58,
     CURLE_SSL_CACERT_BADFILE = 77,
     CURLE_ABORTED_BY_CALLBACK = 42,
+    CURLE_AGAIN = 81,
     _,
 };
 
@@ -116,7 +117,7 @@ pub const CURLoption = enum(c_int) {
 
 pub const CURLINFO = enum(c_int) {
     CURLINFO_RESPONSE_CODE = 0x200002,
-    CURLINFO_ACTIVESOCKET = 0x500028,
+    CURLINFO_ACTIVESOCKET = 0x50002c,
     _,
 };
 
@@ -178,6 +179,8 @@ pub const curl_ws_frame = extern struct {
 };
 
 pub const CURLWS_TEXT: c_uint = 1 << 0;
+pub const CURLWS_BINARY: c_uint = 1 << 1;
+pub const CURLWS_CONT: c_uint = 1 << 2;
 pub const CURLWS_CLOSE: c_uint = 1 << 3;
 pub const CURLWS_PING: c_uint = 1 << 4;
 pub const CURLWS_PONG: c_uint = 1 << 6;


### PR DESCRIPTION
## Summary

Two commits:

1. **fix(agent): detect dead WebSocket streams with app-level heartbeat** — switches the WebSocket connection from write-callback mode to `CURLOPT_CONNECT_ONLY=2` driven by `curl_ws_recv`/`curl_ws_send`, so the agent can send heartbeats and notice a stream that went silent (NAT timeout, network change) instead of blocking inside `perform()` forever.

2. **feat(agent): gate WebSocket heartbeat behind `--ws-heartbeat` flag** — the app-level ping/pong requires the hub to auto-reply `pong` (e.g. Durable Object `setWebSocketAutoResponse`). Default is **off** so the agent keeps working against any WebSocket server (falling back to TCP keepalive / send-error detection); deployments whose hub supports auto-pong opt in for deterministic 90s dead-stream detection.

Net effect on default behavior: connection architecture changes (connect-only + poll loop), but no heartbeat traffic and no idle teardown unless `--ws-heartbeat` is passed.

Why opt-in rather than opt-out: a send on a silently-dead TCP connection succeeds into the kernel buffer and only errors after the retransmission timeout (minutes), so ping-send-failure alone cannot provide fast detection — but requiring pong support by default would put hubs without auto-reply into a 90s reconnect loop. Opt-in keeps the default universally safe.

## Testing

- `zig build` (0.15.2) clean; `zig fmt --check` clean
- `hola agent --help` shows the new flag with default-off semantics
- Heartbeat path unchanged from the first commit when the flag is set