### PR TITLE
build: migrate to Zig 0.16.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .zig-cache
 .zig-global-cache
 zig-out
+zig-pkg
 /indicatif
 /test_*
 /zig-cache

--- a/build.zig
+++ b/build.zig
@@ -83,10 +83,10 @@ pub fn build(b: *std.Build) !void {
         const build_zig_zon = @embedFile("build.zig.zon") ++ "";
         var buffer: [10 * build_zig_zon.len]u8 = undefined;
         var fba = std.heap.FixedBufferAllocator.init(&buffer);
-        const parsed = std.zon.parse.fromSlice(
+        const parsed = std.zon.parse.fromSliceAlloc(
             struct { version: []const u8 },
             fba.allocator(),
-            build_zig_zon[0 .. :0],
+            build_zig_zon[0.. :0],
             null,
             .{ .ignore_unknown_fields = true },
         ) catch break :blk "0.0.0";
@@ -127,36 +127,35 @@ pub fn build(b: *std.Build) !void {
     }
 
     // Add mruby header file path
-    exe.addIncludePath(.{ .cwd_relative = b.fmt("{s}/include", .{final_mruby_path}) });
+    exe.root_module.addIncludePath(.{ .cwd_relative = b.fmt("{s}/include", .{final_mruby_path}) });
 
     // Link mruby static library directly (no need to add library path since we specify full path)
-    exe.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libmruby.a", .{final_mruby_path}) });
-    exe.linkLibC();
+    exe.root_module.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libmruby.a", .{final_mruby_path}) });
+    exe.root_module.link_libc = true;
 
     // For Linux cross-compilation, provide linker symbols that mruby expects
     if (target.result.os.tag == .linux) {
-        exe.root_module.link_libc = true;
-        exe.addAssemblyFile(b.path("src/linux_linker_shims.s"));
+        exe.root_module.addAssemblyFile(b.path("src/linux_linker_shims.s"));
         // aarch64-gnu only: provide sigsetjmp symbol for OpenSSL armcap.c
         // musl provides sigsetjmp natively, so only needed for gnu
         if (target.result.cpu.arch == .aarch64 and target.result.abi == .gnu) {
-            exe.addAssemblyFile(b.path("src/linux_aarch64_shims.S"));
+            exe.root_module.addAssemblyFile(b.path("src/linux_aarch64_shims.S"));
         }
     }
 
     // Platform-specific configuration
     if (target.result.os.tag == .macos) {
         // macOS: Link Foundation framework for AppleScript support
-        exe.linkFramework("Foundation");
+        exe.root_module.linkFramework("Foundation", .{});
         // Add Objective-C bridge file for runtime calls
         // Note: .m files are compiled as Objective-C
-        exe.addCSourceFile(.{ .file = b.path("src/applescript_bridge.m"), .flags = &.{"-fobjc-arc"} });
+        exe.root_module.addCSourceFile(.{ .file = b.path("src/applescript_bridge.m"), .flags = &.{"-fobjc-arc"} });
         // Add CFPreferences C wrapper
-        exe.addCSourceFile(.{ .file = b.path("src/cfprefs_wrapper.c"), .flags = &.{} });
+        exe.root_module.addCSourceFile(.{ .file = b.path("src/cfprefs_wrapper.c"), .flags = &.{} });
     }
 
     // Add mruby helpers for array handling
-    exe.addCSourceFile(.{ .file = b.path("src/mruby_helpers.c"), .flags = &.{} });
+    exe.root_module.addCSourceFile(.{ .file = b.path("src/mruby_helpers.c"), .flags = &.{} });
     configureLibGit2(exe, b, final_libgit2_path, target.result.os.tag);
 
     // This declares intent for the executable to be installed into the
@@ -192,10 +191,11 @@ pub fn build(b: *std.Build) !void {
     }
 
     // Create test executable for the main executable's root module
+    // Note: exe_tests shares exe.root_module, which already has libgit2
+    // configured at the module level - no second configureLibGit2 call needed.
     const exe_tests = b.addTest(.{
         .root_module = exe.root_module,
     });
-    configureLibGit2(exe_tests, b, final_libgit2_path, target.result.os.tag);
 
     // Run step for the test executable
     const run_exe_tests = b.addRunArtifact(exe_tests);
@@ -218,33 +218,34 @@ pub fn build(b: *std.Build) !void {
 }
 
 fn configureLibGit2(step: *std.Build.Step.Compile, b: *std.Build, libgit2_path: []const u8, os_tag: std.Target.Os.Tag) void {
+    const mod = step.root_module;
     // All platforms use hola_deps package with unified structure
-    step.addIncludePath(.{ .cwd_relative = b.fmt("{s}/include", .{libgit2_path}) });
+    mod.addIncludePath(.{ .cwd_relative = b.fmt("{s}/include", .{libgit2_path}) });
 
     // Add libgit2 and libcurl
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libgit2.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libcurl.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libgit2.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libcurl.a", .{libgit2_path}) });
 
     // Shared dependencies (needed by both libgit2 and libcurl)
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libssl.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libcrypto.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libssh2.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libz.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libpcre2-8.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libpcre2-posix.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libhttp_parser.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libssl.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libcrypto.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libssh2.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libz.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libpcre2-8.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libpcre2-posix.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libhttp_parser.a", .{libgit2_path}) });
 
     // curl-specific dependencies
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libnghttp2.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libnghttp3.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libbrotlicommon.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libbrotlidec.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libbrotlienc.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libzstd.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libcares.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libidn2.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libpsl.a", .{libgit2_path}) });
-    step.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libunistring.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libnghttp2.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libnghttp3.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libbrotlicommon.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libbrotlidec.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libbrotlienc.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libzstd.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libcares.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libidn2.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libpsl.a", .{libgit2_path}) });
+    mod.addObjectFile(.{ .cwd_relative = b.fmt("{s}/lib/libunistring.a", .{libgit2_path}) });
 
     // Platform-specific system libraries
     if (os_tag == .macos) {
@@ -252,12 +253,12 @@ fn configureLibGit2(step: *std.Build.Step.Compile, b: *std.Build, libgit2_path: 
         const result = b.run(&.{ "xcrun", "--show-sdk-path" });
         const sdk_path = std.mem.trim(u8, result, &std.ascii.whitespace);
 
-        step.addSystemIncludePath(.{ .cwd_relative = b.fmt("{s}/usr/include", .{sdk_path}) });
-        step.addLibraryPath(.{ .cwd_relative = b.fmt("{s}/usr/lib", .{sdk_path}) });
-        step.addFrameworkPath(.{ .cwd_relative = b.fmt("{s}/System/Library/Frameworks", .{sdk_path}) });
+        mod.addSystemIncludePath(.{ .cwd_relative = b.fmt("{s}/usr/include", .{sdk_path}) });
+        mod.addLibraryPath(.{ .cwd_relative = b.fmt("{s}/usr/lib", .{sdk_path}) });
+        mod.addFrameworkPath(.{ .cwd_relative = b.fmt("{s}/System/Library/Frameworks", .{sdk_path}) });
 
-        step.linkSystemLibrary("iconv");
-        step.linkFramework("CoreFoundation");
-        step.linkFramework("Security");
+        mod.linkSystemLibrary("iconv", .{});
+        mod.linkFramework("CoreFoundation", .{});
+        mod.linkFramework("Security", .{});
     }
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -25,7 +25,7 @@
     .fingerprint = 0x6fa0f988704801ae, // Changing this has security and trust implications.
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
@@ -45,24 +45,24 @@
             .hash = "hola_deps-0.1.0-clHq_wTk5AM2_uMo-RFHPDRsVY2T7rmQAAdfV1KmkSK5",
         },
         .clap = .{
-            .url = "https://github.com/Hejsil/zig-clap/archive/c499116264c348e4a98d939917b2446cad79d5fb.tar.gz",
-            .hash = "clap-0.11.0-oBajB-TnAQC7yPLnZRT5WzHZ_4Ly4dX2OILskli74b9H",
+            .url = "https://github.com/Hejsil/zig-clap/archive/1cee79fa8a1daebc2d558e5c9e214d274fd493e8.tar.gz",
+            .hash = "clap-0.12.0-oBajB7foAQDqlSwaSG5g0yq7xGbQARUsBk5T64gAOqP5",
         },
         .vaxis = .{
-            .url = "git+https://github.com/rockorager/libvaxis#cfa6311448755cf18684c09697d20b7a7622e578",
-            .hash = "vaxis-0.5.1-BWNV_IcuCQCjrYTHNe3-ArhtpwLzRfgI2mBu0yKT7IZl",
+            .url = "git+https://github.com/rockorager/libvaxis#06c8b9db2d4b83c279e985603ffabfa828dcbd35",
+            .hash = "vaxis-0.6.0-BWNV_N0GCgC-VGPXJ3sS8N2NBiUqUfkCLti-Mv7hXLNM",
         },
         .ansi_term = .{
             .url = "git+https://github.com/ziglibs/ansi_term?ref=master#47e27d707ac9569be9b0863cfa7b150600d977c9",
             .hash = "ansi_term-0.1.0-_baAywpoAABEqsPmS5Jz_CddDCrG8qdIyRIESH8D2fzd",
         },
         .toml = .{
-            .url = "git+https://github.com/sam701/zig-toml#c261f13a4f79b2330211639f498d33fadb3aad27",
-            .hash = "toml-0.3.0-bV14BSt9AQBdoP2Ofpwjxops6ddrzk0A9Vpd7ckLoYw8",
+            .url = "https://github.com/sam701/zig-toml/archive/00c5715edc45e0019cc0543ee699ee40382e5247.tar.gz",
+            .hash = "toml-0.3.0-bV14BRmKAQAWR0FT0KUKFwVJTImaFhWjSe6HfSMtNZOH",
         },
         .zeit = .{
-            .url = "git+https://github.com/rockorager/zeit#74be5a2afb346b2a6a6349abbb609e89ec7e65a6",
-            .hash = "zeit-0.6.0-5I6bk4t8AgCP0UGGHVF_khlmWZkAF5XtfQWEKCyLoptU",
+            .url = "git+https://github.com/rockorager/zeit#b1c1c2fcbc71fd7799a316bbcf0ff88d06d80ccc",
+            .hash = "zeit-0.9.0-5I6bk2m9AgBSMH8-L6rYJkwuQAyhXplnfxnvTSGzVHUR",
         },
     },
     .paths = .{

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-zig = "0.15.2"
+zig = "0.16.0"
 
 [tasks.build]
 description = "Build hola with release optimizations"

--- a/src/apply.zig
+++ b/src/apply.zig
@@ -9,13 +9,15 @@ const logger = @import("logger.zig");
 const help_formatter = @import("help_formatter.zig");
 const command_runner = @import("command_runner.zig");
 const build_options = @import("build_options");
+const global_io = @import("global_io.zig");
 
 const is_macos = builtin.os.tag == .macos;
 const is_linux = builtin.os.tag == .linux;
 
 /// Helper: find an executable by searching PATH, returning its absolute path if found.
 fn findExecutableInPath(allocator: std.mem.Allocator, names: []const []const u8) !?[]const u8 {
-    const path_env = std.process.getEnvVarOwned(allocator, "PATH") catch return null;
+    const io = global_io.io();
+    const path_env = global_io.getEnvOwned(allocator, "PATH") catch return null;
     defer allocator.free(path_env);
 
     var it = std.mem.splitScalar(u8, path_env, std.fs.path.delimiter);
@@ -25,7 +27,7 @@ fn findExecutableInPath(allocator: std.mem.Allocator, names: []const []const u8)
             const full_path = try std.fs.path.join(allocator, &.{ dir, name });
             defer allocator.free(full_path);
 
-            if (std.fs.accessAbsolute(full_path, .{})) |_| {
+            if (std.Io.Dir.accessAbsolute(io, full_path, .{})) |_| {
                 return try allocator.dupe(u8, full_path);
             } else |_| {}
         }
@@ -47,11 +49,12 @@ fn findFirstExistingJoinedPath(
     roots: []const []const u8,
     leaf: []const u8,
 ) !?[]const u8 {
+    const io = global_io.io();
     for (roots) |root| {
         const path = try std.fs.path.join(allocator, &.{ root, leaf });
         defer allocator.free(path);
 
-        std.fs.accessAbsolute(path, .{}) catch |err| switch (err) {
+        std.Io.Dir.accessAbsolute(io, path, .{}) catch |err| switch (err) {
             error.FileNotFound => continue,
             else => return err,
         };
@@ -159,7 +162,7 @@ fn runWithBootstrap(comptime Impl: type, allocator: std.mem.Allocator, opts: App
     // 1. config_root/.config/hola/provision.rb
     // 2. ~/.dotfiles/.config/hola/provision.rb
     // 3. $HOME/.config/hola/provision.rb
-    const home = try std.process.getEnvVarOwned(allocator, "HOME");
+    const home = try global_io.getEnvOwned(allocator, "HOME");
     defer allocator.free(home);
     const dotfiles_root = try std.fs.path.join(allocator, &.{ home, ".dotfiles" });
     defer allocator.free(dotfiles_root);
@@ -213,7 +216,8 @@ fn linkDotfiles(allocator: std.mem.Allocator, config_root: []const u8, dry_run: 
 
     // config_root is the dotfiles repository location
     // Check if it exists
-    std.fs.accessAbsolute(config_root, .{}) catch |err| switch (err) {
+    const io = global_io.io();
+    std.Io.Dir.accessAbsolute(io, config_root, .{}) catch |err| switch (err) {
         error.FileNotFound => {
             const msg = try std.fmt.allocPrint(allocator, "Dotfiles directory not found: {s}, skipping dotfiles linking", .{config_root});
             defer allocator.free(msg);
@@ -259,13 +263,16 @@ fn installHomebrew(allocator: std.mem.Allocator, display: *modern_display.Modern
 
             // Run homebrew install script
             const install_script = "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"";
-            var proc = std.process.Child.init(&[_][]const u8{ "/bin/bash", "-c", install_script }, allocator);
-            proc.stdout_behavior = .Inherit;
-            proc.stderr_behavior = .Inherit;
+            const io = global_io.io();
+            var proc = try std.process.spawn(io, .{
+                .argv = &[_][]const u8{ "/bin/bash", "-c", install_script },
+                .stdout = .inherit,
+                .stderr = .inherit,
+            });
 
-            const term = try proc.spawnAndWait();
+            const term = try proc.wait(io);
             switch (term) {
-                .Exited => |code| {
+                .exited => |code| {
                     if (code != 0) {
                         return error.HomebrewInstallFailed;
                     }
@@ -333,7 +340,7 @@ fn installBrewPackages(allocator: std.mem.Allocator, _: []const u8, display: *mo
     // Check if user wants to skip upgrades (default: yes, skip upgrades)
     // Only upgrade if HOMEBREW_BUNDLE_NO_UPGRADE is explicitly set to "0"
     const should_upgrade = blk: {
-        const env_val = std.process.getEnvVarOwned(allocator, "HOMEBREW_BUNDLE_NO_UPGRADE") catch break :blk false;
+        const env_val = global_io.getEnvOwned(allocator, "HOMEBREW_BUNDLE_NO_UPGRADE") catch break :blk false;
         defer allocator.free(env_val);
         break :blk std.mem.eql(u8, env_val, "0");
     };
@@ -367,6 +374,7 @@ fn installBrewPackages(allocator: std.mem.Allocator, _: []const u8, display: *mo
 
 /// Install mise and mise tools
 fn installMiseTools(allocator: std.mem.Allocator, config_root: []const u8, display: *modern_display.ModernProvisionDisplay) !void {
+    const io = global_io.io();
     // Step 1: Install mise if not installed
     const mise_path = findMise(allocator) catch |err| switch (err) {
         error.MiseNotFound => blk: {
@@ -400,7 +408,7 @@ fn installMiseTools(allocator: std.mem.Allocator, config_root: []const u8, displ
         const path = try std.fs.path.join(allocator, &.{ config_root, config_name });
         defer allocator.free(path);
 
-        std.fs.accessAbsolute(path, .{}) catch |err| switch (err) {
+        std.Io.Dir.accessAbsolute(io, path, .{}) catch |err| switch (err) {
             error.FileNotFound => continue,
             else => return err,
         };
@@ -412,7 +420,7 @@ fn installMiseTools(allocator: std.mem.Allocator, config_root: []const u8, displ
 
     // If not found in config_root, try ~/.dotfiles
     if (mise_toml_path == null) {
-        const home = try std.process.getEnvVarOwned(allocator, "HOME");
+        const home = try global_io.getEnvOwned(allocator, "HOME");
         defer allocator.free(home);
         const dotfiles_root = try std.fs.path.join(allocator, &.{ home, ".dotfiles" });
         defer allocator.free(dotfiles_root);
@@ -421,7 +429,7 @@ fn installMiseTools(allocator: std.mem.Allocator, config_root: []const u8, displ
             const path = try std.fs.path.join(allocator, &.{ dotfiles_root, config_name });
             defer allocator.free(path);
 
-            std.fs.accessAbsolute(path, .{}) catch |err| switch (err) {
+            std.Io.Dir.accessAbsolute(io, path, .{}) catch |err| switch (err) {
                 error.FileNotFound => continue,
                 else => return err,
             };
@@ -437,7 +445,7 @@ fn installMiseTools(allocator: std.mem.Allocator, config_root: []const u8, displ
                 const path = try std.fs.path.join(allocator, &.{ home, config_name });
                 defer allocator.free(path);
 
-                std.fs.accessAbsolute(path, .{}) catch |err| switch (err) {
+                std.Io.Dir.accessAbsolute(io, path, .{}) catch |err| switch (err) {
                     error.FileNotFound => continue,
                     else => return err,
                 };
@@ -468,6 +476,7 @@ fn installMiseTools(allocator: std.mem.Allocator, config_root: []const u8, displ
 
 /// Find mise executable
 fn findMise(allocator: std.mem.Allocator) ![]const u8 {
+    const io = global_io.io();
     // Check common locations
     const locations = [_][]const u8{
         "/usr/local/bin/mise",
@@ -477,18 +486,18 @@ fn findMise(allocator: std.mem.Allocator) ![]const u8 {
 
     for (locations) |path| {
         const expanded = if (path[0] == '~') blk: {
-            const home = std.process.getEnvVarOwned(allocator, "HOME") catch continue;
+            const home = global_io.getEnvOwned(allocator, "HOME") catch continue;
             defer allocator.free(home);
             break :blk try std.fmt.allocPrint(allocator, "{s}{s}", .{ home, path[1..] });
         } else try allocator.dupe(u8, path);
         defer allocator.free(expanded);
 
-        std.fs.accessAbsolute(expanded, .{}) catch continue;
+        std.Io.Dir.accessAbsolute(io, expanded, .{}) catch continue;
         return try allocator.dupe(u8, expanded);
     }
 
     // Search PATH environment variable
-    const path_env = std.process.getEnvVarOwned(allocator, "PATH") catch return error.MiseNotFound;
+    const path_env = global_io.getEnvOwned(allocator, "PATH") catch return error.MiseNotFound;
     defer allocator.free(path_env);
 
     var it = std.mem.splitScalar(u8, path_env, std.fs.path.delimiter);
@@ -497,7 +506,7 @@ fn findMise(allocator: std.mem.Allocator) ![]const u8 {
         const full_path = std.fs.path.join(allocator, &.{ dir, "mise" }) catch continue;
         defer allocator.free(full_path);
 
-        if (std.fs.accessAbsolute(full_path, .{})) |_| {
+        if (std.Io.Dir.accessAbsolute(io, full_path, .{})) |_| {
             return allocator.dupe(u8, full_path) catch return error.MiseNotFound;
         } else |_| {}
     }
@@ -506,16 +515,19 @@ fn findMise(allocator: std.mem.Allocator) ![]const u8 {
 }
 
 /// Install mise using official installer
-fn installMise(allocator: std.mem.Allocator) !void {
+fn installMise(_: std.mem.Allocator) !void {
     // Use official mise installer
     const install_script = "curl https://mise.run | sh";
-    var proc = std.process.Child.init(&[_][]const u8{ "/bin/bash", "-c", install_script }, allocator);
-    proc.stdout_behavior = .Inherit;
-    proc.stderr_behavior = .Inherit;
+    const io = global_io.io();
+    var proc = try std.process.spawn(io, .{
+        .argv = &[_][]const u8{ "/bin/bash", "-c", install_script },
+        .stdout = .inherit,
+        .stderr = .inherit,
+    });
 
-    const term = try proc.spawnAndWait();
+    const term = try proc.wait(io);
     switch (term) {
-        .Exited => |code| {
+        .exited => |code| {
             if (code != 0) {
                 return error.MiseInstallFailed;
             }
@@ -532,7 +544,8 @@ fn loadLinkConfig(allocator: std.mem.Allocator, root: []const u8) !?[]const []co
     // 1. Project directory: .hola.toml, hola.toml
     // 2. XDG config directory: ~/.config/hola/hola.toml
     const project_config_paths = [_][]const u8{ ".hola.toml", "hola.toml" };
-    var config_file: ?std.fs.File = null;
+    const io = global_io.io();
+    var config_file: ?std.Io.File = null;
     var config_path: []const u8 = undefined;
 
     // Try project directory first
@@ -540,7 +553,7 @@ fn loadLinkConfig(allocator: std.mem.Allocator, root: []const u8) !?[]const []co
         const path = try std.fs.path.join(allocator, &.{ root, config_name });
         defer allocator.free(path);
 
-        const file = std.fs.openFileAbsolute(path, .{}) catch |err| switch (err) {
+        const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch |err| switch (err) {
             error.FileNotFound => continue,
             else => return err,
         };
@@ -556,7 +569,7 @@ fn loadLinkConfig(allocator: std.mem.Allocator, root: []const u8) !?[]const []co
         const xdg_config_path = try xdg.getConfigFile();
         defer allocator.free(xdg_config_path);
 
-        if (std.fs.openFileAbsolute(xdg_config_path, .{})) |f| {
+        if (std.Io.Dir.openFileAbsolute(io, xdg_config_path, .{})) |f| {
             config_file = f;
             config_path = try allocator.dupe(u8, xdg_config_path);
         } else |err| switch (err) {
@@ -567,10 +580,12 @@ fn loadLinkConfig(allocator: std.mem.Allocator, root: []const u8) !?[]const []co
 
     // No config file found, use defaults
     const file = config_file orelse return null;
-    defer file.close();
+    defer file.close(io);
     defer allocator.free(config_path);
 
-    const content = try file.readToEndAlloc(allocator, std.math.maxInt(usize));
+    var read_buf: [4096]u8 = undefined;
+    var file_reader = file.reader(io, &read_buf);
+    const content = try file_reader.interface.allocRemaining(allocator, .unlimited);
     defer allocator.free(content);
 
     const Config = struct {

--- a/src/apt_bootstrap.zig
+++ b/src/apt_bootstrap.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const global_io = @import("global_io.zig");
 const modern_display = @import("modern_provision_display.zig");
 const logger = @import("logger.zig");
 const command_runner = @import("command_runner.zig");
@@ -27,7 +28,8 @@ pub fn installPackages(
     const apt_list_path = try std.fs.path.join(allocator, &.{ config_root, "packages.apt.txt" });
     defer allocator.free(apt_list_path);
 
-    const file = std.fs.openFileAbsolute(apt_list_path, .{}) catch |err| switch (err) {
+    const io = global_io.io();
+    const file = std.Io.Dir.openFileAbsolute(io, apt_list_path, .{}) catch |err| switch (err) {
         error.FileNotFound => {
             const msg = try std.fmt.allocPrint(allocator, "No packages.apt.txt found in {s}, skipping apt install", .{config_root});
             defer allocator.free(msg);
@@ -36,9 +38,11 @@ pub fn installPackages(
         },
         else => return err,
     };
-    defer file.close();
+    defer file.close(io);
 
-    const content = try file.readToEndAlloc(allocator, std.math.maxInt(usize));
+    var read_buf: [4096]u8 = undefined;
+    var file_reader = file.readerStreaming(io, &read_buf);
+    const content = try file_reader.interface.allocRemaining(allocator, .unlimited);
     defer allocator.free(content);
 
     var packages = std.ArrayList([]const u8).empty;

--- a/src/async_executor.zig
+++ b/src/async_executor.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const global_io = @import("global_io.zig");
 
 /// Global poll callback for UI updates during async execution
 threadlocal var global_poll_callback: ?*const fn () anyerror!void = null;
@@ -19,7 +20,7 @@ pub const AsyncExecutor = struct {
             status: std.atomic.Value(u8), // 0=running, 1=completed, 2=failed
             result: ?T = null,
             err: ?anyerror = null,
-            mutex: std.Thread.Mutex = .{},
+            mutex: std.Io.Mutex = .init,
 
             pub fn init() @This() {
                 return .{
@@ -41,16 +42,16 @@ pub const AsyncExecutor = struct {
         const Worker = struct {
             fn run(context: *Context(T)) void {
                 const result = func() catch |err| {
-                    context.mutex.lock();
+                    context.mutex.lockUncancelable(global_io.io());
                     context.err = err;
-                    context.mutex.unlock();
+                    context.mutex.unlock(global_io.io());
                     context.status.store(2, .release);
                     return;
                 };
 
-                context.mutex.lock();
+                context.mutex.lockUncancelable(global_io.io());
                 context.result = result;
-                context.mutex.unlock();
+                context.mutex.unlock(global_io.io());
                 context.status.store(1, .release);
             }
         };
@@ -65,15 +66,15 @@ pub const AsyncExecutor = struct {
                 break;
             }
             // Sleep briefly to allow main thread to update UI
-            std.Thread.sleep(50 * std.time.ns_per_ms);
+            global_io.io().sleep(.fromNanoseconds(50 * std.time.ns_per_ms), .awake) catch {};
         }
 
         // Wait for thread to complete
         thread.join();
 
         // Check result
-        ctx.mutex.lock();
-        defer ctx.mutex.unlock();
+        ctx.mutex.lockUncancelable(global_io.io());
+        defer ctx.mutex.unlock(global_io.io());
 
         if (ctx.status.load(.acquire) == 2) {
             return ctx.err orelse error.UnknownError;
@@ -107,7 +108,7 @@ pub const AsyncExecutor = struct {
             status: std.atomic.Value(u8),
             result: ?ResultType = null,
             err: ?anyerror = null,
-            mutex: std.Thread.Mutex = .{},
+            mutex: std.Io.Mutex = .init,
         };
 
         var ctx = TaskContext{
@@ -119,16 +120,16 @@ pub const AsyncExecutor = struct {
         const Worker = struct {
             fn run(task_ctx: *TaskContext) void {
                 const result = func(task_ctx.user_context) catch |err| {
-                    task_ctx.mutex.lock();
+                    task_ctx.mutex.lockUncancelable(global_io.io());
                     task_ctx.err = err;
-                    task_ctx.mutex.unlock();
+                    task_ctx.mutex.unlock(global_io.io());
                     task_ctx.status.store(2, .release);
                     return;
                 };
 
-                task_ctx.mutex.lock();
+                task_ctx.mutex.lockUncancelable(global_io.io());
                 task_ctx.result = result;
-                task_ctx.mutex.unlock();
+                task_ctx.mutex.unlock(global_io.io());
                 task_ctx.status.store(1, .release);
             }
         };
@@ -150,15 +151,15 @@ pub const AsyncExecutor = struct {
             }
 
             // Sleep briefly to yield to main thread
-            std.Thread.sleep(50 * std.time.ns_per_ms);
+            global_io.io().sleep(.fromNanoseconds(50 * std.time.ns_per_ms), .awake) catch {};
         }
 
         // Wait for thread to complete
         thread.join();
 
         // Check result
-        ctx.mutex.lock();
-        defer ctx.mutex.unlock();
+        ctx.mutex.lockUncancelable(global_io.io());
+        defer ctx.mutex.unlock(global_io.io());
 
         if (ctx.status.load(.acquire) == 2) {
             return ctx.err orelse error.UnknownError;

--- a/src/base_resource.zig
+++ b/src/base_resource.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const mruby = @import("mruby.zig");
 pub const notification = @import("notification.zig");
 const builtin = @import("builtin");
+const global_io = @import("global_io.zig");
 
 // Guards (only_if/not_if) run arbitrary shell commands; a stuck one (e.g.
 // `only_if "sleep 99999"`) must not hang provisioning forever. Bound them with
@@ -194,18 +195,11 @@ pub const CommonProps = struct {
     /// Execute a shell command and return true if exit code is 0
     /// Optionally runs as specified user/group
     fn executeShellCommand(command: []const u8, user: ?[]const u8, group: ?[]const u8) !bool {
-        // Use ArenaAllocator for temporary allocations (matches pattern in execute.zig)
-        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-        defer arena.deinit();
-        const temp_allocator = arena.allocator();
+        const io = global_io.io();
 
-        var child = std.process.Child.init(&[_][]const u8{ "/bin/sh", "-c", command }, temp_allocator);
-        child.stdin_behavior = .Ignore;
-        child.stdout_behavior = .Ignore;
-        child.stderr_behavior = .Ignore;
-        child.pgid = 0; // own process group, so a timeout can signal the whole tree
-
-        // Set user and/or group if specified (same logic as execute resource)
+        // Resolve user/group to uid/gid before spawning (same logic as execute resource)
+        var uid: ?std.posix.uid_t = null;
+        var gid: ?std.posix.gid_t = null;
         if (user != null or group != null) {
             const c = @cImport({
                 @cInclude("pwd.h");
@@ -227,8 +221,8 @@ pub const CommonProps = struct {
                     return error.UserNotFound;
                 }
 
-                child.uid = @intCast(pwd.*.pw_uid);
-                child.gid = @intCast(pwd.*.pw_gid);
+                uid = @intCast(pwd.*.pw_uid);
+                gid = @intCast(pwd.*.pw_gid);
             }
 
             // Override with group if specified
@@ -246,45 +240,51 @@ pub const CommonProps = struct {
                     return error.GroupNotFound;
                 }
 
-                child.gid = @intCast(grp.*.gr_gid);
+                gid = @intCast(grp.*.gr_gid);
             }
         }
 
-        try child.spawn();
-        // A pre-exec failure makes the forked child _exit(); reap it so the
-        // error path doesn't leave a zombie. stdio is .Ignore, so there are no
-        // parent-held pipes to close.
-        child.waitForSpawn() catch |err| {
-            reapGuardChild(child.id);
-            return err;
-        };
+        // A pre-exec failure is reported by spawn itself (which reaps the
+        // forked child); stdio is .ignore, so there are no parent-held pipes.
+        const child = try std.process.spawn(io, .{
+            .argv = &[_][]const u8{ "/bin/sh", "-c", command },
+            .stdin = .ignore,
+            .stdout = .ignore,
+            .stderr = .ignore,
+            .pgid = 0, // own process group, so a timeout can signal the whole tree
+            .uid = uid,
+            .gid = gid,
+        });
 
-        const term = waitGuardWithTimeout(child.id);
+        const child_pid = child.id orelse return error.SpawnFailed;
+        const term = waitGuardWithTimeout(child_pid);
 
         return switch (term) {
-            .Exited => |code| code == 0,
+            .exited => |code| code == 0,
             else => false, // signalled / timed out / unknown => treat as non-zero
         };
     }
 
     fn termFromStatus(status: u32) std.process.Child.Term {
         return if (std.posix.W.IFEXITED(status))
-            .{ .Exited = std.posix.W.EXITSTATUS(status) }
+            .{ .exited = std.posix.W.EXITSTATUS(status) }
         else if (std.posix.W.IFSIGNALED(status))
-            .{ .Signal = std.posix.W.TERMSIG(status) }
+            .{ .signal = std.posix.W.TERMSIG(status) }
         else if (std.posix.W.IFSTOPPED(status))
-            .{ .Stopped = std.posix.W.STOPSIG(status) }
+            .{ .stopped = std.posix.W.STOPSIG(status) }
         else
-            .{ .Unknown = status };
+            .{ .unknown = status };
     }
 
     /// Best-effort non-blocking reap for an already-dead child.
     fn reapGuardChild(pid: std.posix.pid_t) void {
-        const deadline = std.time.milliTimestamp() + GUARD_REAP_GRACE_MS;
-        while (std.time.milliTimestamp() < deadline) {
-            const res = std.posix.waitpid(pid, std.posix.W.NOHANG);
-            if (res.pid != 0) return;
-            std.Thread.sleep(GUARD_POLL_INTERVAL_MS * std.time.ns_per_ms);
+        const io = global_io.io();
+        const deadline = std.Io.Timestamp.now(io, .real).toMilliseconds() + GUARD_REAP_GRACE_MS;
+        while (std.Io.Timestamp.now(io, .real).toMilliseconds() < deadline) {
+            var status: c_int = 0;
+            const res = std.c.waitpid(pid, &status, std.posix.W.NOHANG);
+            if (res > 0) return;
+            io.sleep(.fromNanoseconds(GUARD_POLL_INTERVAL_MS * std.time.ns_per_ms), .awake) catch {};
         }
     }
 
@@ -294,16 +294,18 @@ pub const CommonProps = struct {
     /// indefinitely — if the child is unresponsive even to SIGKILL we abandon it.
     fn waitGuardWithTimeout(pid: std.posix.pid_t) std.process.Child.Term {
         const logger = @import("logger.zig");
-        const deadline = std.time.milliTimestamp() + @as(i64, GUARD_TIMEOUT_S) * std.time.ms_per_s;
+        const io = global_io.io();
+        const deadline = std.Io.Timestamp.now(io, .real).toMilliseconds() + @as(i64, GUARD_TIMEOUT_S) * std.time.ms_per_s;
         var timed_out = false;
         var kill_deadline_ms: ?i64 = null;
         var give_up_deadline_ms: ?i64 = null;
 
         while (true) {
-            const res = std.posix.waitpid(pid, std.posix.W.NOHANG);
-            if (res.pid != 0) return termFromStatus(res.status);
+            var status: c_int = 0;
+            const res = std.c.waitpid(pid, &status, std.posix.W.NOHANG);
+            if (res > 0) return termFromStatus(@bitCast(status));
 
-            const now = std.time.milliTimestamp();
+            const now = std.Io.Timestamp.now(io, .real).toMilliseconds();
             if (!timed_out) {
                 if (now >= deadline) {
                     timed_out = true;
@@ -322,11 +324,11 @@ pub const CommonProps = struct {
                 if (give_up_deadline_ms) |gd| {
                     if (now >= gd) {
                         logger.warn("guard: child {d} unresponsive after SIGKILL; abandoning", .{pid});
-                        return .{ .Unknown = 0 };
+                        return .{ .unknown = 0 };
                     }
                 }
             }
-            std.Thread.sleep(GUARD_POLL_INTERVAL_MS * std.time.ns_per_ms);
+            io.sleep(.fromNanoseconds(GUARD_POLL_INTERVAL_MS * std.time.ns_per_ms), .awake) catch {};
         }
     }
 
@@ -531,7 +533,8 @@ pub const FileAttributes = struct {
 /// Uses AT_FDCWD to work with the current working directory
 /// Silently ignores errors to maintain backward compatibility
 pub fn setFileMode(file_path: []const u8, mode: u32) void {
-    std.posix.fchmodat(std.posix.AT.FDCWD, file_path, @as(std.posix.mode_t, @intCast(mode)), 0) catch {};
+    const path_z = std.posix.toPosixPath(file_path) catch return;
+    _ = std.c.fchmodat(std.posix.AT.FDCWD, &path_z, @as(std.posix.mode_t, @intCast(mode)), 0);
 }
 
 /// Set file owner (user) for a given file path
@@ -545,12 +548,13 @@ pub fn setFileOwner(file_path: []const u8, owner: []const u8) !void {
     // Get UID from username
     const uid = try getUserId(owner);
 
-    // Get current GID (we're not changing group) using fstatat
-    const stat = try std.posix.fstatat(std.posix.AT.FDCWD, file_path, 0);
-    const gid = stat.gid;
+    // POSIX: (gid_t)-1 leaves the group unchanged - no stat needed
+    // (std.c.stat is unavailable on linux and musl's struct stat does not
+    // survive translate-c).
+    const path_z = try std.posix.toPosixPath(file_path);
+    const gid: std.posix.gid_t = @bitCast(@as(i32, -1));
 
     // Change ownership
-    const path_z = try std.posix.toPosixPath(file_path);
     if (c.chown(&path_z, uid, gid) != 0) {
         return error.ChownFailed;
     }
@@ -565,12 +569,11 @@ pub fn setFileGroup(file_path: []const u8, group: []const u8) !void {
     // Get GID from group name
     const gid = try getGroupId(group);
 
-    // Get current UID (we're not changing owner) using fstatat
-    const stat = try std.posix.fstatat(std.posix.AT.FDCWD, file_path, 0);
-    const uid = stat.uid;
+    // POSIX: (uid_t)-1 leaves the owner unchanged - no stat needed.
+    const path_z = try std.posix.toPosixPath(file_path);
+    const uid: std.posix.uid_t = @bitCast(@as(i32, -1));
 
     // Change ownership
-    const path_z = try std.posix.toPosixPath(file_path);
     if (c.chown(&path_z, uid, gid) != 0) {
         return error.ChownFailed;
     }
@@ -582,12 +585,12 @@ pub fn setFileOwnerAndGroup(file_path: []const u8, owner: ?[]const u8, group: ?[
         @cInclude("unistd.h");
     });
 
-    const stat = try std.posix.fstatat(std.posix.AT.FDCWD, file_path, 0);
-
-    const uid = if (owner) |o| try getUserId(o) else stat.uid;
-    const gid = if (group) |g| try getGroupId(g) else stat.gid;
-
     const path_z = try std.posix.toPosixPath(file_path);
+
+    // POSIX: an id of -1 leaves that field unchanged - no stat needed.
+    const uid: std.posix.uid_t = if (owner) |o| try getUserId(o) else @bitCast(@as(i32, -1));
+    const gid: std.posix.gid_t = if (group) |g| try getGroupId(g) else @bitCast(@as(i32, -1));
+
     if (c.chown(&path_z, uid, gid) != 0) {
         return error.ChownFailed;
     }
@@ -641,39 +644,43 @@ pub fn getGroupId(groupname: []const u8) !std.posix.gid_t {
 /// Returns void and closes the backup file properly to prevent fd leaks
 /// If the original file doesn't exist, returns error.FileNotFound
 pub fn createBackup(allocator: std.mem.Allocator, file_path: []const u8, backup_ext: []const u8) !void {
+    const io = global_io.io();
     const backup_path = try std.fmt.allocPrint(allocator, "{s}.{s}", .{ file_path, backup_ext });
     defer allocator.free(backup_path);
 
     // Open original file for reading
-    const original = std.fs.cwd().openFile(file_path, .{}) catch |err| switch (err) {
+    const original = std.Io.Dir.cwd().openFile(io, file_path, .{}) catch |err| switch (err) {
         error.FileNotFound => return error.FileNotFound, // No file to backup
         else => return err,
     };
-    defer original.close();
+    defer original.close(io);
 
     // Create backup file (with parent directories if needed)
     const backup = blk: {
-        if (std.fs.cwd().createFile(backup_path, .{ .truncate = true })) |file| {
+        if (std.Io.Dir.cwd().createFile(io, backup_path, .{ .truncate = true })) |file| {
             break :blk file;
         } else |err| {
             if (err == error.FileNotFound) {
                 if (std.fs.path.dirname(backup_path)) |dir| {
-                    try std.fs.cwd().makePath(dir);
+                    try std.Io.Dir.cwd().createDirPath(io, dir);
                 }
-                break :blk try std.fs.cwd().createFile(backup_path, .{ .truncate = true });
+                break :blk try std.Io.Dir.cwd().createFile(io, backup_path, .{ .truncate = true });
             }
             return err;
         }
     };
-    defer backup.close(); // Properly close to prevent fd leak
+    defer backup.close(io); // Properly close to prevent fd leak
 
-    // Copy file contents in chunks
-    var buf: [4096]u8 = undefined;
-    while (true) {
-        const bytes_read = try original.read(&buf);
-        if (bytes_read == 0) break;
-        try backup.writeAll(buf[0..bytes_read]);
-    }
+    // Copy file contents from original to backup
+    var read_buf: [4096]u8 = undefined;
+    var original_reader = original.reader(io, &read_buf);
+    var write_buf: [4096]u8 = undefined;
+    var backup_writer = backup.writer(io, &write_buf);
+    _ = original_reader.interface.streamRemaining(&backup_writer.interface) catch |err| switch (err) {
+        error.ReadFailed => return original_reader.err.?,
+        error.WriteFailed => return backup_writer.err.?,
+    };
+    backup_writer.interface.flush() catch return backup_writer.err.?;
 }
 
 /// Ensure the parent directory for `path` exists, handling absolute and relative paths.
@@ -686,14 +693,15 @@ pub fn ensureParentDir(path: []const u8) !void {
 
 /// Ensure the provided path exists as a directory (creates parents as needed).
 pub fn ensurePath(path: []const u8) !void {
+    const io = global_io.io();
     if (std.fs.path.isAbsolute(path)) {
-        std.fs.makeDirAbsolute(path) catch |err| switch (err) {
+        std.Io.Dir.createDirAbsolute(io, path, .default_dir) catch |err| switch (err) {
             error.PathAlreadyExists => {},
             error.FileNotFound => {
                 if (std.fs.path.dirname(path)) |parent| {
                     if (parent.len == 0) return err;
                     try ensurePath(parent);
-                    try std.fs.makeDirAbsolute(path);
+                    try std.Io.Dir.createDirAbsolute(io, path, .default_dir);
                 } else {
                     return err;
                 }
@@ -701,6 +709,6 @@ pub fn ensurePath(path: []const u8) !void {
             else => return err,
         };
     } else {
-        try std.fs.cwd().makePath(path);
+        try std.Io.Dir.cwd().createDirPath(io, path);
     }
 }

--- a/src/brew.zig
+++ b/src/brew.zig
@@ -5,6 +5,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const global_io = @import("global_io.zig");
 
 // Only compile on macOS
 comptime {
@@ -28,14 +29,15 @@ pub fn findBrew(allocator: std.mem.Allocator) Error![]const u8 {
         "/home/linuxbrew/.linuxbrew/bin/brew",
     };
 
+    const io = global_io.io();
     for (locations) |path| {
-        const file = std.fs.openFileAbsolute(path, .{}) catch continue;
-        file.close();
+        const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch continue;
+        file.close(io);
         return try allocator.dupe(u8, path);
     }
 
     // Search PATH environment variable
-    const path_env = std.process.getEnvVarOwned(allocator, "PATH") catch return Error.BrewNotFound;
+    const path_env = global_io.getEnvOwned(allocator, "PATH") catch return Error.BrewNotFound;
     defer allocator.free(path_env);
 
     var it = std.mem.splitScalar(u8, path_env, std.fs.path.delimiter);
@@ -44,7 +46,7 @@ pub fn findBrew(allocator: std.mem.Allocator) Error![]const u8 {
         const full_path = std.fs.path.join(allocator, &.{ dir, "brew" }) catch continue;
         defer allocator.free(full_path);
 
-        if (std.fs.accessAbsolute(full_path, .{})) |_| {
+        if (std.Io.Dir.accessAbsolute(io, full_path, .{})) |_| {
             return allocator.dupe(u8, full_path) catch return Error.BrewNotFound;
         } else |_| {}
     }

--- a/src/cf.zig
+++ b/src/cf.zig
@@ -1,6 +1,24 @@
 // Global CoreFoundation bindings
 // Import this instead of doing @cImport in each file to ensure constants have consistent addresses
 
+// Note: zig 0.16's translate-c cannot handle the mach_msg descriptor types
+// pulled in by the CoreFoundation.h umbrella header (via CFRunLoop/CFMachPort),
+// so include only the specific headers this codebase uses.
 pub const c = @cImport({
-    @cInclude("CoreFoundation/CoreFoundation.h");
+    // Skip mach/message.h: its descriptor types are untranslatable and its
+    // eager _Static_asserts fail under translate-c. Nothing here needs
+    // mach messaging (pulled in only via CFPropertyList -> CFStream -> CFRunLoop).
+    @cDefine("_MACH_MESSAGE_H_", "1");
+    @cInclude("CoreFoundation/CFBase.h");
+    @cInclude("CoreFoundation/CFString.h");
+    @cInclude("CoreFoundation/CFArray.h");
+    @cInclude("CoreFoundation/CFDictionary.h");
+    @cInclude("CoreFoundation/CFData.h");
+    @cInclude("CoreFoundation/CFDate.h");
+    @cInclude("CoreFoundation/CFNumber.h");
+    @cInclude("CoreFoundation/CFPreferences.h");
+    @cInclude("CoreFoundation/CFPropertyList.h");
+    @cInclude("CoreFoundation/CFURL.h");
+    @cInclude("CoreFoundation/CFURLAccess.h");
+    @cInclude("CoreFoundation/CFError.h");
 });

--- a/src/command_runner.zig
+++ b/src/command_runner.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const global_io = @import("global_io.zig");
 const logger = @import("logger.zig");
 
 /// Execute a command with real-time output and log it via logger.logCommand.
@@ -25,26 +26,25 @@ pub fn executeCommandWithLogging(
     // Show command being executed.
     std.debug.print("\x1b[90m$ {s}\x1b[0m\n", .{cmd_str});
 
-    var proc = std.process.Child.init(args, allocator);
-    if (cwd) |dir| {
-        proc.cwd = dir;
-    }
+    const io = global_io.io();
     // Inherit stdout/stderr for real-time output.
-    proc.stdout_behavior = .Inherit;
-    proc.stderr_behavior = .Inherit;
-
-    try proc.spawn();
-    const term = try proc.wait();
+    var proc = try std.process.spawn(io, .{
+        .argv = args,
+        .cwd = if (cwd) |dir| .{ .path = dir } else .inherit,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    });
+    const term = try proc.wait(io);
 
     const exit_code: ?i32 = switch (term) {
-        .Exited => |code| code,
+        .exited => |code| code,
         else => null,
     };
 
     logger.logCommand(cmd_str, "", "", exit_code);
 
     switch (term) {
-        .Exited => |code| {
+        .exited => |code| {
             if (code != 0) return error.CommandFailed;
         },
         else => return error.CommandFailed,

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -5,6 +5,7 @@ const provision_cmd = @import("provision.zig");
 const provision = @import("../provision.zig");
 const base_resource = @import("../base_resource.zig");
 const node_info = @import("../node_info.zig");
+const global_io = @import("../global_io.zig");
 
 const params = clap.parseParamsComptime(
     \\-h, --help                 Show help for agent
@@ -129,7 +130,7 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
     // Check expiration
     if (obj.get("expires_at")) |ea| {
         if (ea == .string) {
-            const now = std.time.timestamp();
+            const now = std.Io.Timestamp.now(global_io.io(), .real).toSeconds();
             const expires = parseIso8601(ea.string) catch |err| {
                 std.debug.print("[agent] invalid expires_at: {s} ({})\n", .{ ea.string, err });
                 return;
@@ -232,57 +233,57 @@ fn buildCallbackBody(allocator: std.mem.Allocator, event_data: []const u8, statu
     _ = obj.fetchSwapRemove("callback");
     _ = obj.fetchSwapRemove("secrets");
 
-    var result = std.json.ObjectMap.init(aa);
-    try result.put("status", .{ .string = status });
+    var result: std.json.ObjectMap = .empty;
+    try result.put(aa, "status", .{ .string = status });
     if (err_msg) |msg| {
-        try result.put("error", .{ .string = msg });
+        try result.put(aa, "error", .{ .string = msg });
     }
     if (err_detail) |detail| {
-        try result.put("error_message", .{ .string = detail });
+        try result.put(aa, "error_message", .{ .string = detail });
     }
 
     if (prov_result) |pr| {
-        try result.put("executed", .{ .integer = @intCast(pr.executed_count) });
-        try result.put("updated", .{ .integer = @intCast(pr.updated_count) });
-        try result.put("skipped", .{ .integer = @intCast(pr.skipped_count) });
-        try result.put("failed", .{ .integer = @intCast(pr.failed_count) });
-        try result.put("duration_ms", .{ .integer = pr.duration_ms });
+        try result.put(aa, "executed", .{ .integer = @intCast(pr.executed_count) });
+        try result.put(aa, "updated", .{ .integer = @intCast(pr.updated_count) });
+        try result.put(aa, "skipped", .{ .integer = @intCast(pr.skipped_count) });
+        try result.put(aa, "failed", .{ .integer = @intCast(pr.failed_count) });
+        try result.put(aa, "duration_ms", .{ .integer = pr.duration_ms });
 
         var resources_arr = std.json.Array.init(aa);
         for (pr.resource_results.items) |rr| {
-            var res_obj = std.json.ObjectMap.init(aa);
-            try res_obj.put("type", .{ .string = rr.type_name });
-            try res_obj.put("name", .{ .string = rr.name });
-            try res_obj.put("action", .{ .string = rr.action });
-            try res_obj.put("updated", .{ .bool = rr.was_updated });
+            var res_obj: std.json.ObjectMap = .empty;
+            try res_obj.put(aa, "type", .{ .string = rr.type_name });
+            try res_obj.put(aa, "name", .{ .string = rr.name });
+            try res_obj.put(aa, "action", .{ .string = rr.action });
+            try res_obj.put(aa, "updated", .{ .bool = rr.was_updated });
             if (rr.skipped) {
-                try res_obj.put("skipped", .{ .bool = true });
+                try res_obj.put(aa, "skipped", .{ .bool = true });
             }
             if (rr.skip_reason) |sr| {
-                try res_obj.put("skip_reason", .{ .string = sr });
+                try res_obj.put(aa, "skip_reason", .{ .string = sr });
             }
             if (rr.error_name) |en| {
-                try res_obj.put("error", .{ .string = en });
+                try res_obj.put(aa, "error", .{ .string = en });
             }
             if (rr.error_message) |em| {
-                try res_obj.put("error_message", .{ .string = em });
+                try res_obj.put(aa, "error_message", .{ .string = em });
             }
             if (rr.output) |o| {
-                try res_obj.put("output", .{ .string = o });
+                try res_obj.put(aa, "output", .{ .string = o });
             }
             try resources_arr.append(.{ .object = res_obj });
         }
-        try result.put("resources", .{ .array = resources_arr });
+        try result.put(aa, "resources", .{ .array = resources_arr });
     }
 
-    try obj.put("result", .{ .object = result });
+    try obj.put(aa, "result", .{ .object = result });
 
     const node = node_info.getNodeInfo(aa) catch null;
     if (node) |n| {
         const node_json = try std.fmt.allocPrint(aa, "{f}", .{std.json.fmt(n, .{})});
         const node_parsed = try std.json.parseFromSlice(std.json.Value, aa, node_json, .{});
         const node_clone = try cloneJsonValue(aa, node_parsed.value);
-        try obj.put("node", node_clone);
+        try obj.put(aa, "node", node_clone);
     }
 
     const body = try std.fmt.allocPrint(aa, "{f}", .{std.json.fmt(std.json.Value{ .object = obj }, .{})});
@@ -306,12 +307,12 @@ fn cloneJsonValue(allocator: std.mem.Allocator, value: std.json.Value) !std.json
             break :blk .{ .array = new_arr };
         },
         .object => |obj| blk: {
-            var new_obj = std.json.ObjectMap.init(allocator);
+            var new_obj: std.json.ObjectMap = .empty;
             var it = obj.iterator();
             while (it.next()) |entry| {
                 const key = try allocator.dupe(u8, entry.key_ptr.*);
                 const val = try cloneJsonValue(allocator, entry.value_ptr.*);
-                try new_obj.put(key, val);
+                try new_obj.put(allocator, key, val);
             }
             break :blk .{ .object = new_obj };
         },
@@ -386,7 +387,7 @@ fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []c
     while (true) {
         wsConnect(allocator, ws_endpoint, node_name, default_callback, tls_auth, heartbeat) catch {
             std.debug.print("[agent] reconnecting in {d}ms...\n", .{backoff_ms});
-            std.Thread.sleep(backoff_ms * std.time.ns_per_ms);
+            global_io.io().sleep(.fromNanoseconds(backoff_ms * std.time.ns_per_ms), .awake) catch {};
             backoff_ms = @min(backoff_ms * 2, MAX_BACKOFF_MS);
             continue;
         };
@@ -398,6 +399,7 @@ fn runSseMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []c
 
 fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []const u8, default_callback: ?[]const u8, tls_auth: TlsClientAuth, heartbeat: bool) !void {
     const curl = @import("../curl.zig");
+    const io = global_io.io();
     const handle = curl.curl_easy_init() orelse return error.ConnectionFailed;
     defer curl.curl_easy_cleanup(handle);
 
@@ -470,7 +472,7 @@ fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []co
     var msg_buf = std.ArrayList(u8).empty;
     defer msg_buf.deinit(allocator);
 
-    var last_rx: i64 = std.time.milliTimestamp();
+    var last_rx: i64 = std.Io.Timestamp.now(io, .real).toMilliseconds();
     var last_ping: i64 = last_rx;
 
     while (true) {
@@ -487,7 +489,7 @@ fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []co
                 std.debug.print("[agent] WebSocket recv error: {s}\n", .{std.mem.span(curl.curl_easy_strerror(recv_rc))});
                 return error.ConnectionFailed;
             }
-            last_rx = std.time.milliTimestamp();
+            last_rx = std.Io.Timestamp.now(io, .real).toMilliseconds();
 
             const m = meta orelse continue :drain;
             const flags: c_uint = @bitCast(m.flags);
@@ -513,12 +515,12 @@ fn wsConnect(allocator: std.mem.Allocator, endpoint: []const u8, node_name: []co
                 msg_buf.clearRetainingCapacity();
                 // A task can run for minutes inside handleWsMessage; don't
                 // count that time as idle or we'd tear down a live connection.
-                last_rx = std.time.milliTimestamp();
+                last_rx = std.Io.Timestamp.now(io, .real).toMilliseconds();
                 last_ping = last_rx;
             }
         }
 
-        const now = std.time.milliTimestamp();
+        const now = std.Io.Timestamp.now(io, .real).toMilliseconds();
         if (heartbeat and now - last_rx > WS_IDLE_TIMEOUT_MS) {
             std.debug.print("[agent] no data for {d}s, assuming dead connection\n", .{@divTrunc(now - last_rx, 1000)});
             return error.ConnectionFailed;
@@ -577,7 +579,7 @@ fn runWatchMode(allocator: std.mem.Allocator, endpoint: []const u8, node_name: [
 
     while (true) {
         pollOnce(allocator, endpoint, node_name, default_callback, tls_auth);
-        std.Thread.sleep(@as(u64, interval_s) * std.time.ns_per_s);
+        global_io.io().sleep(.fromNanoseconds(@as(u64, interval_s) * std.time.ns_per_s), .awake) catch {};
     }
 }
 
@@ -652,13 +654,13 @@ fn getDefaultNodeName(allocator: std.mem.Allocator) []const u8 {
     return node_info.getHostname(allocator) catch "unknown";
 }
 
-pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
+pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
     var diag = clap.Diagnostic{};
     var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
         .allocator = allocator,
         .diagnostic = &diag,
     }) catch |err| {
-        try diag.reportToFile(std.fs.File.stderr(), err);
+        try diag.reportToFile(global_io.io(), std.Io.File.stderr(), err);
         return;
     };
     defer res.deinit();
@@ -694,12 +696,13 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
 }
 
 fn printHelp(reason: ?[]const u8) !void {
-    const out = std.fs.File.stdout();
+    const io = global_io.io();
+    const out = std.Io.File.stdout();
     if (reason) |msg| {
-        try out.writeAll(msg);
-        try out.writeAll("\n\n");
+        try out.writeStreamingAll(io, msg);
+        try out.writeStreamingAll(io, "\n\n");
     }
-    try out.writeAll(
+    try out.writeStreamingAll(io,
         \\agent
         \\  hola agent [OPTIONS] <endpoint>
         \\

--- a/src/commands/applescript.zig
+++ b/src/commands/applescript.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const clap = @import("clap");
 const applescript = @import("../applescript.zig");
+const global_io = @import("../global_io.zig");
 
 const params = clap.parseParamsComptime(
     \\-h, --help            Show help for applescript
@@ -14,13 +15,13 @@ const parsers = .{
     .script = clap.parsers.string,
 };
 
-pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
+pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
     var diag = clap.Diagnostic{};
     var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
         .allocator = allocator,
         .diagnostic = &diag,
     }) catch |err| {
-        try diag.reportToFile(std.fs.File.stderr(), err);
+        try diag.reportToFile(global_io.io(), std.Io.File.stderr(), err);
         return;
     };
     defer res.deinit();
@@ -32,13 +33,16 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
     defer if (script_owned) |s| allocator.free(s);
 
     if (res.args.file) |file_path| {
-        const file = std.fs.openFileAbsolute(file_path, .{}) catch |err| {
+        const io = global_io.io();
+        const file = std.Io.Dir.openFileAbsolute(io, file_path, .{}) catch |err| {
             std.debug.print("Error opening file '{s}': {}\n", .{ file_path, err });
             return;
         };
-        defer file.close();
+        defer file.close(io);
 
-        script_owned = try file.readToEndAlloc(allocator, std.math.maxInt(usize));
+        var read_buf: [4096]u8 = undefined;
+        var file_reader = file.reader(io, &read_buf);
+        script_owned = try file_reader.interface.allocRemaining(allocator, .unlimited);
         script_source = script_owned.?;
     } else {
         script_source = res.positionals[0] orelse return printHelp("Missing script argument.");
@@ -58,12 +62,13 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
 }
 
 fn printHelp(reason: ?[]const u8) !void {
-    const out = std.fs.File.stdout();
+    const io = global_io.io();
+    const out = std.Io.File.stdout();
     if (reason) |msg| {
-        try out.writeAll(msg);
-        try out.writeAll("\n\n");
+        try out.writeStreamingAll(io, msg);
+        try out.writeStreamingAll(io, "\n\n");
     }
-    try out.writeAll(
+    try out.writeStreamingAll(io,
         \\applescript
         \\  hola applescript <script> [--file <path>]
         \\

--- a/src/commands/apply.zig
+++ b/src/commands/apply.zig
@@ -5,15 +5,17 @@ const http = @import("../http.zig");
 const apply_module = @import("../apply.zig");
 const logger = @import("../logger.zig");
 const dotfiles_paths = @import("../dotfiles_paths.zig");
+const global_io = @import("../global_io.zig");
 
 /// Check if clone destination exists and is non-empty
 fn checkCloneDestination(dest: []const u8) !void {
-    if (std.fs.openDirAbsolute(dest, .{ .iterate = true })) |dir_handle| {
+    const io = global_io.io();
+    if (std.Io.Dir.openDirAbsolute(io, dest, .{ .iterate = true })) |dir_handle| {
         var dir = dir_handle;
-        defer dir.close();
+        defer dir.close(io);
 
         var iter_dir = dir.iterate();
-        if (try iter_dir.next()) |_| {
+        if (try iter_dir.next(io)) |_| {
             std.debug.print("Warning: {s} already exists and is not empty\n", .{dest});
             std.debug.print("Please remove it first or use --dotfiles to specify a different location\n", .{});
             return error.DotfilesAlreadyExists;
@@ -110,20 +112,20 @@ const parsers = .{
     .name = clap.parsers.string,
 };
 
-pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
+pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
     var diag = clap.Diagnostic{};
     var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
         .allocator = allocator,
         .diagnostic = &diag,
     }) catch |err| {
-        try diag.reportToFile(std.fs.File.stderr(), err);
+        try diag.reportToFile(global_io.io(), std.Io.File.stderr(), err);
         return;
     };
     defer res.deinit();
 
     if (res.args.help != 0) return printHelp(null);
 
-    const home = try std.process.getEnvVarOwned(allocator, "HOME");
+    const home = try global_io.getEnvOwned(allocator, "HOME");
     defer allocator.free(home);
 
     const dry_run = @field(res.args, "dry-run") != 0;
@@ -189,12 +191,13 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
 }
 
 fn printHelp(reason: ?[]const u8) !void {
-    const out = std.fs.File.stdout();
+    const io = global_io.io();
+    const out = std.Io.File.stdout();
     if (reason) |msg| {
-        try out.writeAll(msg);
-        try out.writeAll("\n\n");
+        try out.writeStreamingAll(io, msg);
+        try out.writeStreamingAll(io, "\n\n");
     }
-    try out.writeAll(
+    try out.writeStreamingAll(io,
         \\apply
         \\  hola apply [OPTIONS]
         \\

--- a/src/commands/dock.zig
+++ b/src/commands/dock.zig
@@ -1,9 +1,8 @@
 const std = @import("std");
 const plist = @import("../plist.zig");
+const global_io = @import("../global_io.zig");
 
-const c_cf = @cImport({
-    @cInclude("CoreFoundation/CoreFoundation.h");
-});
+const c_cf = @import("../cf.zig").c;
 
 /// Read a dock preference from a specific host domain (AnyHost or CurrentHost).
 fn readDockPrefFromHost(alloc: std.mem.Allocator, key: []const u8, host: c_cf.CFStringRef) !?plist.Value {
@@ -118,10 +117,10 @@ fn readDockPref(alloc: std.mem.Allocator, key: []const u8) !?plist.Value {
     return null;
 }
 
-pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
+pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
     _ = iter;
 
-    const home_dir = std.process.getEnvVarOwned(allocator, "HOME") catch {
+    const home_dir = global_io.getEnvOwned(allocator, "HOME") catch {
         std.debug.print("Error: HOME environment variable not set\n", .{});
         return;
     };
@@ -277,13 +276,13 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
     }
 
     try output.appendSlice(allocator, "  ]\n");
-    try std.fmt.format(output.writer(allocator), "  orientation :{s}\n", .{orientation});
-    try std.fmt.format(output.writer(allocator), "  autohide {s}\n", .{if (autohide) "true" else "false"});
-    try std.fmt.format(output.writer(allocator), "  magnification {s}\n", .{if (magnification) "true" else "false"});
-    try std.fmt.format(output.writer(allocator), "  tilesize {d}\n", .{tilesize});
-    try std.fmt.format(output.writer(allocator), "  largesize {d}\n", .{largesize});
+    try output.print(allocator, "  orientation :{s}\n", .{orientation});
+    try output.print(allocator, "  autohide {s}\n", .{if (autohide) "true" else "false"});
+    try output.print(allocator, "  magnification {s}\n", .{if (magnification) "true" else "false"});
+    try output.print(allocator, "  tilesize {d}\n", .{tilesize});
+    try output.print(allocator, "  largesize {d}\n", .{largesize});
     try output.appendSlice(allocator, "end\n");
 
-    const stdout = std.fs.File.stdout();
-    try stdout.writeAll(output.items);
+    const stdout = std.Io.File.stdout();
+    try stdout.writeStreamingAll(global_io.io(), output.items);
 }

--- a/src/commands/git_clone.zig
+++ b/src/commands/git_clone.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const clap = @import("clap");
 const git = @import("../git.zig");
 const http = @import("../http.zig");
+const global_io = @import("../global_io.zig");
 
 const params = clap.parseParamsComptime(
     \\-h, --help            Show help for git-clone
@@ -20,13 +21,13 @@ const parsers = .{
     .dest = clap.parsers.string,
 };
 
-pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
+pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
     var diag = clap.Diagnostic{};
     var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
         .allocator = allocator,
         .diagnostic = &diag,
     }) catch |err| {
-        try diag.reportToFile(std.fs.File.stderr(), err);
+        try diag.reportToFile(global_io.io(), std.Io.File.stderr(), err);
         return;
     };
     defer res.deinit();
@@ -53,12 +54,13 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
 }
 
 fn printHelp(reason: ?[]const u8) !void {
-    const out = std.fs.File.stdout();
+    const io = global_io.io();
+    const out = std.Io.File.stdout();
     if (reason) |msg| {
-        try out.writeAll(msg);
-        try out.writeAll("\n\n");
+        try out.writeStreamingAll(io, msg);
+        try out.writeStreamingAll(io, "\n\n");
     }
-    try out.writeAll(
+    try out.writeStreamingAll(io,
         \\git-clone
         \\  hola git-clone <repo> <dest> [--branch <name>] [--bare] [--quiet]
         \\

--- a/src/commands/link.zig
+++ b/src/commands/link.zig
@@ -4,6 +4,7 @@ const dotfiles = @import("../dotfiles.zig");
 const toml = @import("toml");
 const logger = @import("../logger.zig");
 const dotfiles_paths = @import("../dotfiles_paths.zig");
+const global_io = @import("../global_io.zig");
 
 const params = clap.parseParamsComptime(
     \\-h, --help                 Show help for link
@@ -18,13 +19,13 @@ const parsers = .{
     .home_dir = clap.parsers.string,
 };
 
-pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
+pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
     var diag = clap.Diagnostic{};
     var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
         .allocator = allocator,
         .diagnostic = &diag,
     }) catch |err| {
-        try diag.reportToFile(std.fs.File.stderr(), err);
+        try diag.reportToFile(global_io.io(), std.Io.File.stderr(), err);
         return;
     };
     defer res.deinit();
@@ -43,7 +44,7 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
         }
     }
 
-    const actual_home = try std.process.getEnvVarOwned(allocator, "HOME");
+    const actual_home = try global_io.getEnvOwned(allocator, "HOME");
     defer allocator.free(actual_home);
 
     if (res.args.dotfiles) |dotfiles_path| {
@@ -77,15 +78,16 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
 }
 
 fn loadLinkConfig(allocator: std.mem.Allocator, root: []const u8) !?[]const []const u8 {
+    const io = global_io.io();
     const project_config_paths = [_][]const u8{ ".hola.toml", "hola.toml" };
-    var config_file: ?std.fs.File = null;
+    var config_file: ?std.Io.File = null;
     var config_path: []const u8 = undefined;
 
     for (project_config_paths) |config_name| {
         const path = try std.fs.path.join(allocator, &.{ root, config_name });
         defer allocator.free(path);
 
-        const file = std.fs.openFileAbsolute(path, .{}) catch |err| switch (err) {
+        const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch |err| switch (err) {
             error.FileNotFound => continue,
             else => return err,
         };
@@ -100,7 +102,7 @@ fn loadLinkConfig(allocator: std.mem.Allocator, root: []const u8) !?[]const []co
         const xdg_config_path = try xdg.getConfigFile();
         defer allocator.free(xdg_config_path);
 
-        if (std.fs.openFileAbsolute(xdg_config_path, .{})) |f| {
+        if (std.Io.Dir.openFileAbsolute(io, xdg_config_path, .{})) |f| {
             config_file = f;
             config_path = try allocator.dupe(u8, xdg_config_path);
         } else |err| switch (err) {
@@ -110,10 +112,12 @@ fn loadLinkConfig(allocator: std.mem.Allocator, root: []const u8) !?[]const []co
     }
 
     const file = config_file orelse return null;
-    defer file.close();
+    defer file.close(io);
     defer allocator.free(config_path);
 
-    const content = try file.readToEndAlloc(allocator, std.math.maxInt(usize));
+    var read_buf: [4096]u8 = undefined;
+    var file_reader = file.reader(io, &read_buf);
+    const content = try file_reader.interface.allocRemaining(allocator, .unlimited);
     defer allocator.free(content);
 
     const Config = struct {
@@ -145,12 +149,13 @@ fn loadLinkConfig(allocator: std.mem.Allocator, root: []const u8) !?[]const []co
 }
 
 fn printHelp(reason: ?[]const u8) !void {
-    const out = std.fs.File.stdout();
+    const io = global_io.io();
+    const out = std.Io.File.stdout();
     if (reason) |msg| {
-        try out.writeAll(msg);
-        try out.writeAll("\n\n");
+        try out.writeStreamingAll(io, msg);
+        try out.writeStreamingAll(io, "\n\n");
     }
-    try out.writeAll(
+    try out.writeStreamingAll(io,
         \\link
         \\  hola link [--dotfiles <path>] [--home <path>] [--dry-run]
         \\

--- a/src/commands/node_info.zig
+++ b/src/commands/node_info.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const clap = @import("clap");
 const node_info = @import("../node_info.zig");
+const global_io = @import("../global_io.zig");
 
 const params = clap.parseParamsComptime(
     \\-h, --help            Show help for node-info
@@ -9,13 +10,13 @@ const params = clap.parseParamsComptime(
 
 const parsers = .{};
 
-pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
+pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
     var diag = clap.Diagnostic{};
     var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
         .allocator = allocator,
         .diagnostic = &diag,
     }) catch |err| {
-        try diag.reportToFile(std.fs.File.stderr(), err);
+        try diag.reportToFile(global_io.io(), std.Io.File.stderr(), err);
         return;
     };
     defer res.deinit();
@@ -32,18 +33,20 @@ fn printNodeInfo(allocator: std.mem.Allocator) !void {
     const json_str = try std.fmt.allocPrint(allocator, "{f}", .{std.json.fmt(node, .{ .whitespace = .indent_2 })});
     defer allocator.free(json_str);
 
-    const stdout = std.fs.File.stdout();
-    try stdout.writeAll(json_str);
-    try stdout.writeAll("\n");
+    const io = global_io.io();
+    const stdout = std.Io.File.stdout();
+    try stdout.writeStreamingAll(io, json_str);
+    try stdout.writeStreamingAll(io, "\n");
 }
 
 fn printHelp(reason: ?[]const u8) !void {
-    const out = std.fs.File.stdout();
+    const io = global_io.io();
+    const out = std.Io.File.stdout();
     if (reason) |msg| {
-        try out.writeAll(msg);
-        try out.writeAll("\n\n");
+        try out.writeStreamingAll(io, msg);
+        try out.writeStreamingAll(io, "\n\n");
     }
-    try out.writeAll(
+    try out.writeStreamingAll(io,
         \\node-info
         \\  hola node-info
         \\

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const clap = @import("clap");
 const provision = @import("../provision.zig");
 const http = @import("../http.zig");
+const global_io = @import("../global_io.zig");
 
 const params = clap.parseParamsComptime(
     \\-h, --help            Show help for provision
@@ -84,9 +85,11 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, u
     const is_url = std.mem.startsWith(u8, script_path_or_url, "http://") or
         std.mem.startsWith(u8, script_path_or_url, "https://");
 
+    const io = global_io.io();
+
     var temp_file_path: ?[]const u8 = null;
     defer if (temp_file_path) |path| {
-        std.fs.deleteFileAbsolute(path) catch {};
+        std.Io.Dir.deleteFileAbsolute(io, path) catch {};
         allocator.free(path);
     };
 
@@ -101,14 +104,14 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, u
 
         std.debug.print("[fetch] Downloading provision script from {s}\n", .{display_url});
 
-        const temp_dir = std.process.getEnvVarOwned(allocator, "TMPDIR") catch
+        const temp_dir = global_io.getEnvOwned(allocator, "TMPDIR") catch
             try allocator.dupe(u8, "/tmp");
         defer allocator.free(temp_dir);
 
         var rand_buf: [8]u8 = undefined;
-        std.crypto.random.bytes(&rand_buf);
+        io.random(&rand_buf);
         const rand_hex = std.fmt.bytesToHex(rand_buf, .lower);
-        const temp_file = try std.fmt.allocPrint(allocator, "{s}/provision-{d}-{s}.rb", .{ temp_dir, std.time.timestamp(), &rand_hex });
+        const temp_file = try std.fmt.allocPrint(allocator, "{s}/provision-{d}-{s}.rb", .{ temp_dir, std.Io.Timestamp.now(io, .real).toSeconds(), &rand_hex });
         temp_file_path = temp_file;
 
         const cfg = http.Config{
@@ -154,9 +157,9 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, u
             return error.DownloadFailed;
         }
 
-        const file = try std.fs.cwd().createFile(temp_file, .{ .exclusive = true });
-        defer file.close();
-        try file.writeAll(response.body);
+        const file = try std.Io.Dir.cwd().createFile(io, temp_file, .{ .exclusive = true });
+        defer file.close(io);
+        try file.writeStreamingAll(io, response.body);
 
         std.debug.print("[fetch] Downloaded to {s}\n", .{temp_file});
         break :blk temp_file;
@@ -170,13 +173,13 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, u
     });
 }
 
-pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
+pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
     var diag = clap.Diagnostic{};
     var res = clap.parseEx(clap.Help, &params, parsers, iter, .{
         .allocator = allocator,
         .diagnostic = &diag,
     }) catch |err| {
-        try diag.reportToFile(std.fs.File.stderr(), err);
+        try diag.reportToFile(global_io.io(), std.Io.File.stderr(), err);
         return;
     };
     defer res.deinit();
@@ -185,7 +188,7 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
 
     const script_path_or_url = res.positionals[0] orelse return printHelp("Missing provision file path or URL.");
 
-    var use_pretty_output = std.posix.isatty(std.posix.STDOUT_FILENO);
+    var use_pretty_output = std.Io.File.stdout().isTty(global_io.io()) catch false;
     if (res.args.output) |output_mode| {
         if (std.mem.eql(u8, output_mode, "plain")) {
             use_pretty_output = false;
@@ -265,12 +268,13 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
 }
 
 fn printHelp(reason: ?[]const u8) !void {
-    const out = std.fs.File.stdout();
+    const io = global_io.io();
+    const out = std.Io.File.stdout();
     if (reason) |msg| {
-        try out.writeAll(msg);
-        try out.writeAll("\n\n");
+        try out.writeStreamingAll(io, msg);
+        try out.writeStreamingAll(io, "\n\n");
     }
-    try out.writeAll(
+    try out.writeStreamingAll(io,
         \\provision
         \\  hola provision [OPTIONS] <file-or-url>
         \\

--- a/src/dotfiles.zig
+++ b/src/dotfiles.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const fmt = std.fmt;
+const global_io = @import("global_io.zig");
 const table = @import("table.zig");
 const glob = @import("glob.zig");
 const logger = @import("logger.zig");
@@ -18,7 +19,7 @@ pub const Options = struct {
     dry_run: bool = false, // Default: actually create links
     home_override: ?[]const u8 = null,
     ignore_patterns: ?[]const []const u8 = null,
-    output_writer: ?std.fs.File.Writer = null, // Optional writer for output (for progress display integration)
+    output_writer: ?std.Io.File.Writer = null, // Optional writer for output (for progress display integration)
 };
 
 pub fn run(allocator: std.mem.Allocator, opts: Options) !void {
@@ -48,7 +49,7 @@ pub const runDryRun = run;
 
 fn resolveHome(allocator: std.mem.Allocator, override: ?[]const u8) ![]const u8 {
     if (override) |value| return allocator.dupe(u8, value);
-    return std.process.getEnvVarOwned(allocator, "HOME");
+    return global_io.getEnvOwned(allocator, "HOME");
 }
 
 fn resolvePath(allocator: std.mem.Allocator, path: []const u8, home: []const u8) ![]const u8 {
@@ -62,8 +63,10 @@ fn resolvePath(allocator: std.mem.Allocator, path: []const u8, home: []const u8)
     if (std.fs.path.isAbsolute(path)) {
         return allocator.dupe(u8, path);
     }
-    const cwd = try std.fs.cwd().realpathAlloc(allocator, ".");
-    defer allocator.free(cwd);
+    const io = global_io.io();
+    var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cwd_len = try std.Io.Dir.cwd().realPath(io, &cwd_buf);
+    const cwd = cwd_buf[0..cwd_len];
     return std.fs.path.join(allocator, &.{ cwd, path });
 }
 
@@ -87,9 +90,9 @@ const Planner = struct {
     home: []const u8,
     display_prefix: []const u8,
     owns_display_prefix: bool,
-    entries: std.ArrayListUnmanaged(PlanEntry) = .{},
-    builder: std.ArrayListUnmanaged(u8) = .{},
-    ignore_patterns: std.ArrayListUnmanaged([]const u8) = .{},
+    entries: std.ArrayListUnmanaged(PlanEntry) = .empty,
+    builder: std.ArrayListUnmanaged(u8) = .empty,
+    ignore_patterns: std.ArrayListUnmanaged([]const u8) = .empty,
 
     const PlanEntry = struct {
         rel_path: []const u8,
@@ -162,11 +165,12 @@ const Planner = struct {
     }
 
     fn scan(self: *Planner, abs_path: []const u8) !void {
-        var dir = try std.fs.openDirAbsolute(abs_path, .{ .iterate = true });
-        defer dir.close();
+        const io = global_io.io();
+        var dir = try std.Io.Dir.openDirAbsolute(io, abs_path, .{ .iterate = true });
+        defer dir.close(io);
 
         var it = dir.iterate();
-        while (try it.next()) |entry| {
+        while (try it.next(io)) |entry| {
             const prev_len = self.builder.items.len;
             if (prev_len != 0) try self.builder.append(self.allocator, '/');
             try self.builder.appendSlice(self.allocator, entry.name);
@@ -207,8 +211,9 @@ const Planner = struct {
         const target_abs = try std.fs.path.join(self.allocator, &.{ self.home, rel_path });
         defer self.allocator.free(target_abs);
 
+        const io = global_io.io();
         var link_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const link_result = std.fs.readLinkAbsolute(target_abs, &link_buf) catch |err| switch (err) {
+        const link_len = std.Io.Dir.readLinkAbsolute(io, target_abs, &link_buf) catch |err| switch (err) {
             error.FileNotFound => return .{ .status = .create_link },
             error.NotLink => {
                 const kind = try statKind(target_abs);
@@ -219,6 +224,7 @@ const Planner = struct {
             },
             else => return err,
         };
+        const link_result = link_buf[0..link_len];
 
         if (std.mem.eql(u8, link_result, source_abs)) {
             return .{ .status = .already_linked };
@@ -228,17 +234,18 @@ const Planner = struct {
         return .{ .status = .different_link, .existing_target = existing };
     }
 
-    fn statKind(path: []const u8) !std.fs.File.Kind {
+    fn statKind(path: []const u8) !std.Io.File.Kind {
+        const io = global_io.io();
         const parent = std.fs.path.dirname(path) orelse "/";
         const base = std.fs.path.basename(path);
-        var dir = try std.fs.openDirAbsolute(parent, .{});
-        defer dir.close();
-        const stat = try dir.statFile(base);
+        var dir = try std.Io.Dir.openDirAbsolute(io, parent, .{});
+        defer dir.close(io);
+        const stat = try dir.statFile(io, base, .{});
         return stat.kind;
     }
 
     fn renderReport(self: *Planner) !void {
-        const out = std.fs.File.stdout();
+        const out = std.Io.File.stdout();
         const simple = table.SimpleTable.init(self.allocator, out);
 
         if (self.entries.items.len == 0) {
@@ -265,7 +272,7 @@ const Planner = struct {
         });
         defer tbl.deinit();
 
-        var cells_buf: std.ArrayListUnmanaged([]const u8) = .{};
+        var cells_buf: std.ArrayListUnmanaged([]const u8) = .empty;
         defer {
             for (cells_buf.items) |cell| {
                 self.allocator.free(cell);
@@ -299,7 +306,7 @@ const Planner = struct {
 
         try tbl.render();
 
-        try out.writeAll("\n");
+        try out.writeStreamingAll(global_io.io(), "\n");
         try simple.printSummary(&.{
             .{ .label = "plan", .value = create_count, .color = Ansi.green },
             .{ .label = "ok", .value = ok_count, .color = Ansi.cyan },
@@ -368,7 +375,7 @@ const Planner = struct {
     }
 
     fn apply(self: *Planner) !void {
-        const out = std.fs.File.stdout();
+        const out = std.Io.File.stdout();
         const simple = table.SimpleTable.init(self.allocator, out);
 
         var buf: [256]u8 = undefined;
@@ -383,7 +390,7 @@ const Planner = struct {
         });
         defer tbl.deinit();
 
-        var cells_buf: std.ArrayListUnmanaged([]const u8) = .{};
+        var cells_buf: std.ArrayListUnmanaged([]const u8) = .empty;
         defer {
             for (cells_buf.items) |cell| {
                 self.allocator.free(cell);
@@ -451,7 +458,7 @@ const Planner = struct {
 
         try tbl.render();
 
-        try out.writeAll("\n");
+        try out.writeStreamingAll(global_io.io(), "\n");
         try simple.printSummary(&.{
             .{ .label = "linked", .value = linked_count, .color = Ansi.green },
             .{ .label = "skipped", .value = skipped_count, .color = Ansi.yellow },
@@ -459,19 +466,20 @@ const Planner = struct {
     }
 
     fn applyLink(self: *Planner, entry: PlanEntry) !ApplyOutcome {
+        const io = global_io.io();
         const source_abs = try std.fs.path.join(self.allocator, &.{ self.root, entry.rel_path });
         defer self.allocator.free(source_abs);
         const target_abs = try std.fs.path.join(self.allocator, &.{ self.home, entry.rel_path });
         defer self.allocator.free(target_abs);
 
         if (std.fs.path.dirname(target_abs)) |dir| {
-            std.fs.cwd().makePath(dir) catch |err| {
+            std.Io.Dir.cwd().createDirPath(io, dir) catch |err| {
                 logger.err("Failed to create parent directories for {s}: {s}", .{ target_abs, @errorName(err) });
                 return .skipped;
             };
         }
 
-        std.fs.symLinkAbsolute(source_abs, target_abs, .{}) catch |err| {
+        std.Io.Dir.symLinkAbsolute(io, source_abs, target_abs, .{}) catch |err| {
             logger.err("Failed to create symlink {s}: {s}", .{ target_abs, @errorName(err) });
             return .skipped;
         };
@@ -481,11 +489,12 @@ const Planner = struct {
 };
 
 fn ensureRootExists(path: []const u8) !void {
-    var dir = try std.fs.openDirAbsolute(path, .{});
-    defer dir.close();
+    const io = global_io.io();
+    var dir = try std.Io.Dir.openDirAbsolute(io, path, .{});
+    defer dir.close(io);
 }
 
-fn shouldSkip(planner: *Planner, rel_path: []const u8, kind: std.fs.Dir.Entry.Kind) bool {
+fn shouldSkip(planner: *Planner, rel_path: []const u8, kind: std.Io.File.Kind) bool {
     // Check default ignore components (first component only)
     const component_end = std.mem.indexOfScalar(u8, rel_path, '/') orelse rel_path.len;
     const first_component = rel_path[0..component_end];

--- a/src/dotfiles_paths.zig
+++ b/src/dotfiles_paths.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const global_io = @import("global_io.zig");
 
 pub fn resolvePathForLink(allocator: std.mem.Allocator, path: []const u8, home: []const u8) ![]const u8 {
     if (path.len == 0) return error.InvalidPath;
@@ -11,18 +12,21 @@ pub fn resolvePathForLink(allocator: std.mem.Allocator, path: []const u8, home: 
     if (std.fs.path.isAbsolute(path)) {
         return allocator.dupe(u8, path);
     }
-    const cwd = try std.fs.cwd().realpathAlloc(allocator, ".");
-    defer allocator.free(cwd);
+    const io = global_io.io();
+    var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cwd_len = try std.Io.Dir.cwd().realPath(io, &cwd_buf);
+    const cwd = cwd_buf[0..cwd_len];
     return std.fs.path.join(allocator, &.{ cwd, path });
 }
 
 pub fn getDefaultDotfilesPath(allocator: std.mem.Allocator, home: []const u8) ![]const u8 {
+    const io = global_io.io();
     const state_link = try std.fs.path.join(allocator, &.{ home, ".local/state/hola/dotfiles" });
     defer allocator.free(state_link);
 
     var link_buf: [std.fs.max_path_bytes]u8 = undefined;
-    if (std.fs.readLinkAbsolute(state_link, &link_buf)) |target| {
-        return allocator.dupe(u8, target);
+    if (std.Io.Dir.readLinkAbsolute(io, state_link, &link_buf)) |link_len| {
+        return allocator.dupe(u8, link_buf[0..link_len]);
     } else |_| {
         return std.fs.path.join(allocator, &.{ home, ".dotfiles" });
     }
@@ -37,14 +41,15 @@ inline fn ignoreError(err: anyerror, comptime errors_to_ignore: []const anyerror
 }
 
 pub fn saveDotfilesPreference(allocator: std.mem.Allocator, dotfiles_path: []const u8, home: []const u8) !void {
+    const io = global_io.io();
     const state_dir = try std.fs.path.join(allocator, &.{ home, ".local/state/hola" });
     defer allocator.free(state_dir);
 
     const state_link = try std.fs.path.join(allocator, &.{ state_dir, "dotfiles" });
     defer allocator.free(state_link);
 
-    std.fs.makeDirAbsolute(state_dir) catch |err| try ignoreError(err, &.{error.PathAlreadyExists});
-    std.fs.deleteFileAbsolute(state_link) catch |err| try ignoreError(err, &.{error.FileNotFound});
+    std.Io.Dir.createDirAbsolute(io, state_dir, .default_dir) catch |err| try ignoreError(err, &.{error.PathAlreadyExists});
+    std.Io.Dir.deleteFileAbsolute(io, state_link) catch |err| try ignoreError(err, &.{error.FileNotFound});
 
-    try std.fs.symLinkAbsolute(dotfiles_path, state_link, .{});
+    try std.Io.Dir.symLinkAbsolute(io, dotfiles_path, state_link, .{});
 }

--- a/src/env_access.zig
+++ b/src/env_access.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const global_io = @import("global_io.zig");
 const mruby = @import("mruby.zig");
 const c = @cImport({
     @cInclude("stdlib.h");
@@ -29,7 +30,7 @@ pub fn zig_env_get(mrb: *mruby.mrb_state, _: mruby.mrb_value) callconv(.c) mruby
     const key = key_ptr[0..@intCast(key_len)];
 
     // Get environment variable
-    const value = std.process.getEnvVarOwned(allocator, key) catch {
+    const value = global_io.getEnvOwned(allocator, key) catch {
         return mruby.mrb_nil_value();
     };
     defer allocator.free(value);
@@ -110,7 +111,7 @@ pub fn zig_env_has_key(mrb: *mruby.mrb_state, _: mruby.mrb_value) callconv(.c) m
     const key = key_ptr[0..@intCast(key_len)];
 
     // Check if environment variable exists
-    if (std.process.getEnvVarOwned(allocator, key)) |value| {
+    if (global_io.getEnvOwned(allocator, key)) |value| {
         allocator.free(value);
         return zig_mrb_true_value();
     } else |_| {

--- a/src/file_ext.zig
+++ b/src/file_ext.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const global_io = @import("global_io.zig");
 const mruby = @import("mruby.zig");
 const mruby_module = @import("mruby_module.zig");
 const logger = @import("logger.zig");
@@ -19,11 +20,12 @@ fn file_stat(mrb: ?*mruby.mrb_state, _: mruby.mrb_value) callconv(.c) mruby.mrb_
     }
 
     const path = path_ptr[0..@intCast(path_len)];
+    const io = global_io.io();
 
     // Get file stats using std.fs
     // For absolute paths use openFileAbsolute, for relative use cwd
     const file = if (std.fs.path.isAbsolute(path))
-        std.fs.openFileAbsolute(path, .{}) catch {
+        std.Io.Dir.openFileAbsolute(io, path, .{}) catch {
             const allocator = std.heap.c_allocator;
             const err_msg = std.fmt.allocPrint(allocator, "No such file or directory - {s}\x00", .{path}) catch {
                 const fallback_msg = mruby.mrb_str_new(state, "file not found", 14);
@@ -37,7 +39,7 @@ fn file_stat(mrb: ?*mruby.mrb_state, _: mruby.mrb_value) callconv(.c) mruby.mrb_
             mruby.mrb_raise(state, exc_class, mruby.mrb_str_to_cstr(state, msg_val));
         }
     else
-        std.fs.cwd().openFile(path, .{}) catch {
+        std.Io.Dir.cwd().openFile(io, path, .{}) catch {
             const allocator = std.heap.c_allocator;
             const err_msg = std.fmt.allocPrint(allocator, "No such file or directory - {s}\x00", .{path}) catch {
                 const fallback_msg = mruby.mrb_str_new(state, "file not found", 14);
@@ -50,9 +52,9 @@ fn file_stat(mrb: ?*mruby.mrb_state, _: mruby.mrb_value) callconv(.c) mruby.mrb_
             const exc_class = mruby.mrb_class_get(state, "RuntimeError");
             mruby.mrb_raise(state, exc_class, mruby.mrb_str_to_cstr(state, msg_val));
         };
-    defer file.close();
+    defer file.close(io);
 
-    const stat_result = file.stat() catch {
+    const stat_result = file.stat(io) catch {
         const err_msg = mruby.mrb_str_new(state, "failed to get file stats", 24);
         const exc_class = mruby.mrb_class_get(state, "RuntimeError");
         mruby.mrb_raise(state, exc_class, mruby.mrb_str_to_cstr(state, err_msg));
@@ -62,13 +64,13 @@ fn file_stat(mrb: ?*mruby.mrb_state, _: mruby.mrb_value) callconv(.c) mruby.mrb_
     const hash = mruby.mrb_hash_new(state);
 
     // Add mtime (modification time) - convert nanoseconds to seconds
-    const mtime_sec: i64 = @intCast(@divTrunc(stat_result.mtime, std.time.ns_per_s));
+    const mtime_sec: i64 = stat_result.mtime.toSeconds();
     const mtime_val = mruby.zig_mrb_int_value(state, mtime_sec);
     const mtime_key = mruby.mrb_str_new(state, "mtime", 5);
     mruby.mrb_hash_set(state, hash, mtime_key, mtime_val);
 
     // Add atime (access time) - convert nanoseconds to seconds
-    const atime_sec: i64 = @intCast(@divTrunc(stat_result.atime, std.time.ns_per_s));
+    const atime_sec: i64 = if (stat_result.atime) |t| t.toSeconds() else 0;
     const atime_val = mruby.zig_mrb_int_value(state, atime_sec);
     const atime_key = mruby.mrb_str_new(state, "atime", 5);
     mruby.mrb_hash_set(state, hash, atime_key, atime_val);
@@ -80,7 +82,7 @@ fn file_stat(mrb: ?*mruby.mrb_state, _: mruby.mrb_value) callconv(.c) mruby.mrb_
     mruby.mrb_hash_set(state, hash, size_key, size_val);
 
     // Add mode
-    const mode: i64 = @intCast(stat_result.mode);
+    const mode: i64 = @intCast(stat_result.permissions.toMode());
     const mode_val = mruby.zig_mrb_int_value(state, mode);
     const mode_key = mruby.mrb_str_new(state, "mode", 4);
     mruby.mrb_hash_set(state, hash, mode_key, mode_val);
@@ -109,11 +111,12 @@ fn file_mtime(mrb: ?*mruby.mrb_state, _: mruby.mrb_value) callconv(.c) mruby.mrb
     }
 
     const path = path_ptr[0..@intCast(path_len)];
+    const io = global_io.io();
 
     // Get file stats using std.fs
     // For absolute paths use openFileAbsolute, for relative use cwd
     const file = if (std.fs.path.isAbsolute(path))
-        std.fs.openFileAbsolute(path, .{}) catch {
+        std.Io.Dir.openFileAbsolute(io, path, .{}) catch {
             // Raise Errno::ENOENT instead of returning nil
             const allocator = std.heap.c_allocator;
             const err_msg = std.fmt.allocPrint(allocator, "No such file or directory - {s}\x00", .{path}) catch {
@@ -128,7 +131,7 @@ fn file_mtime(mrb: ?*mruby.mrb_state, _: mruby.mrb_value) callconv(.c) mruby.mrb
             mruby.mrb_raise(state, exc_class, mruby.mrb_str_to_cstr(state, msg_val));
         }
     else
-        std.fs.cwd().openFile(path, .{}) catch {
+        std.Io.Dir.cwd().openFile(io, path, .{}) catch {
             // Raise error for file not found
             const allocator = std.heap.c_allocator;
             const err_msg = std.fmt.allocPrint(allocator, "No such file or directory - {s}\x00", .{path}) catch {
@@ -142,16 +145,16 @@ fn file_mtime(mrb: ?*mruby.mrb_state, _: mruby.mrb_value) callconv(.c) mruby.mrb
             const exc_class = mruby.mrb_class_get(state, "RuntimeError");
             mruby.mrb_raise(state, exc_class, mruby.mrb_str_to_cstr(state, msg_val));
         };
-    defer file.close();
+    defer file.close(io);
 
-    const stat_result = file.stat() catch {
+    const stat_result = file.stat(io) catch {
         const err_msg = mruby.mrb_str_new(state, "failed to get file stats", 24);
         const exc_class = mruby.mrb_class_get(state, "RuntimeError");
         mruby.mrb_raise(state, exc_class, mruby.mrb_str_to_cstr(state, err_msg));
         return mruby.mrb_nil_value();
     };
 
-    const mtime_sec: i64 = @intCast(@divTrunc(stat_result.mtime, std.time.ns_per_s));
+    const mtime_sec: i64 = stat_result.mtime.toSeconds();
 
     // Create a Time object from the timestamp using Time.at(timestamp)
     const time_class = mruby.mrb_class_get(state, "Time");

--- a/src/global_io.zig
+++ b/src/global_io.zig
@@ -1,0 +1,53 @@
+//! Process-wide `std.Io` instance.
+//!
+//! Zig 0.16 requires an explicit `Io` for filesystem, time, and process
+//! APIs. `main` stores the instance provided by `std.process.Init` here so
+//! the rest of the codebase (including mruby C callbacks, which cannot
+//! thread an `Io` parameter through) can access it. When unset (unit tests,
+//! standalone tools), falls back to the blocking single-threaded
+//! implementation from std.
+const std = @import("std");
+
+var override: ?std.Io = null;
+
+pub fn set(new_io: std.Io) void {
+    override = new_io;
+}
+
+pub fn io() std.Io {
+    return override orelse std.Io.Threaded.global_single_threaded.io();
+}
+
+var environ_map: ?*std.process.Environ.Map = null;
+
+pub fn setEnviron(map: *std.process.Environ.Map) void {
+    environ_map = map;
+}
+
+/// Access the process environment map (set by main). Null in unit tests.
+pub fn environMap() ?*std.process.Environ.Map {
+    return environ_map;
+}
+
+/// Replacement for the removed `std.posix.getenv`. Returns a slice that
+/// borrows from the process environment; do not free.
+pub fn getEnv(key: []const u8) ?[]const u8 {
+    if (environ_map) |m| return m.get(key);
+    // Fallback for contexts where main hasn't run (unit tests): libc getenv,
+    // available because hola always links libc.
+    var buf: [256]u8 = undefined;
+    if (key.len >= buf.len) return null;
+    @memcpy(buf[0..key.len], key);
+    buf[key.len] = 0;
+    const value = std.c.getenv(buf[0..key.len :0]) orelse return null;
+    return std.mem.span(value);
+}
+
+/// Drop-in replacement for the removed `std.process.getEnvVarOwned`.
+pub fn getEnvOwned(
+    gpa: std.mem.Allocator,
+    key: []const u8,
+) error{ OutOfMemory, EnvironmentVariableNotFound }![]u8 {
+    const value = getEnv(key) orelse return error.EnvironmentVariableNotFound;
+    return gpa.dupe(u8, value);
+}

--- a/src/http/client.zig
+++ b/src/http/client.zig
@@ -3,6 +3,7 @@ const curl = @import("../curl.zig");
 const types = @import("types.zig");
 const config_mod = @import("config.zig");
 const logger = @import("../logger.zig");
+const global_io = @import("../global_io.zig");
 
 const Request = types.Request;
 const Response = types.Response;
@@ -72,6 +73,7 @@ pub const Client = struct {
         // *this* call (or null on success / non-libcurl failure).
         clearLastCurlError();
 
+        const io = global_io.io();
         var attempt: u32 = 0;
         const max_attempts = @max(1, self.config.retry.max_attempts); // Ensure at least 1 attempt
 
@@ -95,7 +97,7 @@ pub const Client = struct {
                 // Calculate backoff delay
                 const backoff_ms = self.calculateBackoff(attempt);
                 logger.debug("Request failed (attempt {d}/{d}), retrying in {d}ms: {}", .{ attempt + 1, max_attempts, backoff_ms, err });
-                std.Thread.sleep(backoff_ms * std.time.ns_per_ms);
+                io.sleep(.fromNanoseconds(backoff_ms * std.time.ns_per_ms), .awake) catch {};
                 continue;
             };
 
@@ -104,7 +106,7 @@ pub const Client = struct {
                 logger.debug("Server error {d} (attempt {d}/{d}), retrying in {d}ms", .{ result.status, attempt + 1, max_attempts, backoff_ms });
                 var owned = result;
                 owned.deinit();
-                std.Thread.sleep(backoff_ms * std.time.ns_per_ms);
+                io.sleep(.fromNanoseconds(backoff_ms * std.time.ns_per_ms), .awake) catch {};
                 continue;
             }
 

--- a/src/http/config.zig
+++ b/src/http/config.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const global_io = @import("../global_io.zig");
 const build_options = if (@hasDecl(@import("root"), "build_options")) @import("build_options") else struct {
     pub const version = "0.1.0";
     pub const is_nightly = false;
@@ -83,7 +84,8 @@ pub fn validateClientAuthFiles(cert: ?[]const u8, key: ?[]const u8) error{Invali
 }
 
 fn ensureReadable(path: []const u8, label: []const u8) error{InvalidClientAuth}!void {
-    var file = std.fs.cwd().openFile(path, .{}) catch |err| {
+    const io = global_io.io();
+    var file = std.Io.Dir.cwd().openFile(io, path, .{}) catch |err| {
         if (!builtin.is_test) {
             switch (err) {
                 error.FileNotFound => std.debug.print("Error: {s} file not found: {s}\n", .{ label, path }),
@@ -93,7 +95,7 @@ fn ensureReadable(path: []const u8, label: []const u8) error{InvalidClientAuth}!
         }
         return error.InvalidClientAuth;
     };
-    file.close();
+    file.close(io);
 }
 
 /// Version string for User-Agent from build.zig.zon

--- a/src/http/download/downloader.zig
+++ b/src/http/download/downloader.zig
@@ -4,6 +4,7 @@ const types = @import("../types.zig");
 const Task = @import("task.zig").Task;
 const logger = @import("../../logger.zig");
 const utils = @import("../utils.zig");
+const global_io = @import("../../global_io.zig");
 
 const LAST_DOWNLOAD_ERROR_BUF_SIZE = 1024;
 threadlocal var last_download_error_buf: [LAST_DOWNLOAD_ERROR_BUF_SIZE]u8 = undefined;
@@ -68,7 +69,7 @@ pub const Result = struct {
 
 /// Context for download progress tracking
 const DownloadContext = struct {
-    file: std.fs.File,
+    file: std.Io.File,
 };
 
 /// Simple download file wrapper (for direct use without Manager)
@@ -94,6 +95,8 @@ pub fn downloadFileWithClient(
     opts: Options,
 ) !Result {
     clearLastDownloadError();
+
+    const io = global_io.io();
 
     // Build request
     var req = types.Request.init(.GET, url);
@@ -146,27 +149,29 @@ pub fn downloadFileWithClient(
     const use_temp_file = opts.resume_from == null;
 
     const actual_dest_path = if (use_temp_file)
-        try std.fmt.allocPrint(allocator, "{s}.tmp.{d}", .{ dest_path, std.time.timestamp() })
+        try std.fmt.allocPrint(allocator, "{s}.tmp.{d}", .{ dest_path, std.Io.Timestamp.now(io, .real).toSeconds() })
     else
         dest_path;
     defer if (use_temp_file) allocator.free(actual_dest_path);
 
     // Open file for writing
-    const file = try std.fs.cwd().createFile(actual_dest_path, .{
+    const file = try std.Io.Dir.cwd().createFile(io, actual_dest_path, .{
         .truncate = opts.resume_from == null,
     });
     var file_closed = false;
     defer if (!file_closed) {
-        file.close();
+        file.close(io);
         // Clean up temp file if we used one and didn't move it
         if (use_temp_file) {
-            std.fs.cwd().deleteFile(actual_dest_path) catch {};
+            std.Io.Dir.cwd().deleteFile(io, actual_dest_path) catch {};
         }
     };
 
     // Seek to resume position if needed
     if (opts.resume_from) |offset| {
-        try file.seekTo(offset);
+        var seek_buf: [0]u8 = .{};
+        var seeker = file.writerStreaming(io, &seek_buf);
+        try seeker.seekTo(offset);
     }
 
     // Download context
@@ -213,9 +218,9 @@ pub fn downloadFileWithClient(
         stream_result.headers.deinit();
 
         // Remove the partially written file before retrying.
-        std.fs.cwd().deleteFile(dest_path) catch {};
+        std.Io.Dir.cwd().deleteFile(io, dest_path) catch {};
         file_closed = true;
-        file.close();
+        file.close(io);
 
         var fresh_opts = opts;
         fresh_opts.resume_from = null;
@@ -246,20 +251,20 @@ pub fn downloadFileWithClient(
         // Temp file will be cleaned up by defer automatically
         // For resume mode, explicitly delete the corrupted file
         if (!use_temp_file) {
-            std.fs.cwd().deleteFile(dest_path) catch {};
+            std.Io.Dir.cwd().deleteFile(io, dest_path) catch {};
         }
         return error.InvalidResponse;
     }
 
     // Close file before moving (required on Windows)
     file_closed = true;
-    file.close();
+    file.close(io);
 
     // If we used a temp file for conditional request, atomically replace the original
     if (use_temp_file) {
         // Delete old file first, then rename temp to dest
-        std.fs.cwd().deleteFile(dest_path) catch {};
-        try std.fs.cwd().rename(actual_dest_path, dest_path);
+        std.Io.Dir.cwd().deleteFile(io, dest_path) catch {};
+        try std.Io.Dir.cwd().rename(actual_dest_path, std.Io.Dir.cwd(), dest_path, io);
     }
 
     // Extract ETag and Last-Modified from response headers
@@ -320,15 +325,17 @@ pub fn downloadTask(
         try verifyChecksum(allocator, task.temp_path, expected_checksum);
     }
 
+    const io = global_io.io();
+
     // Move to final location
-    try std.fs.cwd().rename(task.temp_path, task.final_path);
+    try std.Io.Dir.cwd().rename(task.temp_path, std.Io.Dir.cwd(), task.final_path, io);
 
     // Set file mode if provided
     if (task.mode) |mode_str| {
         const mode = try std.fmt.parseInt(u16, mode_str, 8);
-        const final_file = try std.fs.cwd().openFile(task.final_path, .{});
-        defer final_file.close();
-        try final_file.chmod(mode);
+        const final_file = try std.Io.Dir.cwd().openFile(io, task.final_path, .{});
+        defer final_file.close(io);
+        try final_file.setPermissions(io, .fromMode(@intCast(mode)));
     }
 
     task.status.store(.completed, .release);
@@ -340,7 +347,7 @@ fn streamToFile(data: []const u8, context: *anyopaque) !usize {
     const ctx: *DownloadContext = @ptrCast(@alignCast(context));
 
     // Write to file
-    try ctx.file.writeAll(data);
+    try ctx.file.writeStreamingAll(global_io.io(), data);
 
     return data.len;
 }
@@ -353,14 +360,18 @@ fn taskProgressCallback(downloaded: usize, total: usize, context: *anyopaque) vo
 
 /// Verify file checksum (SHA256)
 pub fn verifyChecksum(_: std.mem.Allocator, file_path: []const u8, expected: []const u8) !void {
-    const file = try std.fs.cwd().openFile(file_path, .{});
-    defer file.close();
+    const io = global_io.io();
+    const file = try std.Io.Dir.cwd().openFile(io, file_path, .{});
+    defer file.close(io);
 
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
     var buf: [8192]u8 = undefined;
 
     while (true) {
-        const n = try file.read(&buf);
+        const n = file.readStreaming(io, &.{&buf}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => return err,
+        };
         if (n == 0) break;
         hasher.update(buf[0..n]);
     }

--- a/src/http/download/manager.zig
+++ b/src/http/download/manager.zig
@@ -5,6 +5,7 @@ const Task = @import("task.zig").Task;
 const downloader = @import("downloader.zig");
 const logger = @import("../../logger.zig");
 const utils = @import("../utils.zig");
+const global_io = @import("../../global_io.zig");
 
 // Thread-local storage for current Manager (for use in remote_file resource)
 threadlocal var current_manager: ?*Manager = null;
@@ -18,8 +19,8 @@ pub const Manager = struct {
     // Worker pool
     workers: []std.Thread,
     max_concurrent: usize,
-    mutex: std.Thread.Mutex,
-    condition: std.Thread.Condition,
+    mutex: std.Io.Mutex,
+    condition: std.Io.Condition,
     shutdown: bool,
     next_task_index: usize,
 
@@ -45,8 +46,8 @@ pub const Manager = struct {
             .tasks = std.ArrayList(Task).empty,
             .workers = &.{},
             .max_concurrent = cfg.max_concurrent,
-            .mutex = .{},
-            .condition = .{},
+            .mutex = .init,
+            .condition = .init,
             .shutdown = false,
             .next_task_index = 0,
             .completed_counter = std.atomic.Value(usize).init(0),
@@ -89,15 +90,17 @@ pub const Manager = struct {
 
     /// Add task to queue
     pub fn addTask(self: *Manager, task: Task) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = global_io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         try self.tasks.append(self.allocator, task);
     }
 
     /// Pop next task in queue (used by tests and single-threaded flows)
     pub fn getNextTask(self: *Manager) ?*Task {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = global_io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         if (self.next_task_index >= self.tasks.items.len) {
             return null;
@@ -110,8 +113,9 @@ pub const Manager = struct {
 
     /// Get task by ID
     pub fn getTask(self: *Manager, id: []const u8) ?*Task {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = global_io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         for (self.tasks.items) |*task| {
             if (std.mem.eql(u8, task.id, id)) {
@@ -150,10 +154,11 @@ pub const Manager = struct {
 
     /// Cancel all pending tasks
     pub fn cancel(self: *Manager) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = global_io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         self.shutdown = true;
-        self.condition.broadcast();
+        self.condition.broadcast(io);
     }
 
     /// Get progress statistics
@@ -205,23 +210,24 @@ const WorkerContext = struct {
 fn workerLoop(ctx: WorkerContext) void {
     const mgr = ctx.manager;
 
+    const io = global_io.io();
     while (true) {
         // Get next task index
-        mgr.mutex.lock();
+        mgr.mutex.lockUncancelable(io);
 
         if (mgr.shutdown) {
-            mgr.mutex.unlock();
+            mgr.mutex.unlock(io);
             break;
         }
 
         const task_index = mgr.next_task_index;
         if (task_index >= mgr.tasks.items.len) {
-            mgr.mutex.unlock();
+            mgr.mutex.unlock(io);
             break;
         }
 
         mgr.next_task_index += 1;
-        mgr.mutex.unlock();
+        mgr.mutex.unlock(io);
 
         // Process task (without holding lock)
         processTask(mgr, task_index);
@@ -243,9 +249,10 @@ fn taskProgressWrapper(downloaded: usize, total: usize, context: *anyopaque) voi
 
 /// Process single task
 fn processTask(mgr: *Manager, task_index: usize) void {
-    mgr.mutex.lock();
+    const io = global_io.io();
+    mgr.mutex.lockUncancelable(io);
     const task = &mgr.tasks.items[task_index];
-    mgr.mutex.unlock();
+    mgr.mutex.unlock(io);
 
     logger.debug("Worker processing task {d}: {s}", .{ task_index, task.display_name });
 

--- a/src/http/utils.zig
+++ b/src/http/utils.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const global_io = @import("../global_io.zig");
 
 /// Mask the password in a URL's `user:password@` userinfo for safe display or
 /// logging. Writes `scheme://user:***@rest` into `buf` (no allocation) and
@@ -203,14 +204,18 @@ pub fn slugifyPath(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {
 /// Calculate SHA256 checksum of a file
 /// Returns hex-encoded string
 pub fn calculateSha256(allocator: std.mem.Allocator, file_path: []const u8) ![]const u8 {
-    const file = try std.fs.cwd().openFile(file_path, .{});
-    defer file.close();
+    const io = global_io.io();
+    const file = try std.Io.Dir.cwd().openFile(io, file_path, .{});
+    defer file.close(io);
 
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
     var buf: [8192]u8 = undefined;
 
     while (true) {
-        const n = try file.read(&buf);
+        const n = file.readStreaming(io, &.{&buf}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => return err,
+        };
         if (n == 0) break;
         hasher.update(buf[0..n]);
     }

--- a/src/indicatif/format.zig
+++ b/src/indicatif/format.zig
@@ -34,10 +34,10 @@ pub const HumanBytes = struct {
     }
 
     pub fn toString(self: Self, allocator: std.mem.Allocator) ![]const u8 {
-        var list: std.ArrayList(u8) = .{};
-        defer list.deinit(allocator);
-        try self.format(list.writer(allocator));
-        return try list.toOwnedSlice(allocator);
+        var aw: std.Io.Writer.Allocating = .init(allocator);
+        defer aw.deinit();
+        try self.format(&aw.writer);
+        return try aw.toOwnedSlice();
     }
 };
 
@@ -93,10 +93,10 @@ pub const HumanDuration = struct {
     }
 
     pub fn toString(self: Self, allocator: std.mem.Allocator) ![]const u8 {
-        var list: std.ArrayList(u8) = .{};
-        defer list.deinit(allocator);
-        try self.format(list.writer(allocator));
-        return try list.toOwnedSlice(allocator);
+        var aw: std.Io.Writer.Allocating = .init(allocator);
+        defer aw.deinit();
+        try self.format(&aw.writer);
+        return try aw.toOwnedSlice();
     }
 };
 
@@ -126,10 +126,10 @@ pub const HumanCount = struct {
     }
 
     pub fn toString(self: Self, allocator: std.mem.Allocator) ![]const u8 {
-        var list: std.ArrayList(u8) = .{};
-        defer list.deinit(allocator);
-        try self.format(list.writer(allocator));
-        return try list.toOwnedSlice(allocator);
+        var aw: std.Io.Writer.Allocating = .init(allocator);
+        defer aw.deinit();
+        try self.format(&aw.writer);
+        return try aw.toOwnedSlice();
     }
 };
 

--- a/src/indicatif/multi_progress.zig
+++ b/src/indicatif/multi_progress.zig
@@ -1,11 +1,12 @@
 const std = @import("std");
+const global_io = @import("../global_io.zig");
 const ProgressBar = @import("progress_bar.zig").ProgressBar;
 
 /// MultiProgress manages multiple progress bars
 pub const MultiProgress = struct {
     allocator: std.mem.Allocator,
-    bars: std.ArrayList(*ProgressBar) = .{},
-    mutex: std.Thread.Mutex = .{},
+    bars: std.ArrayList(*ProgressBar) = .empty,
+    mutex: std.Io.Mutex = .init,
     draw_enabled: bool = true,
     last_total_lines: usize = 0,
 
@@ -27,8 +28,8 @@ pub const MultiProgress = struct {
 
     /// Add a progress bar to the multi-progress
     pub fn add(self: *Self, bar: *ProgressBar) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
 
         // Disable individual drawing for bars managed by MultiProgress
         bar.draw_enabled = false;
@@ -37,8 +38,8 @@ pub const MultiProgress = struct {
 
     /// Remove a progress bar
     pub fn remove(self: *Self, bar: *ProgressBar) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
 
         for (self.bars.items, 0..) |b, i| {
             if (b == bar) {
@@ -51,8 +52,8 @@ pub const MultiProgress = struct {
 
     /// Move a progress bar to the end of the list
     pub fn moveToEnd(self: *Self, bar: *ProgressBar) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
 
         // Find and remove the bar from its current position
         for (self.bars.items, 0..) |b, i| {
@@ -70,10 +71,10 @@ pub const MultiProgress = struct {
         if (!self.draw_enabled) return;
 
         // Build the entire output in a single buffer to ensure atomic write
-        var output_buffer = std.ArrayList(u8){};
-        defer output_buffer.deinit(self.allocator);
+        var output_aw: std.Io.Writer.Allocating = .init(self.allocator);
+        defer output_aw.deinit();
 
-        const writer = output_buffer.writer(self.allocator);
+        const writer = &output_aw.writer;
 
         // Move cursor up to the start of our drawing area
         if (self.last_total_lines > 0) {
@@ -81,17 +82,17 @@ pub const MultiProgress = struct {
         }
 
         // Pre-allocate buffer for individual bar rendering
-        var bar_buffer: std.ArrayList(u8) = .{};
-        defer bar_buffer.deinit(self.allocator);
-        try bar_buffer.ensureTotalCapacity(self.allocator, 512);
+        var bar_aw: std.Io.Writer.Allocating = .init(self.allocator);
+        defer bar_aw.deinit();
+        try bar_aw.ensureTotalCapacity(512);
 
         // Draw each progress bar
         var total_lines: usize = 0;
         for (self.bars.items) |bar| {
-            bar_buffer.clearRetainingCapacity();
+            bar_aw.clearRetainingCapacity();
 
-            try bar.style.format(bar.state, bar.width, bar_buffer.writer(self.allocator));
-            try writer.print("\x1b[K{s}\n", .{bar_buffer.items});
+            try bar.style.format(bar.state, bar.width, &bar_aw.writer);
+            try writer.print("\x1b[K{s}\n", .{bar_aw.written()});
 
             total_lines += 1;
         }
@@ -105,13 +106,13 @@ pub const MultiProgress = struct {
         self.last_total_lines = self.bars.items.len;
 
         // Single atomic write to terminal
-        std.debug.print("{s}", .{output_buffer.items});
+        std.debug.print("{s}", .{output_aw.written()});
     }
 
     /// Draw all progress bars
     pub fn draw(self: *Self) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
         try self.drawInternal();
     }
 
@@ -121,10 +122,10 @@ pub const MultiProgress = struct {
 
         if (self.last_total_lines > 0) {
             // Build the entire clear sequence in a single buffer
-            var output_buffer = std.ArrayList(u8){};
-            defer output_buffer.deinit(self.allocator);
+            var output_aw: std.Io.Writer.Allocating = .init(self.allocator);
+            defer output_aw.deinit();
 
-            const writer = output_buffer.writer(self.allocator);
+            const writer = &output_aw.writer;
 
             // Move cursor up
             try writer.print("\x1b[{d}F", .{self.last_total_lines});
@@ -139,7 +140,7 @@ pub const MultiProgress = struct {
             try writer.print("\x1b[{d}F", .{self.last_total_lines});
 
             // Single atomic write
-            std.debug.print("{s}", .{output_buffer.items});
+            std.debug.print("{s}", .{output_aw.written()});
         }
 
         self.last_total_lines = 0;
@@ -147,21 +148,21 @@ pub const MultiProgress = struct {
 
     /// Clear all progress bars from the terminal
     pub fn clear(self: *Self) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
         try self.clearInternal();
     }
 
     /// Print a message above all progress bars
     pub fn println(self: *Self, msg: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
 
         // Build the entire sequence (clear + message + redraw) in a single buffer
-        var output_buffer = std.ArrayList(u8){};
-        defer output_buffer.deinit(self.allocator);
+        var output_aw: std.Io.Writer.Allocating = .init(self.allocator);
+        defer output_aw.deinit();
 
-        const writer = output_buffer.writer(self.allocator);
+        const writer = &output_aw.writer;
 
         // 1. Clear sequence
         if (self.last_total_lines > 0) {
@@ -181,15 +182,15 @@ pub const MultiProgress = struct {
             try writer.print("\x1b[{d}F", .{self.last_total_lines});
         }
 
-        var bar_buffer: std.ArrayList(u8) = .{};
-        defer bar_buffer.deinit(self.allocator);
-        try bar_buffer.ensureTotalCapacity(self.allocator, 512);
+        var bar_aw: std.Io.Writer.Allocating = .init(self.allocator);
+        defer bar_aw.deinit();
+        try bar_aw.ensureTotalCapacity(512);
 
         var total_lines: usize = 0;
         for (self.bars.items) |bar| {
-            bar_buffer.clearRetainingCapacity();
-            try bar.style.format(bar.state, bar.width, bar_buffer.writer(self.allocator));
-            try writer.print("\x1b[K{s}\n", .{bar_buffer.items});
+            bar_aw.clearRetainingCapacity();
+            try bar.style.format(bar.state, bar.width, &bar_aw.writer);
+            try writer.print("\x1b[K{s}\n", .{bar_aw.written()});
             total_lines += 1;
         }
 
@@ -201,7 +202,7 @@ pub const MultiProgress = struct {
         self.last_total_lines = self.bars.items.len;
 
         // Single atomic write
-        std.debug.print("{s}", .{output_buffer.items});
+        std.debug.print("{s}", .{output_aw.written()});
     }
 
     /// Join all bars (wait for them to finish)
@@ -209,18 +210,18 @@ pub const MultiProgress = struct {
         while (true) {
             var all_finished = true;
 
-            self.mutex.lock();
+            self.mutex.lockUncancelable(global_io.io());
             for (self.bars.items) |bar| {
                 if (!bar.isFinished()) {
                     all_finished = false;
                     break;
                 }
             }
-            self.mutex.unlock();
+            self.mutex.unlock(global_io.io());
 
             if (all_finished) break;
 
-            std.time.sleep(50 * std.time.ns_per_ms);
+            global_io.io().sleep(.fromNanoseconds(50 * std.time.ns_per_ms), .awake) catch {};
             self.draw() catch {};
         }
     }

--- a/src/indicatif/progress_bar.zig
+++ b/src/indicatif/progress_bar.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const global_io = @import("../global_io.zig");
 const ProgressState = @import("progress_state.zig").ProgressState;
 const ProgressStyle = @import("progress_style.zig").ProgressStyle;
 
@@ -11,7 +12,7 @@ pub const ProgressBar = struct {
     steady_tick_thread: ?std.Thread = null,
     steady_tick_running: bool = false,
     width: usize = 80,
-    buffer: std.ArrayList(u8) = .{},
+    buffer: std.ArrayList(u8) = .empty,
     last_draw_len: usize = 0,
 
     const Self = @This();
@@ -141,7 +142,7 @@ pub const ProgressBar = struct {
 
     fn steadyTickWorker(self: *Self, interval_ms: u64) void {
         while (self.steady_tick_running) {
-            std.Thread.sleep(interval_ms * std.time.ns_per_ms);
+            global_io.io().sleep(.fromNanoseconds(@intCast(interval_ms * std.time.ns_per_ms)), .awake) catch {};
             if (!self.steady_tick_running) break;
             // Use tickNoDraw when managed by MultiProgress
             if (self.draw_enabled) {
@@ -197,15 +198,16 @@ pub const ProgressBar = struct {
         if (self.state.isFinished() and self.last_draw_len == 0) return;
 
         self.buffer.clearRetainingCapacity();
-        const writer = self.buffer.writer(self.allocator);
+        var aw: std.Io.Writer.Allocating = .fromArrayList(self.allocator, &self.buffer);
+        defer self.buffer = aw.toArrayList();
 
         // Format using the style template
-        try self.style.format(self.state, self.width, writer);
+        try self.style.format(self.state, self.width, &aw.writer);
 
         // Move cursor to beginning of line and clear, then write
-        std.debug.print("\r\x1b[K{s}", .{self.buffer.items});
+        std.debug.print("\r\x1b[K{s}", .{aw.written()});
 
-        self.last_draw_len = self.buffer.items.len;
+        self.last_draw_len = aw.written().len;
     }
 
     /// Print a message above the progress bar

--- a/src/indicatif/progress_state.zig
+++ b/src/indicatif/progress_state.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const global_io = @import("../global_io.zig");
 
 /// ProgressState holds the current state of a progress bar
 pub const ProgressState = struct {
@@ -9,7 +10,7 @@ pub const ProgressState = struct {
     message: []const u8 = "",
     prefix: []const u8 = "",
     finished: bool = false,
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = .init,
 
     // WARNING: message and prefix are just pointers!
     // The caller must ensure they remain valid for the lifetime of this state.
@@ -20,55 +21,55 @@ pub const ProgressState = struct {
     pub fn init(len: ?u64) Self {
         return .{
             .len = len,
-            .started = @as(i64, @intCast(std.time.nanoTimestamp())),
+            .started = @as(i64, @intCast(std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds())),
         };
     }
 
     pub fn setPosition(self: *Self, pos: u64) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
         self.pos = pos;
     }
 
     pub fn inc(self: *Self, delta: u64) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
         self.pos += delta;
     }
 
     pub fn setLength(self: *Self, len: u64) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
         self.len = len;
     }
 
     pub fn setMessage(self: *Self, msg: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
         self.message = msg;
     }
 
     pub fn setPrefix(self: *Self, prefix: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
         self.prefix = prefix;
     }
 
     pub fn finish(self: *Self) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
         self.finished = true;
     }
 
     pub fn isFinished(self: *Self) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
         return self.finished;
     }
 
     pub fn percentComplete(self: *Self) f64 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
 
         if (self.len) |len| {
             if (len == 0) return 100.0;
@@ -78,18 +79,18 @@ pub const ProgressState = struct {
     }
 
     pub fn elapsed(self: *Self) i64 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-        return @as(i64, @intCast(std.time.nanoTimestamp())) - self.started;
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
+        return @as(i64, @intCast(std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds())) - self.started;
     }
 
     pub fn eta(self: *Self) i64 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
 
         if (self.len) |len| {
             if (self.pos == 0) return 0;
-            const elapsed_ns = @as(i64, @intCast(std.time.nanoTimestamp())) - self.started;
+            const elapsed_ns = @as(i64, @intCast(std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds())) - self.started;
             const rate = @as(f64, @floatFromInt(elapsed_ns)) / @as(f64, @floatFromInt(self.pos));
             const remaining = len -| self.pos;
             return @as(i64, @intFromFloat(rate * @as(f64, @floatFromInt(remaining))));
@@ -98,10 +99,10 @@ pub const ProgressState = struct {
     }
 
     pub fn perSec(self: *Self) f64 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
 
-        const elapsed_ns = @as(i64, @intCast(std.time.nanoTimestamp())) - self.started;
+        const elapsed_ns = @as(i64, @intCast(std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds())) - self.started;
         if (elapsed_ns == 0) return 0.0;
         const elapsed_sec = @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000_000.0;
         return @as(f64, @floatFromInt(self.pos)) / elapsed_sec;

--- a/src/json.zig
+++ b/src/json.zig
@@ -66,7 +66,7 @@ pub fn freeJsonValue(allocator: std.mem.Allocator, value: *std.json.Value) void 
                 allocator.free(entry.key_ptr.*);
                 freeJsonValue(allocator, entry.value_ptr);
             }
-            obj.deinit();
+            obj.deinit(allocator);
         },
         else => {},
     }
@@ -120,7 +120,7 @@ pub fn mrubyValueToJsonValue(mrb: *mruby.mrb_state, allocator: std.mem.Allocator
     } else if (zig_mrb_hash_p(val) != 0) {
         const keys = mrb_hash_keys(mrb, val);
         const len = mruby.mrb_ary_len(mrb, keys);
-        var obj = std.json.ObjectMap.init(allocator);
+        var obj = std.json.ObjectMap.empty;
 
         for (0..@intCast(len)) |i| {
             const key = mruby.mrb_ary_ref(mrb, keys, @intCast(i));
@@ -131,7 +131,7 @@ pub fn mrubyValueToJsonValue(mrb: *mruby.mrb_state, allocator: std.mem.Allocator
             const key_owned = try allocator.dupe(u8, std.mem.span(key_cstr));
 
             const json_value = try mrubyValueToJsonValue(mrb, allocator, value);
-            try obj.put(key_owned, json_value);
+            try obj.put(allocator, key_owned, json_value);
         }
         return .{ .object = obj };
     }

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const zeit = @import("zeit");
+const global_io = @import("global_io.zig");
 
 /// Log levels (similar to std.log)
 pub const Level = enum {
@@ -37,7 +38,7 @@ pub const Level = enum {
 /// Logger for recording external command outputs and operations
 pub const Logger = struct {
     allocator: std.mem.Allocator,
-    log_file: ?std.fs.File = null,
+    log_file: ?std.Io.File = null,
     log_dir: []const u8,
     log_path: ?[]const u8 = null, // Full path to current log file
     enabled: bool = true,
@@ -47,11 +48,12 @@ pub const Logger = struct {
 
     /// Initialize logger with log directory
     pub fn init(allocator: std.mem.Allocator, log_dir: []const u8) !Self {
+        const io = global_io.io();
         // Create log directory recursively if it doesn't exist
-        try std.fs.cwd().makePath(log_dir);
+        try std.Io.Dir.cwd().createDirPath(io, log_dir);
 
         // Read log level from environment variable HOLA_LOG_LEVEL
-        const log_level = if (std.process.getEnvVarOwned(allocator, "HOLA_LOG_LEVEL")) |level_str| blk: {
+        const log_level = if (global_io.getEnvOwned(allocator, "HOLA_LOG_LEVEL")) |level_str| blk: {
             defer allocator.free(level_str);
             break :blk Level.fromString(level_str) orelse .debug;
         } else |_| .debug;
@@ -66,7 +68,7 @@ pub const Logger = struct {
 
     pub fn deinit(self: *Self) void {
         if (self.log_file) |file| {
-            file.close();
+            file.close(global_io.io());
         }
         if (self.log_path) |path| {
             self.allocator.free(path);
@@ -78,17 +80,19 @@ pub const Logger = struct {
     pub fn openLogFile(self: *Self) !void {
         if (!self.enabled) return;
 
+        const io = global_io.io();
+
         // Get current date in YYYYMMDD format (local timezone)
-        const tz = zeit.local(self.allocator, null) catch zeit.utc;
+        const tz = zeit.local(self.allocator, io, .{}) catch zeit.utc;
         defer if (!std.meta.eql(tz, zeit.utc)) tz.deinit();
-        const now = try zeit.instant(.{});
+        const now = zeit.instant(.{ .now = io }, &zeit.utc);
         const now_local = now.in(&tz);
         const dt = now_local.time();
 
         var date_buf: [9]u8 = undefined;
-        var fbs = std.io.fixedBufferStream(&date_buf);
-        dt.strftime(fbs.writer(), "%Y%m%d") catch return error.DateFormatFailed;
-        const date_str = fbs.getWritten();
+        var date_writer = std.Io.Writer.fixed(&date_buf);
+        dt.strftime(&date_writer, "%Y%m%d") catch return error.DateFormatFailed;
+        const date_str = date_writer.buffered();
 
         var log_filename_buf: [128]u8 = undefined;
         const log_filename = try std.fmt.bufPrint(&log_filename_buf, "hola-{s}.log", .{date_str});
@@ -97,16 +101,17 @@ pub const Logger = struct {
         self.log_path = log_path; // Store for later retrieval
 
         // Open file in append mode (create if doesn't exist)
-        self.log_file = try std.fs.createFileAbsolute(log_path, .{ .truncate = false });
-        try self.log_file.?.seekFromEnd(0);
+        self.log_file = try std.Io.Dir.createFileAbsolute(io, log_path, .{ .truncate = false });
 
         // Write session header with timestamp
         var header_buf: [256]u8 = undefined;
-        var header_fbs = std.io.fixedBufferStream(&header_buf);
-        header_fbs.writer().writeAll("\n=== Session started at ") catch {};
-        dt.strftime(header_fbs.writer(), "%Y-%m-%d %H:%M:%S %Z") catch {};
-        header_fbs.writer().writeAll(" ===\n\n") catch {};
-        try self.log_file.?.writeAll(header_fbs.getWritten());
+        var header_writer = std.Io.Writer.fixed(&header_buf);
+        header_writer.writeAll("\n=== Session started at ") catch {};
+        dt.strftime(&header_writer, "%Y-%m-%d %H:%M:%S %Z") catch {};
+        header_writer.writeAll(" ===\n\n") catch {};
+        const header_bytes = header_writer.buffered();
+        const end_pos = try self.log_file.?.length(io);
+        try self.log_file.?.writePositionalAll(io, header_bytes, end_pos);
     }
 
     /// Get the current log file path
@@ -118,7 +123,9 @@ pub const Logger = struct {
     pub fn write(self: *Self, data: []const u8) !void {
         if (!self.enabled) return;
         if (self.log_file) |file| {
-            try file.writeAll(data);
+            const io = global_io.io();
+            const end_pos = try file.length(io);
+            try file.writePositionalAll(io, data, end_pos);
         }
     }
 
@@ -136,7 +143,7 @@ pub const Logger = struct {
         if (!level.shouldLog(self.level)) return;
 
         // Get current timestamp with microsecond precision
-        const timestamp_ns = std.time.nanoTimestamp();
+        const timestamp_ns: i128 = std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds();
         const timestamp_us = @divFloor(timestamp_ns, 1000); // Convert to microseconds
         const timestamp_s = @divFloor(timestamp_us, 1_000_000); // Convert to seconds
         const microseconds: i64 = @intCast(@mod(timestamp_us, 1_000_000));

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const clap = @import("clap");
 const logger = @import("logger.zig");
+const global_io = @import("global_io.zig");
 const help_formatter = @import("help_formatter.zig");
 pub const build_options = @import("build_options");
 const commands = @import("commands.zig");
@@ -18,16 +19,16 @@ const main_parsers = .{
     .command = clap.parsers.string,
 };
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    global_io.set(init.io);
+    global_io.setEnviron(init.environ_map);
 
     // Initialize logger (non-critical, continue if it fails)
     logger.initGlobal(allocator, null) catch {};
     defer logger.deinitGlobal();
 
-    var iter = try std.process.ArgIterator.initWithAllocator(allocator);
+    var iter = init.minimal.args.iterate();
     defer iter.deinit();
     _ = iter.next(); // skip exe name
 
@@ -37,7 +38,7 @@ pub fn main() !void {
         .diagnostic = &diag,
         .terminating_positional = 0,
     }) catch |err| {
-        try diag.reportToFile(std.fs.File.stderr(), err);
+        try diag.reportToFile(init.io, std.Io.File.stderr(), err);
         return;
     };
     defer parsed.deinit();
@@ -60,7 +61,7 @@ pub fn main() !void {
     try printMainHelp(null);
 }
 
-fn dispatchCommand(command: []const u8, allocator: std.mem.Allocator, iter: *std.process.ArgIterator) !void {
+fn dispatchCommand(command: []const u8, allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
     if (std.mem.eql(u8, command, "help")) {
         try printMainHelp(null);
         return;
@@ -251,10 +252,12 @@ test "simple test" {
 
 test "fuzz example" {
     const Context = struct {
-        fn testOne(context: @This(), input: []const u8) anyerror!void {
+        fn testOne(context: @This(), smith: *std.testing.Smith) anyerror!void {
             _ = context;
             // Try passing `--fuzz` to `zig build test` and see if it manages to fail this test case!
-            try std.testing.expect(!std.mem.eql(u8, "canyoufindme", input));
+            var buf: [32]u8 = undefined;
+            const len = smith.slice(&buf);
+            try std.testing.expect(!std.mem.eql(u8, "canyoufindme", buf[0..len]));
         }
     };
     try std.testing.fuzz(Context{}, Context.testOne, .{});

--- a/src/modern_provision_display.zig
+++ b/src/modern_provision_display.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const global_io = @import("global_io.zig");
 const indicatif = @import("indicatif.zig");
 const ansi = @import("ansi_term");
 const ansi_constants = @import("ansi_constants.zig");
@@ -29,7 +30,7 @@ pub const ModernProvisionDisplay = struct {
     allocator: std.mem.Allocator,
     mp: indicatif.MultiProgress,
     download_spinners: std.StringHashMap(DownloadEntry),
-    download_spinners_mutex: std.Thread.Mutex = .{},
+    download_spinners_mutex: std.Io.Mutex = .init,
     download_finished_messages: std.ArrayList([]const u8), // Keep finished messages allocated
     section_messages: std.ArrayList([]const u8), // Keep section header messages allocated
     download_section_spinner: ?*indicatif.ProgressBar = null, // Static section header for downloads
@@ -150,7 +151,8 @@ pub const ModernProvisionDisplay = struct {
         if (!self.show_progress) return;
         if (self.timer_spinner == null) return;
 
-        const current_time = std.time.nanoTimestamp();
+        const io = global_io.io();
+        const current_time: i128 = std.Io.Timestamp.now(io, .real).toNanoseconds();
         const elapsed_ns = current_time - self.start_time;
         const elapsed_ms = @divTrunc(elapsed_ns, std.time.ns_per_ms);
         const elapsed_s = @divTrunc(elapsed_ms, 1000);
@@ -177,7 +179,8 @@ pub const ModernProvisionDisplay = struct {
         if (!self.show_progress) return;
         if (self.timer_spinner == null) return;
 
-        const current_time = std.time.nanoTimestamp();
+        const io = global_io.io();
+        const current_time: i128 = std.Io.Timestamp.now(io, .real).toNanoseconds();
         const elapsed_ns = current_time - self.start_time;
         const elapsed_ms = @divTrunc(elapsed_ns, std.time.ns_per_ms);
         const elapsed_s = @divTrunc(elapsed_ms, 1000);
@@ -299,9 +302,9 @@ pub const ModernProvisionDisplay = struct {
         if (!self.show_progress) return;
 
         for (names) |name| {
-            self.download_spinners_mutex.lock();
+            self.download_spinners_mutex.lockUncancelable(global_io.io());
             const already_exists = self.download_spinners.contains(name);
-            self.download_spinners_mutex.unlock();
+            self.download_spinners_mutex.unlock(global_io.io());
             if (already_exists) continue;
 
             const spinner = try self.mp.addSpinner();
@@ -314,9 +317,9 @@ pub const ModernProvisionDisplay = struct {
             spinner.setMessage(label);
             spinner.setPrefix(STATUS_PENDING);
 
-            self.download_spinners_mutex.lock();
+            self.download_spinners_mutex.lockUncancelable(global_io.io());
             try self.download_spinners.put(name_copy, .{ .spinner = spinner, .label = label });
-            self.download_spinners_mutex.unlock();
+            self.download_spinners_mutex.unlock(global_io.io());
         }
     }
 
@@ -327,8 +330,8 @@ pub const ModernProvisionDisplay = struct {
             return;
         }
 
-        self.download_spinners_mutex.lock();
-        defer self.download_spinners_mutex.unlock();
+        self.download_spinners_mutex.lockUncancelable(global_io.io());
+        defer self.download_spinners_mutex.unlock(global_io.io());
 
         if (self.download_spinners.getPtr(name)) |entry| {
             // Update existing entry
@@ -369,8 +372,8 @@ pub const ModernProvisionDisplay = struct {
     pub fn updateDownload(self: *Self, name: []const u8, bytes_downloaded: u64) !void {
         if (!self.show_progress) return;
 
-        self.download_spinners_mutex.lock();
-        defer self.download_spinners_mutex.unlock();
+        self.download_spinners_mutex.lockUncancelable(global_io.io());
+        defer self.download_spinners_mutex.unlock(global_io.io());
 
         if (self.download_spinners.getPtr(name)) |entry| {
             entry.bytes_downloaded = bytes_downloaded;
@@ -420,9 +423,9 @@ pub const ModernProvisionDisplay = struct {
             return;
         }
 
-        self.download_spinners_mutex.lock();
+        self.download_spinners_mutex.lockUncancelable(global_io.io());
         if (self.download_spinners.getPtr(name)) |entry| {
-            self.download_spinners_mutex.unlock();
+            self.download_spinners_mutex.unlock(global_io.io());
 
             const status_text = if (success) "done" else "failed";
             const label_text = entry.label orelse name;
@@ -445,7 +448,7 @@ pub const ModernProvisionDisplay = struct {
             entry.spinner.state.finish();
             entry.spinner.setPrefix(if (success) STATUS_DONE else STATUS_FAILED);
         } else {
-            self.download_spinners_mutex.unlock();
+            self.download_spinners_mutex.unlock(global_io.io());
         }
     }
 
@@ -661,7 +664,8 @@ pub const ModernProvisionDisplay = struct {
                 std.debug.print("Failed: \x1b[31m{d}\x1b[0m resources\n", .{self.failed_count});
             }
 
-            const current_time = std.time.nanoTimestamp();
+            const io = global_io.io();
+            const current_time: i128 = std.Io.Timestamp.now(io, .real).toNanoseconds();
             const elapsed_ns = current_time - self.start_time;
             const elapsed_ms = @divTrunc(elapsed_ns, std.time.ns_per_ms);
             const elapsed_s = @divTrunc(elapsed_ms, 1000);
@@ -685,7 +689,7 @@ pub const ModernProvisionDisplay = struct {
         try self.updateTimer();
 
         // Tick all ACTIVE spinners to animate them (only those still in the HashMap)
-        self.download_spinners_mutex.lock();
+        self.download_spinners_mutex.lockUncancelable(global_io.io());
         var iter = self.download_spinners.valueIterator();
         while (iter.next()) |entry_ptr| {
             const entry = entry_ptr.*;
@@ -693,7 +697,7 @@ pub const ModernProvisionDisplay = struct {
                 entry.spinner.tickNoDraw();
             }
         }
-        self.download_spinners_mutex.unlock();
+        self.download_spinners_mutex.unlock(global_io.io());
 
         if (self.resource_spinner) |spinner| {
             spinner.tickNoDraw();
@@ -709,17 +713,17 @@ pub const ModernProvisionDisplay = struct {
     }
 
     fn makeColoredMessage(self: *Self, color: AnsiColor, bold: bool, text: []const u8) ![]u8 {
-        var buffer = std.ArrayList(u8){};
-        errdefer buffer.deinit(self.allocator);
+        var aw: std.Io.Writer.Allocating = .init(self.allocator);
+        errdefer aw.deinit();
         const style = AnsiStyle{
             .foreground = color,
             .font_style = if (bold) .{ .bold = true } else .{},
         };
-        var writer = buffer.writer(self.allocator);
+        const writer = &aw.writer;
         try ansi.format.updateStyle(writer, style, null);
         try writer.writeAll(text);
         try ansi.format.resetStyle(writer);
-        return try buffer.toOwnedSlice(self.allocator);
+        return try aw.toOwnedSlice();
     }
 
     fn buildResourceMessage(self: *Self, resource_type: []const u8, resource_name: []const u8, suffix: []const u8) ![]u8 {

--- a/src/node_info.zig
+++ b/src/node_info.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const global_io = @import("global_io.zig");
 const mruby = @import("mruby.zig");
 const builtin = @import("builtin");
 const http_client = @import("http/client.zig");
@@ -471,10 +472,13 @@ fn isRunningOnEc2() bool {
     }
 
     // Best method: Check system vendor (works for all EC2 instance types)
-    if (std.fs.cwd().openFile("/sys/class/dmi/id/sys_vendor", .{})) |file| {
-        defer file.close();
+    const io = global_io.io();
+    if (std.Io.Dir.cwd().openFile(io, "/sys/class/dmi/id/sys_vendor", .{})) |file| {
+        defer file.close(io);
         var buf: [64]u8 = undefined;
-        if (file.readAll(&buf)) |n| {
+        var read_buf: [64]u8 = undefined;
+        var file_reader = file.readerStreaming(io, &read_buf);
+        if (file_reader.interface.readSliceShort(&buf)) |n| {
             const content = std.mem.trim(u8, buf[0..n], " \n\r\t");
             // Amazon EC2 instances report "Amazon EC2" as sys_vendor
             if (std.mem.eql(u8, content, "Amazon EC2")) {
@@ -669,10 +673,13 @@ fn parseEc2IdentityDocument(allocator: std.mem.Allocator, json_body: []const u8)
 pub fn getLsbInfo(allocator: std.mem.Allocator) !?LsbInfo {
     if (builtin.os.tag != .linux) return null;
 
-    const file = std.fs.cwd().openFile("/etc/os-release", .{}) catch return null;
-    defer file.close();
+    const io = global_io.io();
+    const file = std.Io.Dir.cwd().openFile(io, "/etc/os-release", .{}) catch return null;
+    defer file.close(io);
 
-    const content = try file.readToEndAlloc(allocator, 8192);
+    var read_buf: [4096]u8 = undefined;
+    var file_reader = file.readerStreaming(io, &read_buf);
+    const content = try file_reader.interface.allocRemaining(allocator, .limited(8192));
     defer allocator.free(content);
 
     var id: ?[]const u8 = null;
@@ -804,10 +811,13 @@ fn getDefaultGatewayMacOS(allocator: std.mem.Allocator) !?DefaultGateway {
 
 /// Get default gateway on Linux by reading /proc/net/route
 fn getDefaultGatewayLinux(allocator: std.mem.Allocator) !?DefaultGateway {
-    const file = std.fs.cwd().openFile("/proc/net/route", .{}) catch return null;
-    defer file.close();
+    const io = global_io.io();
+    const file = std.Io.Dir.cwd().openFile(io, "/proc/net/route", .{}) catch return null;
+    defer file.close(io);
 
-    const content = try file.readToEndAlloc(allocator, 8192);
+    var read_buf: [4096]u8 = undefined;
+    var file_reader = file.readerStreaming(io, &read_buf);
+    const content = try file_reader.interface.allocRemaining(allocator, .limited(8192));
     defer allocator.free(content);
 
     var lines = std.mem.splitScalar(u8, content, '\n');
@@ -1318,10 +1328,13 @@ fn getCpuInfoMacOS(allocator: std.mem.Allocator) !CPU {
 fn getCpuInfoLinux(allocator: std.mem.Allocator) !CPU {
     var cpu = CPU{ .architecture = getCpuArch() };
 
-    const file = std.fs.cwd().openFile("/proc/cpuinfo", .{}) catch return cpu;
-    defer file.close();
+    const io = global_io.io();
+    const file = std.Io.Dir.cwd().openFile(io, "/proc/cpuinfo", .{}) catch return cpu;
+    defer file.close(io);
 
-    const content = try file.readToEndAlloc(allocator, 65536);
+    var read_buf: [4096]u8 = undefined;
+    var file_reader = file.readerStreaming(io, &read_buf);
+    const content = try file_reader.interface.allocRemaining(allocator, .limited(65536));
     defer allocator.free(content);
 
     var processor_count: u32 = 0;
@@ -1394,8 +1407,7 @@ fn getMemoryInfoMacOS(allocator: std.mem.Allocator) !Memory {
     }
 
     // Use vm_stat command to get memory statistics
-    const result = std.process.Child.run(.{
-        .allocator = allocator,
+    const result = std.process.run(allocator, global_io.io(), .{
         .argv = &[_][]const u8{"vm_stat"},
     }) catch return memory;
     defer allocator.free(result.stdout);
@@ -1487,10 +1499,13 @@ fn convertKBtoMB(allocator: std.mem.Allocator, value_str: []const u8) ![]const u
 fn getMemoryInfoLinux(allocator: std.mem.Allocator) !Memory {
     var memory = Memory{};
 
-    const file = std.fs.cwd().openFile("/proc/meminfo", .{}) catch return memory;
-    defer file.close();
+    const io = global_io.io();
+    const file = std.Io.Dir.cwd().openFile(io, "/proc/meminfo", .{}) catch return memory;
+    defer file.close(io);
 
-    const content = try file.readToEndAlloc(allocator, 8192);
+    var read_buf: [4096]u8 = undefined;
+    var file_reader = file.readerStreaming(io, &read_buf);
+    const content = try file_reader.interface.allocRemaining(allocator, .limited(8192));
     defer allocator.free(content);
 
     var lines = std.mem.splitScalar(u8, content, '\n');

--- a/src/notifications.zig
+++ b/src/notifications.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const global_io = @import("global_io.zig");
 
 /// Send a macOS notification with title, subtitle, and body using AppleScript
 /// Uses osascript command specifically for notifications
@@ -34,11 +35,13 @@ pub fn notify(allocator: std.mem.Allocator, title: []const u8, subtitle: ?[]cons
 
     // Use osascript for notifications specifically (not because NSAppleScript doesn't work,
     // but because 'display notification' requires special permissions only osascript has)
-    var proc = std.process.Child.init(&[_][]const u8{ "osascript", "-e", script }, allocator);
-    proc.stdout_behavior = .Ignore;
-    proc.stderr_behavior = .Ignore;
-
-    _ = try proc.spawnAndWait();
+    const io = global_io.io();
+    var proc = try std.process.spawn(io, .{
+        .argv = &[_][]const u8{ "osascript", "-e", script },
+        .stdout = .ignore,
+        .stderr = .ignore,
+    });
+    _ = try proc.wait(io);
 }
 
 /// Send a simple notification with just title and body

--- a/src/plist.zig
+++ b/src/plist.zig
@@ -25,6 +25,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const global_io = @import("global_io.zig");
 
 // Only compile on macOS
 comptime {
@@ -33,9 +34,7 @@ comptime {
     }
 }
 
-const c = @cImport({
-    @cInclude("CoreFoundation/CoreFoundation.h");
-});
+const c = @import("cf.zig").c;
 
 /// Error types for plist operations
 pub const Error = error{
@@ -381,7 +380,7 @@ pub const Dictionary = struct {
         const cf_keys = try allocator.alloc(c.CFStringRef, @intCast(count));
         defer allocator.free(cf_keys);
 
-        c.CFDictionaryGetKeysAndValues(self.cf_dict, cf_keys.ptr, null);
+        c.CFDictionaryGetKeysAndValues(self.cf_dict, @ptrCast(cf_keys.ptr), null);
 
         for (0..@intCast(count)) |i| {
             const cf_key = cf_keys[i];
@@ -520,7 +519,7 @@ test "create and manipulate dictionary" {
 
 test "read and write plist file" {
     const gpa = std.testing.allocator;
-    const tmp_dir = std.fs.cwd();
+    const tmp_dir = std.Io.Dir.cwd();
     const test_file = "/tmp/test_hola.plist";
 
     // Create a test dictionary
@@ -546,5 +545,5 @@ test "read and write plist file" {
     int_val.deinit(gpa);
 
     // Cleanup
-    _ = tmp_dir.deleteFile(test_file) catch {};
+    _ = tmp_dir.deleteFile(global_io.io(), test_file) catch {};
 }

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const global_io = @import("global_io.zig");
 const mruby = @import("mruby.zig");
 const mruby_module = @import("mruby_module.zig");
 const resources = @import("resources.zig");
@@ -942,7 +943,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     };
 
     // Record start time for timer
-    const start_time = std.time.nanoTimestamp();
+    const start_time: i128 = std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds();
 
     // Initialize resource results collection
     var resource_results = std.ArrayList(ResourceResult).empty;
@@ -991,14 +992,14 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
         display: *modern_display.ModernProvisionDisplay,
         allocator: std.mem.Allocator,
         tasks: *std.ArrayList(http.download.Task),
-        mutex: *std.Thread.Mutex,
+        mutex: *std.Io.Mutex,
         initialized: [256]std.atomic.Value(bool), // Fixed size array with atomic values
 
         fn callback(ctx_ptr: *anyopaque, task_index: usize, downloaded: usize, total: usize) void {
             const ctx: *@This() = @ptrCast(@alignCast(ctx_ptr));
 
-            ctx.mutex.lock();
-            defer ctx.mutex.unlock();
+            ctx.mutex.lockUncancelable(global_io.io());
+            defer ctx.mutex.unlock(global_io.io());
 
             if (task_index >= ctx.tasks.items.len or task_index >= 256) return;
 
@@ -1026,7 +1027,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
         }
     };
 
-    var progress_mutex = std.Thread.Mutex{};
+    var progress_mutex: std.Io.Mutex = .init;
     const progress_ctx = try allocator.create(ProgressContext);
     defer allocator.destroy(progress_ctx);
     progress_ctx.* = .{
@@ -1219,7 +1220,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
 
                         try display.update();
                         std.Thread.yield() catch {};
-                        std.Thread.sleep(10 * std.time.ns_per_ms);
+                        global_io.io().sleep(.fromNanoseconds(10 * std.time.ns_per_ms), .awake) catch {};
                         max_wait_iterations -= 1;
                     }
                 }
@@ -1364,7 +1365,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     try display.showSummaryWithDuration(0, 0);
 
     // Compute duration
-    const end_time = std.time.nanoTimestamp();
+    const end_time: i128 = std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds();
     const elapsed_ms = @divTrunc(end_time - start_time, std.time.ns_per_ms);
 
     return ProvisionResult{

--- a/src/resolv.zig
+++ b/src/resolv.zig
@@ -25,24 +25,20 @@ pub fn zig_resolv_getaddress(mrb: *mruby.mrb_state, _: mruby.mrb_value) callconv
 
     const hostname = name_ptr[0..@intCast(name_len)];
 
+    _ = allocator;
+
     // Resolve DNS
-    const address_list = std.net.getAddressList(allocator, hostname, 0) catch {
+    var addrs: [simple_dns.max_lookup_results]std.Io.net.IpAddress = undefined;
+    const count = simple_dns.lookupHost(hostname, &addrs) catch {
         return mruby.mrb_nil_value();
     };
-    defer address_list.deinit();
 
     // Find first IPv4 address
-    for (address_list.addrs) |addr| {
-        if (addr.any.family == std.posix.AF.INET) {
-            // Format IPv4 address
-            const addr_bytes = @as(*const [4]u8, @ptrCast(&addr.in.sa.addr));
+    for (addrs[0..count]) |addr| {
+        if (addr == .ip4) {
+            const b = addr.ip4.bytes;
             var ip_buf: [16]u8 = undefined;
-            const ip_str = std.fmt.bufPrint(&ip_buf, "{d}.{d}.{d}.{d}", .{
-                addr_bytes[0],
-                addr_bytes[1],
-                addr_bytes[2],
-                addr_bytes[3],
-            }) catch {
+            const ip_str = std.fmt.bufPrint(&ip_buf, "{d}.{d}.{d}.{d}", .{ b[0], b[1], b[2], b[3] }) catch {
                 return mruby.mrb_nil_value();
             };
 
@@ -127,38 +123,34 @@ pub fn zig_resolv_getaddresses(mrb: *mruby.mrb_state, _: mruby.mrb_value) callco
     }
 
     // Use system resolver
-    const address_list = std.net.getAddressList(allocator, hostname, 0) catch {
+    var addrs: [simple_dns.max_lookup_results]std.Io.net.IpAddress = undefined;
+    const count = simple_dns.lookupHost(hostname, &addrs) catch {
         return mruby.mrb_nil_value();
     };
-    defer address_list.deinit();
 
     // Create result array
     const result = mruby.mrb_ary_new_capa(mrb, 8);
 
     var ip_buf: [46]u8 = undefined;
 
-    for (address_list.addrs) |addr| {
-        const ip_str = if (addr.any.family == std.posix.AF.INET) blk: {
-            // IPv4
-            const addr_bytes = @as(*const [4]u8, @ptrCast(&addr.in.sa.addr));
-            break :blk std.fmt.bufPrint(&ip_buf, "{d}.{d}.{d}.{d}", .{
-                addr_bytes[0],
-                addr_bytes[1],
-                addr_bytes[2],
-                addr_bytes[3],
-            }) catch continue;
-        } else if (addr.any.family == std.posix.AF.INET6) blk: {
-            // IPv6
-            const addr_bytes = &addr.in6.sa.addr;
-            var parts: [8]u16 = undefined;
-            for (0..8) |i| {
-                parts[i] = (@as(u16, addr_bytes[i * 2]) << 8) | addr_bytes[i * 2 + 1];
-            }
-            break :blk std.fmt.bufPrint(&ip_buf, "{x}:{x}:{x}:{x}:{x}:{x}:{x}:{x}", .{
-                parts[0], parts[1], parts[2], parts[3],
-                parts[4], parts[5], parts[6], parts[7],
-            }) catch continue;
-        } else continue;
+    for (addrs[0..count]) |addr| {
+        const ip_str = switch (addr) {
+            .ip4 => |ip4| blk: {
+                const b = ip4.bytes;
+                break :blk std.fmt.bufPrint(&ip_buf, "{d}.{d}.{d}.{d}", .{ b[0], b[1], b[2], b[3] }) catch continue;
+            },
+            .ip6 => |ip6| blk: {
+                const addr_bytes = &ip6.bytes;
+                var parts: [8]u16 = undefined;
+                for (0..8) |i| {
+                    parts[i] = (@as(u16, addr_bytes[i * 2]) << 8) | addr_bytes[i * 2 + 1];
+                }
+                break :blk std.fmt.bufPrint(&ip_buf, "{x}:{x}:{x}:{x}:{x}:{x}:{x}:{x}", .{
+                    parts[0], parts[1], parts[2], parts[3],
+                    parts[4], parts[5], parts[6], parts[7],
+                }) catch continue;
+            },
+        };
 
         const ip_mrb = mruby.mrb_str_new(mrb, ip_str.ptr, @intCast(ip_str.len));
         mruby.mrb_ary_push(mrb, result, ip_mrb);

--- a/src/resources/apt_package.zig
+++ b/src/resources/apt_package.zig
@@ -5,6 +5,7 @@ const logger = @import("../logger.zig");
 const builtin = @import("builtin");
 const AsyncExecutor = @import("../async_executor.zig").AsyncExecutor;
 const common = @import("package_common.zig");
+const global_io = @import("../global_io.zig");
 
 // Only compile on Linux
 comptime {
@@ -254,50 +255,50 @@ fn isInstalled(allocator: std.mem.Allocator, name: []const u8) !bool {
     const cmd = try std.fmt.allocPrint(allocator, "dpkg-query -W -f='${{Status}}' {s} 2>/dev/null | grep -q 'install ok installed'", .{name});
     defer allocator.free(cmd);
 
-    var child = std.process.Child.init(&[_][]const u8{ "/bin/sh", "-c", cmd }, allocator);
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
+    const result = try std.process.run(allocator, global_io.io(), .{
+        .argv = &[_][]const u8{ "/bin/sh", "-c", cmd },
+        .stdout_limit = .limited(1024 * 1024),
+        .stderr_limit = .limited(1024 * 1024),
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
 
-    try child.spawn();
-    const stdout = try child.stdout.?.readToEndAlloc(allocator, 1024 * 1024);
-    defer allocator.free(stdout);
-    const stderr = try child.stderr.?.readToEndAlloc(allocator, 1024 * 1024);
-    defer allocator.free(stderr);
-
-    const term = try child.wait();
-    return switch (term) {
-        .Exited => |code| code == 0,
+    return switch (result.term) {
+        .exited => |code| code == 0,
         else => false,
     };
 }
 
 /// Execute an APT command with appropriate error mapping based on action
 fn runCommand(allocator: std.mem.Allocator, cmd: []const u8, action: common.Action, packages: []const []const u8) !void {
-    var child = std.process.Child.init(&[_][]const u8{ "/bin/sh", "-c", cmd }, allocator);
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
+    // Set Debian/APT-specific environment variables on top of the parent
+    // environment. When the process env map is unavailable (unit tests, before
+    // main ran), inherit the real parent env instead of spawning with only the
+    // overrides.
+    var env_map_storage: ?std.process.Environ.Map = null;
+    defer if (env_map_storage) |*map| map.deinit();
+    var environ_map: ?*const std.process.Environ.Map = null;
+    if (global_io.environMap()) |parent| {
+        var env_map = try parent.clone(allocator);
+        try env_map.put("DEBIAN_FRONTEND", "noninteractive");
+        try env_map.put("APT_LISTCHANGES_FRONTEND", "none");
+        try env_map.put("NEEDRESTART_MODE", "l"); // Avoid needrestart prompts
+        env_map_storage = env_map;
+        environ_map = &env_map_storage.?;
+    }
 
-    // Set stdin to /dev/null to prevent any interactive prompts
-    child.stdin_behavior = .Ignore;
+    // stdin is set to /dev/null (via std.process.run) to prevent interactive prompts
+    const result = try std.process.run(allocator, global_io.io(), .{
+        .argv = &[_][]const u8{ "/bin/sh", "-c", cmd },
+        .environ_map = environ_map,
+    });
 
-    // Set Debian/APT-specific environment variables
-    var env_map = try std.process.getEnvMap(allocator);
-    defer env_map.deinit();
-
-    try env_map.put("DEBIAN_FRONTEND", "noninteractive");
-    try env_map.put("APT_LISTCHANGES_FRONTEND", "none");
-    try env_map.put("NEEDRESTART_MODE", "l"); // Avoid needrestart prompts
-
-    child.env_map = &env_map;
-
-    try child.spawn();
-
-    const stdout = try child.stdout.?.readToEndAlloc(allocator, std.math.maxInt(usize));
-    const stderr = try child.stderr.?.readToEndAlloc(allocator, std.math.maxInt(usize));
+    const stdout = result.stdout;
+    const stderr = result.stderr;
     defer allocator.free(stdout);
     defer allocator.free(stderr);
 
-    const term = try child.wait();
+    const term = result.term;
 
     // Log output (but don't display it)
     if (stdout.len > 0) {
@@ -316,7 +317,7 @@ fn runCommand(allocator: std.mem.Allocator, cmd: []const u8, action: common.Acti
 
     // Check exit status and return appropriate error based on action
     switch (term) {
-        .Exited => |code| {
+        .exited => |code| {
             if (code != 0) {
                 // Format package list for error message
                 const pkg_list = std.mem.join(allocator, ", ", packages) catch "unknown";
@@ -336,10 +337,10 @@ fn runCommand(allocator: std.mem.Allocator, cmd: []const u8, action: common.Acti
                 };
             }
         },
-        .Signal => |sig| {
+        .signal => |sig| {
             const pkg_list = std.mem.join(allocator, ", ", packages) catch "unknown";
             defer if (pkg_list.ptr != "unknown".ptr) allocator.free(pkg_list);
-            logger.err("[apt_package] command killed by signal {d} for package(s): {s}", .{ sig, pkg_list });
+            logger.err("[apt_package] command killed by signal {d} for package(s): {s}", .{ @intFromEnum(sig), pkg_list });
             return common.PackageError.CommandFailed;
         },
         else => {

--- a/src/resources/apt_repository.zig
+++ b/src/resources/apt_repository.zig
@@ -3,6 +3,7 @@ const mruby = @import("../mruby.zig");
 const base = @import("../base_resource.zig");
 const http = @import("../http.zig");
 const logger = @import("../logger.zig");
+const global_io = @import("../global_io.zig");
 
 /// APT repository resource data structure
 /// Manages APT repositories on Debian/Ubuntu systems
@@ -81,7 +82,8 @@ pub const Resource = struct {
     }
 
     fn applyAdd(self: Resource) !bool {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        const io = global_io.io();
+        var gpa = std.heap.DebugAllocator(.{}){};
         defer _ = gpa.deinit();
         const allocator = gpa.allocator();
 
@@ -92,7 +94,7 @@ pub const Resource = struct {
         // Step 1: Download GPG key if specified
         if (self.key_url) |key_url| {
             // Create keyrings directory if it doesn't exist
-            std.fs.cwd().makePath("/etc/apt/keyrings") catch |err| {
+            std.Io.Dir.cwd().createDirPath(io, "/etc/apt/keyrings") catch |err| {
                 logger.warn("Failed to create /etc/apt/keyrings: {}", .{err});
             };
 
@@ -101,7 +103,7 @@ pub const Resource = struct {
                 actual_key_path = try allocator.dupe(u8, explicit_path);
 
                 const key_exists = blk: {
-                    std.fs.accessAbsolute(explicit_path, .{}) catch |err| switch (err) {
+                    std.Io.Dir.accessAbsolute(io, explicit_path, .{}) catch |err| switch (err) {
                         error.FileNotFound => break :blk false,
                         else => return err,
                     };
@@ -126,7 +128,7 @@ pub const Resource = struct {
                 defer allocator.free(asc_path);
 
                 const gpg_exists = blk: {
-                    std.fs.accessAbsolute(gpg_path, .{}) catch |err| switch (err) {
+                    std.Io.Dir.accessAbsolute(io, gpg_path, .{}) catch |err| switch (err) {
                         error.FileNotFound => break :blk false,
                         else => return err,
                     };
@@ -134,7 +136,7 @@ pub const Resource = struct {
                 };
 
                 const asc_exists = blk: {
-                    std.fs.accessAbsolute(asc_path, .{}) catch |err| switch (err) {
+                    std.Io.Dir.accessAbsolute(io, asc_path, .{}) catch |err| switch (err) {
                         error.FileNotFound => break :blk false,
                         else => return err,
                     };
@@ -159,10 +161,10 @@ pub const Resource = struct {
 
                     // Read first few bytes to detect format
                     const is_binary = blk: {
-                        const file = std.fs.openFileAbsolute(temp_path, .{}) catch break :blk true;
-                        defer file.close();
+                        const file = std.Io.Dir.openFileAbsolute(io, temp_path, .{}) catch break :blk true;
+                        defer file.close(io);
                         var buf: [64]u8 = undefined;
-                        const n = file.read(&buf) catch break :blk true;
+                        const n = std.posix.read(file.handle, &buf) catch break :blk true;
                         if (n == 0) break :blk true;
                         // ASCII armored keys start with "-----BEGIN PGP"
                         break :blk !std.mem.startsWith(u8, buf[0..n], "-----BEGIN PGP");
@@ -172,7 +174,7 @@ pub const Resource = struct {
                     actual_key_path = try allocator.dupe(u8, final_path);
 
                     // Rename temp file to final path
-                    try std.fs.renameAbsolute(temp_path, final_path);
+                    try std.Io.Dir.renameAbsolute(temp_path, final_path, io);
                     logger.info("Saved GPG key to {s}", .{final_path});
                     updated = true;
                 }
@@ -268,13 +270,14 @@ pub const Resource = struct {
         const new_content = line_buf.items;
 
         const needs_update = blk: {
-            const file = std.fs.openFileAbsolute(sources_list_path, .{}) catch |err| switch (err) {
+            const file = std.Io.Dir.openFileAbsolute(io, sources_list_path, .{}) catch |err| switch (err) {
                 error.FileNotFound => break :blk true,
                 else => return err,
             };
-            defer file.close();
+            defer file.close(io);
 
-            const existing_content = file.readToEndAlloc(allocator, std.math.maxInt(usize)) catch break :blk true;
+            var file_reader = file.reader(io, &.{});
+            const existing_content = file_reader.interface.allocRemaining(allocator, .unlimited) catch break :blk true;
             defer allocator.free(existing_content);
 
             break :blk !std.mem.eql(u8, existing_content, new_content);
@@ -282,9 +285,11 @@ pub const Resource = struct {
 
         if (needs_update) {
             logger.info("Writing repository configuration to {s}", .{sources_list_path});
-            const file = try std.fs.createFileAbsolute(sources_list_path, .{});
-            defer file.close();
-            try file.writeAll(new_content);
+            const file = try std.Io.Dir.createFileAbsolute(io, sources_list_path, .{});
+            defer file.close(io);
+            var file_writer = file.writer(io, &.{});
+            try file_writer.interface.writeAll(new_content);
+            try file_writer.interface.flush();
             updated = true;
         }
 
@@ -298,7 +303,8 @@ pub const Resource = struct {
     }
 
     fn applyRemove(self: Resource) !bool {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        const io = global_io.io();
+        var gpa = std.heap.DebugAllocator(.{}){};
         defer _ = gpa.deinit();
         const allocator = gpa.allocator();
 
@@ -308,7 +314,7 @@ pub const Resource = struct {
         const sources_list_path = try std.fmt.allocPrint(allocator, "/etc/apt/sources.list.d/{s}.list", .{self.name});
         defer allocator.free(sources_list_path);
 
-        std.fs.deleteFileAbsolute(sources_list_path) catch |err| switch (err) {
+        std.Io.Dir.deleteFileAbsolute(io, sources_list_path) catch |err| switch (err) {
             error.FileNotFound => {}, // Already removed
             else => return err,
         };
@@ -316,7 +322,7 @@ pub const Resource = struct {
 
         // Remove key if it was managed by us
         if (self.key_path) |key_path| {
-            std.fs.deleteFileAbsolute(key_path) catch |err| switch (err) {
+            std.Io.Dir.deleteFileAbsolute(io, key_path) catch |err| switch (err) {
                 error.FileNotFound => {},
                 else => return err,
             };
@@ -332,13 +338,15 @@ pub const Resource = struct {
     }
 
     fn getUbuntuCodename(allocator: std.mem.Allocator) ![]const u8 {
+        const io = global_io.io();
         // Try to get codename from /etc/os-release
-        const file = std.fs.openFileAbsolute("/etc/os-release", .{}) catch {
+        const file = std.Io.Dir.openFileAbsolute(io, "/etc/os-release", .{}) catch {
             return try allocator.dupe(u8, "stable"); // Fallback for non-Debian systems
         };
-        defer file.close();
+        defer file.close(io);
 
-        const content = try file.readToEndAlloc(allocator, std.math.maxInt(usize));
+        var file_reader = file.reader(io, &.{});
+        const content = try file_reader.interface.allocRemaining(allocator, .unlimited);
         defer allocator.free(content);
 
         // Parse VERSION_CODENAME=xxx
@@ -361,18 +369,11 @@ pub const Resource = struct {
         };
         defer allocator.free(apt_path);
 
-        var proc = std.process.Child.init(&[_][]const u8{ apt_path, "update" }, allocator);
-        proc.stdout_behavior = .Pipe;
-        proc.stderr_behavior = .Pipe;
-
-        try proc.spawn();
-
-        const stdout = try proc.stdout.?.readToEndAlloc(allocator, std.math.maxInt(usize));
-        const stderr = try proc.stderr.?.readToEndAlloc(allocator, std.math.maxInt(usize));
+        const result = try std.process.run(allocator, global_io.io(), .{ .argv = &[_][]const u8{ apt_path, "update" } });
+        const stdout = result.stdout;
+        const stderr = result.stderr;
         defer allocator.free(stdout);
         defer allocator.free(stderr);
-
-        const term = try proc.wait();
 
         // Log output
         if (stdout.len > 0) {
@@ -382,8 +383,8 @@ pub const Resource = struct {
             logger.warn("apt update stderr: {s}", .{stderr});
         }
 
-        switch (term) {
-            .Exited => |code| {
+        switch (result.term) {
+            .exited => |code| {
                 if (code != 0) {
                     logger.err("apt update failed with exit code {d}", .{code});
                     return error.AptUpdateFailed;
@@ -394,14 +395,15 @@ pub const Resource = struct {
     }
 
     fn findAptExecutable(allocator: std.mem.Allocator) ![]const u8 {
+        const io = global_io.io();
         const candidates = [_][]const u8{ "/usr/bin/apt-get", "/usr/bin/apt" };
         for (candidates) |path| {
-            std.fs.accessAbsolute(path, .{}) catch continue;
+            std.Io.Dir.accessAbsolute(io, path, .{}) catch continue;
             return try allocator.dupe(u8, path);
         }
 
         // Search PATH
-        const path_env = std.process.getEnvVarOwned(allocator, "PATH") catch return error.AptNotFound;
+        const path_env = global_io.getEnvOwned(allocator, "PATH") catch return error.AptNotFound;
         defer allocator.free(path_env);
 
         var it = std.mem.splitScalar(u8, path_env, std.fs.path.delimiter);
@@ -410,7 +412,7 @@ pub const Resource = struct {
             for ([_][]const u8{ "apt-get", "apt" }) |name| {
                 const full_path = std.fs.path.join(allocator, &.{ dir, name }) catch continue;
                 defer allocator.free(full_path);
-                if (std.fs.accessAbsolute(full_path, .{})) |_| {
+                if (std.Io.Dir.accessAbsolute(io, full_path, .{})) |_| {
                     return allocator.dupe(u8, full_path) catch return error.AptNotFound;
                 } else |_| {}
             }

--- a/src/resources/aws_kms.zig
+++ b/src/resources/aws_kms.zig
@@ -3,6 +3,7 @@ const mruby = @import("../mruby.zig");
 const base = @import("../base_resource.zig");
 const kms = @import("../kms_client.zig");
 const logger = @import("../logger.zig");
+const global_io = @import("../global_io.zig");
 
 pub const Resource = struct {
     name: []const u8,
@@ -72,7 +73,7 @@ pub const Resource = struct {
     }
 
     fn applyEncrypt(self: Resource) !bool {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        var gpa = std.heap.DebugAllocator(.{}){};
         defer _ = gpa.deinit();
         const allocator = gpa.allocator();
 
@@ -96,14 +97,14 @@ pub const Resource = struct {
 
         // Get credentials from env if not provided
         const access_key = self.access_key_id orelse
-            std.process.getEnvVarOwned(allocator, "AWS_ACCESS_KEY_ID") catch {
+            global_io.getEnvOwned(allocator, "AWS_ACCESS_KEY_ID") catch {
             logger.err("aws_kms: AWS_ACCESS_KEY_ID not set and no access_key_id provided", .{});
             return error.MissingCredentials;
         };
         defer if (self.access_key_id == null) allocator.free(access_key);
 
         const secret_key = self.secret_access_key orelse
-            std.process.getEnvVarOwned(allocator, "AWS_SECRET_ACCESS_KEY") catch {
+            global_io.getEnvOwned(allocator, "AWS_SECRET_ACCESS_KEY") catch {
             logger.err("aws_kms: AWS_SECRET_ACCESS_KEY not set and no secret_access_key provided", .{});
             return error.MissingCredentials;
         };
@@ -111,7 +112,7 @@ pub const Resource = struct {
 
         // Get optional session token for temporary credentials
         const session_token = self.session_token orelse
-            std.process.getEnvVarOwned(allocator, "AWS_SESSION_TOKEN") catch null;
+            global_io.getEnvOwned(allocator, "AWS_SESSION_TOKEN") catch null;
         defer if (self.session_token == null and session_token != null) allocator.free(session_token.?);
 
         // Read input data and decode based on source_encoding
@@ -183,7 +184,7 @@ pub const Resource = struct {
     }
 
     fn applyDecrypt(self: Resource) !bool {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        var gpa = std.heap.DebugAllocator(.{}){};
         defer _ = gpa.deinit();
         const allocator = gpa.allocator();
 
@@ -203,14 +204,14 @@ pub const Resource = struct {
 
         // Get credentials from env if not provided
         const access_key = self.access_key_id orelse
-            std.process.getEnvVarOwned(allocator, "AWS_ACCESS_KEY_ID") catch {
+            global_io.getEnvOwned(allocator, "AWS_ACCESS_KEY_ID") catch {
             logger.err("aws_kms: AWS_ACCESS_KEY_ID not set and no access_key_id provided", .{});
             return error.MissingCredentials;
         };
         defer if (self.access_key_id == null) allocator.free(access_key);
 
         const secret_key = self.secret_access_key orelse
-            std.process.getEnvVarOwned(allocator, "AWS_SECRET_ACCESS_KEY") catch {
+            global_io.getEnvOwned(allocator, "AWS_SECRET_ACCESS_KEY") catch {
             logger.err("aws_kms: AWS_SECRET_ACCESS_KEY not set and no secret_access_key provided", .{});
             return error.MissingCredentials;
         };
@@ -218,7 +219,7 @@ pub const Resource = struct {
 
         // Get optional session token for temporary credentials
         const session_token = self.session_token orelse
-            std.process.getEnvVarOwned(allocator, "AWS_SESSION_TOKEN") catch null;
+            global_io.getEnvOwned(allocator, "AWS_SESSION_TOKEN") catch null;
         defer if (self.session_token == null and session_token != null) allocator.free(session_token.?);
 
         // Read ciphertext
@@ -265,24 +266,28 @@ pub const Resource = struct {
         }
 
         // Read from file
-        const file = std.fs.openFileAbsolute(self.source, .{}) catch |err| {
+        const io = global_io.io();
+        const file = std.Io.Dir.openFileAbsolute(io, self.source, .{}) catch |err| {
             logger.err("aws_kms: failed to open source file '{s}': {}", .{ self.source, err });
             return err;
         };
-        defer file.close();
-        return try file.readToEndAlloc(allocator, std.math.maxInt(usize));
+        defer file.close(io);
+        var file_reader = file.reader(io, &.{});
+        return try file_reader.interface.allocRemaining(allocator, .unlimited);
     }
 
     /// Check if output file exists and has the same content
     fn outputUpToDate(self: Resource, allocator: std.mem.Allocator, new_data: []const u8) !bool {
         // Try to read existing file
-        const file = std.fs.openFileAbsolute(self.path, .{}) catch {
+        const io = global_io.io();
+        const file = std.Io.Dir.openFileAbsolute(io, self.path, .{}) catch {
             // File doesn't exist, not up to date
             return false;
         };
-        defer file.close();
+        defer file.close(io);
 
-        const existing_data = file.readToEndAlloc(allocator, std.math.maxInt(usize)) catch {
+        var file_reader = file.reader(io, &.{});
+        const existing_data = file_reader.interface.allocRemaining(allocator, .unlimited) catch {
             return false;
         };
         defer allocator.free(existing_data);
@@ -314,6 +319,7 @@ pub const Resource = struct {
     }
 
     fn writeOutput(self: Resource, allocator: std.mem.Allocator, data: []const u8) !void {
+        const io = global_io.io();
         // Ensure parent directory exists
         try base.ensureParentDir(self.path);
 
@@ -330,7 +336,7 @@ pub const Resource = struct {
 
         // Write to temp file first
         const dir_path = std.fs.path.dirname(self.path);
-        const timestamp = std.time.nanoTimestamp();
+        const timestamp = std.Io.Timestamp.now(io, .real).toNanoseconds();
         const pid = std.c.getpid();
 
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
@@ -343,15 +349,17 @@ pub const Resource = struct {
         else
             temp_name;
 
-        var temp_file = try std.fs.createFileAbsolute(temp_path, .{ .truncate = true, .exclusive = true });
-        errdefer std.fs.deleteFileAbsolute(temp_path) catch {};
+        var temp_file = try std.Io.Dir.createFileAbsolute(io, temp_path, .{ .truncate = true, .exclusive = true });
+        errdefer std.Io.Dir.deleteFileAbsolute(io, temp_path) catch {};
 
-        try temp_file.writeAll(output_data);
-        try temp_file.sync();
-        temp_file.close();
+        var temp_writer = temp_file.writer(io, &.{});
+        try temp_writer.interface.writeAll(output_data);
+        try temp_writer.interface.flush();
+        try temp_file.sync(io);
+        temp_file.close(io);
 
         // Atomic rename
-        try std.fs.renameAbsolute(temp_path, self.path);
+        try std.Io.Dir.renameAbsolute(temp_path, self.path, io);
 
         // Apply file attributes
         base.applyFileAttributes(self.path, .{

--- a/src/resources/directory.zig
+++ b/src/resources/directory.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const mruby = @import("../mruby.zig");
 const base = @import("../base_resource.zig");
 const logger = @import("../logger.zig");
+const global_io = @import("../global_io.zig");
 
 /// Directory resource data structure
 pub const Resource = struct {
@@ -68,17 +69,18 @@ pub const Resource = struct {
     }
 
     fn applyCreate(self: Resource) !bool {
+        const io = global_io.io();
         const is_abs = std.fs.path.isAbsolute(self.path);
 
         // Check if directory already exists
         const dir_exists = blk: {
             if (is_abs) {
-                std.fs.accessAbsolute(self.path, .{}) catch |err| switch (err) {
+                std.Io.Dir.accessAbsolute(io, self.path, .{}) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
             } else {
-                std.fs.cwd().access(self.path, .{}) catch |err| switch (err) {
+                std.Io.Dir.cwd().access(io, self.path, .{}) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
@@ -93,13 +95,13 @@ pub const Resource = struct {
             // Check and update mode
             if (self.attrs.mode) |m| {
                 var dir = if (is_abs)
-                    try std.fs.openDirAbsolute(self.path, .{})
+                    try std.Io.Dir.openDirAbsolute(io, self.path, .{})
                 else
-                    try std.fs.cwd().openDir(self.path, .{});
-                defer dir.close();
+                    try std.Io.Dir.cwd().openDir(io, self.path, .{});
+                defer dir.close(io);
 
-                const stat = try dir.stat();
-                const current_mode = stat.mode & 0o777;
+                const stat = try dir.stat(io);
+                const current_mode = stat.permissions.toMode() & 0o777;
                 if (current_mode != m) {
                     // Update mode using path-based chmod instead of fd-based fchmod
                     // This avoids BADF errors on some systems where dir.fd might not be valid
@@ -125,9 +127,9 @@ pub const Resource = struct {
         } else {
             try base.ensureParentDir(self.path);
             if (is_abs) {
-                try std.fs.makeDirAbsolute(self.path);
+                try std.Io.Dir.createDirAbsolute(io, self.path, .default_dir);
             } else {
-                try std.fs.cwd().makeDir(self.path);
+                try std.Io.Dir.cwd().createDir(io, self.path, .default_dir);
             }
         }
 
@@ -149,17 +151,18 @@ pub const Resource = struct {
     }
 
     fn applyDelete(self: Resource) !void {
+        const io = global_io.io();
         const is_abs = std.fs.path.isAbsolute(self.path);
 
         // Check if directory exists
         const dir_exists = blk: {
             if (is_abs) {
-                std.fs.accessAbsolute(self.path, .{}) catch |err| switch (err) {
+                std.Io.Dir.accessAbsolute(io, self.path, .{}) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
             } else {
-                std.fs.cwd().access(self.path, .{}) catch |err| switch (err) {
+                std.Io.Dir.cwd().access(io, self.path, .{}) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
@@ -175,7 +178,7 @@ pub const Resource = struct {
         defer if (resolved) |buf| std.heap.c_allocator.free(buf);
 
         const abs_path = if (is_abs) self.path else blk: {
-            const buf = try std.fs.cwd().realpathAlloc(std.heap.c_allocator, self.path);
+            const buf = try std.Io.Dir.cwd().realPathFileAlloc(io, self.path, std.heap.c_allocator);
             resolved = buf;
             break :blk buf;
         };
@@ -183,7 +186,7 @@ pub const Resource = struct {
         if (self.recursive) {
             try deleteDirRecursiveAbsolute(abs_path);
         } else {
-            std.fs.deleteDirAbsolute(abs_path) catch |err| switch (err) {
+            std.Io.Dir.deleteDirAbsolute(io, abs_path) catch |err| switch (err) {
                 error.DirNotEmpty => return error.DirNotEmpty,
                 else => return err,
             };
@@ -191,18 +194,19 @@ pub const Resource = struct {
     }
 
     fn deleteDirRecursiveAbsolute(path: []const u8) !void {
-        var dir = try std.fs.openDirAbsolute(path, .{ .iterate = true });
-        defer dir.close();
+        const io = global_io.io();
+        var dir = try std.Io.Dir.openDirAbsolute(io, path, .{ .iterate = true });
+        defer dir.close(io);
         var iterator = dir.iterate();
-        while (try iterator.next()) |entry| {
+        while (try iterator.next(io)) |entry| {
             const child_path = try std.fmt.allocPrint(std.heap.page_allocator, "{s}/{s}", .{ path, entry.name });
             defer std.heap.page_allocator.free(child_path);
             switch (entry.kind) {
                 .directory => try deleteDirRecursiveAbsolute(child_path),
-                else => try std.fs.deleteFileAbsolute(child_path),
+                else => try std.Io.Dir.deleteFileAbsolute(io, child_path),
             }
         }
-        try std.fs.deleteDirAbsolute(path);
+        try std.Io.Dir.deleteDirAbsolute(io, path);
     }
 };
 

--- a/src/resources/execute.zig
+++ b/src/resources/execute.zig
@@ -4,6 +4,7 @@ const base = @import("../base_resource.zig");
 const ansi = @import("../ansi_constants.zig");
 const logger = @import("../logger.zig");
 const AsyncExecutor = @import("../async_executor.zig").AsyncExecutor;
+const global_io = @import("../global_io.zig");
 
 const DEFAULT_TIMEOUT_S: u32 = 3600;
 const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
@@ -67,7 +68,7 @@ pub const Resource = struct {
         // Check 'creates' property - skip if file exists
         if (self.creates) |creates_path| {
             const file_exists = blk: {
-                std.fs.cwd().access(creates_path, .{}) catch |err| {
+                std.Io.Dir.cwd().access(global_io.io(), creates_path, .{}) catch |err| {
                     if (err != error.FileNotFound) {
                         logger.warn("execute[{s}]: Error checking creates path '{s}': {}", .{ self.name, creates_path, err });
                     }
@@ -142,24 +143,25 @@ pub const Resource = struct {
 
     fn termFromStatus(status: u32) std.process.Child.Term {
         return if (std.posix.W.IFEXITED(status))
-            .{ .Exited = std.posix.W.EXITSTATUS(status) }
+            .{ .exited = std.posix.W.EXITSTATUS(status) }
         else if (std.posix.W.IFSIGNALED(status))
-            .{ .Signal = std.posix.W.TERMSIG(status) }
+            .{ .signal = std.posix.W.TERMSIG(status) }
         else if (std.posix.W.IFSTOPPED(status))
-            .{ .Stopped = std.posix.W.STOPSIG(status) }
+            .{ .stopped = std.posix.W.STOPSIG(status) }
         else
-            .{ .Unknown = status };
+            .{ .unknown = status };
     }
 
     fn pollChildTerm(pid: std.posix.pid_t) ?std.process.Child.Term {
-        const result = std.posix.waitpid(pid, std.posix.W.NOHANG);
-        if (result.pid == 0) return null;
-        return termFromStatus(result.status);
+        var status: c_int = undefined;
+        const rc = std.c.waitpid(pid, &status, @intCast(std.posix.W.NOHANG));
+        if (rc <= 0) return null;
+        return termFromStatus(@bitCast(status));
     }
 
-    fn closePipe(pipe: *?std.fs.File) void {
+    fn closePipe(pipe: *?std.Io.File) void {
         if (pipe.*) |*file| {
-            file.close();
+            file.close(global_io.io());
             pipe.* = null;
         }
     }
@@ -170,7 +172,7 @@ pub const Resource = struct {
         closePipe(&child.stderr);
     }
 
-    fn signalProcessGroup(pid: std.posix.pid_t, sig: u8) void {
+    fn signalProcessGroup(pid: std.posix.pid_t, sig: std.posix.SIG) void {
         std.posix.kill(-pid, sig) catch |err| {
             if (err != error.ProcessNotFound) {
                 logger.warn("[execute] failed to signal process group {d}: {}", .{ pid, err });
@@ -182,10 +184,11 @@ pub const Resource = struct {
     /// short grace period but never blocks indefinitely: a process stuck in
     /// uninterruptible sleep must not hang the caller.
     fn reapAfterKill(pid: std.posix.pid_t) void {
-        const deadline = std.time.milliTimestamp() + REAP_GRACE_MS;
-        while (std.time.milliTimestamp() < deadline) {
+        const io = global_io.io();
+        const deadline = std.Io.Timestamp.now(io, .real).toMilliseconds() + REAP_GRACE_MS;
+        while (std.Io.Timestamp.now(io, .real).toMilliseconds() < deadline) {
             if (pollChildTerm(pid) != null) return;
-            std.Thread.sleep(POLL_INTERVAL_MS * std.time.ns_per_ms);
+            io.sleep(.fromNanoseconds(POLL_INTERVAL_MS * std.time.ns_per_ms), .awake) catch {};
         }
         logger.warn("[execute] child {d} not reaped after SIGKILL; possible zombie", .{pid});
     }
@@ -211,11 +214,11 @@ pub const Resource = struct {
 
     fn drainPipe(
         allocator: std.mem.Allocator,
-        file: std.fs.File,
+        file: std.Io.File,
         output: *std.ArrayList(u8),
     ) !bool {
         var buf: [READ_BUFFER_SIZE]u8 = undefined;
-        const n = try file.read(&buf);
+        const n = try std.posix.read(file.handle, &buf);
         if (n == 0) return false;
         try appendOutputBounded(allocator, output, buf[0..n]);
         return true;
@@ -223,7 +226,7 @@ pub const Resource = struct {
 
     fn drainReadyPipe(
         allocator: std.mem.Allocator,
-        pipe: *?std.fs.File,
+        pipe: *?std.Io.File,
         output: *std.ArrayList(u8),
         is_open: *bool,
     ) !void {
@@ -260,20 +263,12 @@ pub const Resource = struct {
         allocator: std.mem.Allocator,
         timeout_s: u32,
     ) !ExecuteResult {
+        const io = global_io.io();
+
         var stdout = std.ArrayList(u8).empty;
         defer stdout.deinit(allocator);
         var stderr = std.ArrayList(u8).empty;
         defer stderr.deinit(allocator);
-
-        try child.spawn();
-        // On a pre-exec failure (bad cwd, setpgid, etc.) the forked child
-        // reports the error and _exit()s. Close our pipe ends and reap it so
-        // the error path doesn't leak fds or leave a zombie.
-        child.waitForSpawn() catch |err| {
-            closeChildPipes(child);
-            reapAfterKill(child.id);
-            return err;
-        };
 
         var stdout_open = child.stdout != null;
         var stderr_open = child.stderr != null;
@@ -283,16 +278,16 @@ pub const Resource = struct {
         var sent_kill = false;
         var post_exit_pipe_deadline_ms: ?i64 = null;
 
-        const pid = child.id;
+        const pid = child.id.?;
         const deadline_ms: ?i64 = if (timeout_s == 0)
             null
         else
-            std.time.milliTimestamp() + @as(i64, timeout_s) * std.time.ms_per_s;
+            std.Io.Timestamp.now(io, .real).toMilliseconds() + @as(i64, timeout_s) * std.time.ms_per_s;
         var kill_deadline_ms: ?i64 = null;
         var close_deadline_ms: ?i64 = null;
 
         while (child_running or stdout_open or stderr_open) {
-            const now = std.time.milliTimestamp();
+            const now = std.Io.Timestamp.now(io, .real).toMilliseconds();
 
             // Reap the child FIRST so the timeout decision below sees accurate
             // liveness in this same iteration. Otherwise a command that exits
@@ -356,7 +351,7 @@ pub const Resource = struct {
             }
 
             if (!stdout_open and !stderr_open) {
-                if (child_running) std.Thread.sleep(POLL_INTERVAL_MS * std.time.ns_per_ms);
+                if (child_running) io.sleep(.fromNanoseconds(POLL_INTERVAL_MS * std.time.ns_per_ms), .awake) catch {};
                 continue;
             }
 
@@ -416,7 +411,7 @@ pub const Resource = struct {
 
         const result_allocator = std.heap.page_allocator;
         return ExecuteResult{
-            .term = term orelse .{ .Unknown = 0 },
+            .term = term orelse .{ .unknown = 0 },
             .stdout = try result_allocator.dupe(u8, stdout.items),
             .stderr = try result_allocator.dupe(u8, stderr.items),
             .timed_out = timed_out,
@@ -428,53 +423,54 @@ pub const Resource = struct {
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
         defer arena.deinit();
         const temp_allocator = arena.allocator();
+        const io = global_io.io();
 
         // Prepare command for shell execution
         const shell_cmd = try std.fmt.allocPrint(temp_allocator, "{s}", .{ctx.command});
 
-        // Create child process
-        var child = std.process.Child.init(&[_][]const u8{ "/bin/sh", "-c", shell_cmd }, temp_allocator);
-
-        // Set working directory if specified
-        if (ctx.cwd) |cwd| {
-            child.cwd = cwd;
-        }
-
         // Set environment variables if specified
         // Note: env_map must live until child.wait() completes
-        var env_map_storage: ?std.process.EnvMap = null;
+        var env_map_storage: ?std.process.Environ.Map = null;
         defer if (env_map_storage) |*map| map.deinit();
+        var environ_map: ?*const std.process.Environ.Map = null;
 
         if (ctx.environment) |env_str| {
-            // Parse environment string "KEY=VALUE\0KEY2=VALUE2\0" into a map
-            // Start with current environment
-            var env_map = try std.process.getEnvMap(temp_allocator);
+            // Parse environment string "KEY=VALUE\0KEY2=VALUE2\0" into a map.
+            // Start from the parent environment so the child keeps PATH etc.
+            // When the process env map is unavailable (unit tests, before main
+            // ran), leave environ_map null to inherit the real parent env
+            // rather than spawning with only the overrides.
+            if (global_io.environMap()) |parent| {
+                var env_map = try parent.clone(temp_allocator);
 
-            // Parse and add/override environment variables
-            var pos: usize = 0;
-            while (pos < env_str.len) {
-                // Find next KEY=VALUE pair (null-terminated)
-                const start = pos;
-                while (pos < env_str.len and env_str[pos] != 0) : (pos += 1) {}
+                // Parse and add/override environment variables
+                var pos: usize = 0;
+                while (pos < env_str.len) {
+                    // Find next KEY=VALUE pair (null-terminated)
+                    const start = pos;
+                    while (pos < env_str.len and env_str[pos] != 0) : (pos += 1) {}
 
-                const pair = env_str[start..pos];
-                if (pair.len > 0) {
-                    // Split on '='
-                    if (std.mem.indexOfScalar(u8, pair, '=')) |eq_pos| {
-                        const key = pair[0..eq_pos];
-                        const value = pair[eq_pos + 1 ..];
-                        try env_map.put(key, value);
+                    const pair = env_str[start..pos];
+                    if (pair.len > 0) {
+                        // Split on '='
+                        if (std.mem.indexOfScalar(u8, pair, '=')) |eq_pos| {
+                            const key = pair[0..eq_pos];
+                            const value = pair[eq_pos + 1 ..];
+                            try env_map.put(key, value);
+                        }
                     }
+
+                    pos += 1; // Skip null terminator
                 }
 
-                pos += 1; // Skip null terminator
+                env_map_storage = env_map;
+                environ_map = &env_map_storage.?;
             }
-
-            env_map_storage = env_map;
-            child.env_map = &env_map_storage.?;
         }
 
         // Set user and/or group if specified (requires root privileges)
+        var uid: ?std.posix.uid_t = null;
+        var gid: ?std.posix.gid_t = null;
         if (ctx.user != null or ctx.group != null) {
             const c = @cImport({
                 @cInclude("pwd.h");
@@ -494,8 +490,8 @@ pub const Resource = struct {
                     return error.UserNotFound;
                 }
 
-                child.uid = @intCast(pwd.*.pw_uid);
-                child.gid = @intCast(pwd.*.pw_gid);
+                uid = @intCast(pwd.*.pw_uid);
+                gid = @intCast(pwd.*.pw_gid);
             }
 
             // Override with group if specified
@@ -511,15 +507,23 @@ pub const Resource = struct {
                     return error.GroupNotFound;
                 }
 
-                child.gid = @intCast(grp.*.gr_gid);
+                gid = @intCast(grp.*.gr_gid);
             }
         }
 
-        // Capture output
-        child.stdin_behavior = .Ignore;
-        child.stdout_behavior = .Pipe;
-        child.stderr_behavior = .Pipe;
-        child.pgid = 0;
+        // Create child process, capturing output. pgid=0 starts a new process
+        // group so the timeout path can signal the whole group.
+        var child = try std.process.spawn(io, .{
+            .argv = &[_][]const u8{ "/bin/sh", "-c", shell_cmd },
+            .cwd = if (ctx.cwd) |cwd| .{ .path = cwd } else .inherit,
+            .environ_map = environ_map,
+            .stdin = .ignore,
+            .stdout = .pipe,
+            .stderr = .pipe,
+            .uid = uid,
+            .gid = gid,
+            .pgid = 0,
+        });
 
         return try collectOutputAndWait(&child, temp_allocator, ctx.timeout_s);
     }
@@ -553,7 +557,7 @@ pub const Resource = struct {
 
         // Log command execution
         const exit_code: ?i32 = switch (term) {
-            .Exited => |code| code,
+            .exited => |code| code,
             else => null,
         };
 
@@ -607,21 +611,21 @@ pub const Resource = struct {
 
         // Check exit status
         switch (term) {
-            .Exited => |code| {
+            .exited => |code| {
                 if (code != 0) {
                     logger.err("[execute] command exited with code {d}", .{code});
                     return error.CommandFailed;
                 }
             },
-            .Signal => |sig| {
-                logger.err("[execute] command killed by signal {d}", .{sig});
+            .signal => |sig| {
+                logger.err("[execute] command killed by signal {d}", .{@intFromEnum(sig)});
                 return error.CommandKilled;
             },
-            .Stopped => |sig| {
-                logger.err("[execute] command stopped by signal {d}", .{sig});
+            .stopped => |sig| {
+                logger.err("[execute] command stopped by signal {d}", .{@intFromEnum(sig)});
                 return error.CommandStopped;
             },
-            .Unknown => |unknown_status| {
+            .unknown => |unknown_status| {
                 logger.err("[execute] command exited with unknown status {d}", .{unknown_status});
                 return error.CommandFailed;
             },

--- a/src/resources/extract.zig
+++ b/src/resources/extract.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const mruby = @import("../mruby.zig");
 const base = @import("../base_resource.zig");
 const logger = @import("../logger.zig");
+const global_io = @import("../global_io.zig");
 
 pub const FileMapping = struct {
     pattern: []const u8, // glob pattern, e.g. "*/s5cmd"
@@ -84,7 +85,7 @@ pub const Resource = struct {
         defer output_buf.deinit(alloc);
 
         // extracted_paths: tracks files created by this run (for targeted attrs)
-        var extracted_paths: std.ArrayListUnmanaged([]const u8) = .{};
+        var extracted_paths: std.ArrayListUnmanaged([]const u8) = .empty;
         defer {
             for (extracted_paths.items) |p| alloc.free(p);
             extracted_paths.deinit(alloc);
@@ -104,7 +105,7 @@ pub const Resource = struct {
                 defer alloc.free(full);
                 // Skip symlinks — applyFileAttributes follows links and would modify the target
                 var buf: [std.fs.max_path_bytes]u8 = undefined;
-                if (std.fs.readLinkAbsolute(full, &buf)) |_| continue else |_| {}
+                if (std.Io.Dir.readLinkAbsolute(global_io.io(), full, &buf)) |_| continue else |_| {}
                 base.applyFileAttributes(full, self.attrs) catch |err| {
                     logger.warn("[extract] failed to apply attributes to {s}: {}", .{ full, err });
                 };
@@ -130,22 +131,23 @@ pub const Resource = struct {
     /// then copy to destination. This avoids including pre-existing files
     /// in the extracted_paths / marker.
     fn extractAll(self: Resource, archive_type: ArchiveType, output_buf: *std.ArrayList(u8), extracted_paths: *std.ArrayListUnmanaged([]const u8)) !void {
+        const io = global_io.io();
         const alloc = std.heap.c_allocator;
 
         // Extract to temp dir first to get clean file list
-        const tmp_dir_path = std.fmt.allocPrint(alloc, "/tmp/hola-extract-all-{d}", .{std.time.nanoTimestamp()}) catch return error.OutOfMemory;
+        const tmp_dir_path = std.fmt.allocPrint(alloc, "/tmp/hola-extract-all-{d}", .{std.Io.Timestamp.now(io, .real).toNanoseconds()}) catch return error.OutOfMemory;
         defer alloc.free(tmp_dir_path);
         try makeDirRecursive(tmp_dir_path);
-        defer std.fs.deleteTreeAbsolute(tmp_dir_path) catch {};
+        defer std.Io.Dir.cwd().deleteTree(io, tmp_dir_path) catch {};
 
-        const file = std.fs.openFileAbsolute(self.path, .{}) catch |err| {
+        const file = std.Io.Dir.openFileAbsolute(io, self.path, .{}) catch |err| {
             logger.err("[extract] failed to open archive {s}: {}", .{ self.path, err });
             return err;
         };
-        defer file.close();
+        defer file.close(io);
 
-        var tmp_dir = try std.fs.openDirAbsolute(tmp_dir_path, .{});
-        defer tmp_dir.close();
+        var tmp_dir = try std.Io.Dir.openDirAbsolute(io, tmp_dir_path, .{});
+        defer tmp_dir.close(io);
 
         try pipeArchiveToFileSystem(file, archive_type, tmp_dir, .{
             .strip_components = self.strip_components,
@@ -178,27 +180,28 @@ pub const Resource = struct {
     ///   Empty directories are not preserved.
     /// - files_only: only extract files/symlinks that match a pattern
     fn extractWithMappings(self: Resource, archive_type: ArchiveType, output_buf: *std.ArrayList(u8), extracted_paths: *std.ArrayListUnmanaged([]const u8)) !void {
+        const io = global_io.io();
         const alloc = std.heap.c_allocator;
 
         // Create temp directory
-        const tmp_dir_path = std.fmt.allocPrint(alloc, "/tmp/hola-extract-{d}", .{std.time.nanoTimestamp()}) catch return error.OutOfMemory;
+        const tmp_dir_path = std.fmt.allocPrint(alloc, "/tmp/hola-extract-{d}", .{std.Io.Timestamp.now(io, .real).toNanoseconds()}) catch return error.OutOfMemory;
         defer alloc.free(tmp_dir_path);
 
-        std.fs.makeDirAbsolute(tmp_dir_path) catch |err| switch (err) {
+        std.Io.Dir.cwd().createDir(io, tmp_dir_path, .default_dir) catch |err| switch (err) {
             error.PathAlreadyExists => {},
             else => return err,
         };
-        defer std.fs.deleteTreeAbsolute(tmp_dir_path) catch {};
+        defer std.Io.Dir.cwd().deleteTree(io, tmp_dir_path) catch {};
 
         // Extract all to temp dir (raw, no strip)
-        const file = std.fs.openFileAbsolute(self.path, .{}) catch |err| {
+        const file = std.Io.Dir.openFileAbsolute(io, self.path, .{}) catch |err| {
             logger.err("[extract] failed to open archive {s}: {}", .{ self.path, err });
             return err;
         };
-        defer file.close();
+        defer file.close(io);
 
-        var tmp_dir = try std.fs.openDirAbsolute(tmp_dir_path, .{});
-        defer tmp_dir.close();
+        var tmp_dir = try std.Io.Dir.openDirAbsolute(io, tmp_dir_path, .{});
+        defer tmp_dir.close(io);
 
         try pipeArchiveToFileSystem(file, archive_type, tmp_dir, .{}, alloc);
 
@@ -287,7 +290,9 @@ pub const Resource = struct {
 };
 
 /// Decompress and pipe tar archive to filesystem
-fn pipeArchiveToFileSystem(file: std.fs.File, archive_type: ArchiveType, dir: std.fs.Dir, pipe_opts: std.tar.PipeOptions, allocator: std.mem.Allocator) !void {
+fn pipeArchiveToFileSystem(file: std.Io.File, archive_type: ArchiveType, dir: std.Io.Dir, pipe_opts: std.tar.PipeOptions, allocator: std.mem.Allocator) !void {
+    const io = global_io.io();
+
     // Use diagnostics to collect non-fatal errors (e.g. stripped directory entries)
     // instead of failing the whole extraction
     var diagnostics: std.tar.Diagnostics = .{ .allocator = allocator };
@@ -301,24 +306,27 @@ fn pipeArchiveToFileSystem(file: std.fs.File, archive_type: ArchiveType, dir: st
     };
 
     var file_read_buf: [4096]u8 = undefined;
-    var file_reader = std.fs.File.Reader.init(file, &file_read_buf);
+    var file_reader = file.reader(io, &file_read_buf);
 
     switch (archive_type) {
         .tar_gz => {
             var decompress_buf: [std.compress.flate.max_window_len]u8 = undefined;
             var decompress = std.compress.flate.Decompress.init(&file_reader.interface, .gzip, &decompress_buf);
-            try std.tar.pipeToFileSystem(dir, &decompress.reader, opts);
+            try std.tar.extract(io, dir, &decompress.reader, opts);
         },
         .tar_xz => {
-            const old_reader = file_reader.interface.adaptToOldInterface();
-            var xz_decomp = try std.compress.xz.decompress(allocator, old_reader);
+            // Decompress takes ownership of the buffer and resizes it via the
+            // allocator; free it ourselves only if init fails before taking it.
+            const xz_buf = try allocator.alloc(u8, 4096);
+            var xz_decomp = std.compress.xz.Decompress.init(&file_reader.interface, allocator, xz_buf) catch |err| {
+                allocator.free(xz_buf);
+                return err;
+            };
             defer xz_decomp.deinit();
-            var xz_reader_buf: [4096]u8 = undefined;
-            var adapter = xz_decomp.reader().adaptToNewApi(&xz_reader_buf);
-            try std.tar.pipeToFileSystem(dir, &adapter.new_interface, opts);
+            try std.tar.extract(io, dir, &xz_decomp.reader, opts);
         },
         .tar => {
-            try std.tar.pipeToFileSystem(dir, &file_reader.interface, opts);
+            try std.tar.extract(io, dir, &file_reader.interface, opts);
         },
         .unknown => unreachable,
     }
@@ -341,22 +349,24 @@ fn pipeArchiveToFileSystem(file: std.fs.File, archive_type: ArchiveType, dir: st
 /// Check if a path exists without following symlinks.
 /// Returns true for regular files, directories, and symlinks (even dangling ones).
 fn pathExistsNoFollow(path: []const u8) bool {
+    const io = global_io.io();
     // First try readLinkAbsolute — succeeds for any symlink (dangling or not)
     var buf: [std.fs.max_path_bytes]u8 = undefined;
-    if (std.fs.readLinkAbsolute(path, &buf)) |_| return true else |_| {}
+    if (std.Io.Dir.readLinkAbsolute(io, path, &buf)) |_| return true else |_| {}
     // Not a symlink — check as regular file/dir
-    std.fs.accessAbsolute(path, .{}) catch return false;
+    std.Io.Dir.accessAbsolute(io, path, .{}) catch return false;
     return true;
 }
 
 fn makeDirRecursive(path: []const u8) !void {
-    std.fs.makeDirAbsolute(path) catch |err| switch (err) {
+    const io = global_io.io();
+    std.Io.Dir.cwd().createDir(io, path, .default_dir) catch |err| switch (err) {
         error.PathAlreadyExists => return,
         error.FileNotFound => {
             // Parent doesn't exist — recurse
             if (std.fs.path.dirname(path)) |parent| {
                 try makeDirRecursive(parent);
-                std.fs.makeDirAbsolute(path) catch |e| switch (e) {
+                std.Io.Dir.cwd().createDir(io, path, .default_dir) catch |e| switch (e) {
                     error.PathAlreadyExists => {},
                     else => return e,
                 };
@@ -375,14 +385,16 @@ fn ensureParentDirRecursive(path: []const u8) !void {
 }
 
 fn copyFile(src: []const u8, dst: []const u8) !void {
+    const io = global_io.io();
     try ensureParentDirRecursive(dst);
 
     // Try to read as symlink first
     var target_buf: [std.fs.max_path_bytes]u8 = undefined;
-    if (std.fs.readLinkAbsolute(src, &target_buf)) |target| {
+    if (std.Io.Dir.readLinkAbsolute(io, src, &target_buf)) |target_len| {
+        const target = target_buf[0..target_len];
         // Source is a symlink — recreate at destination
-        std.fs.deleteFileAbsolute(dst) catch {};
-        std.posix.symlinkat(target, std.posix.AT.FDCWD, dst) catch |err| {
+        std.Io.Dir.deleteFileAbsolute(io, dst) catch {};
+        std.Io.Dir.cwd().symLink(io, target, dst, .{}) catch |err| {
             logger.warn("[extract] symlink creation failed {s}: {}", .{ dst, err });
             return err;
         };
@@ -393,24 +405,25 @@ fn copyFile(src: []const u8, dst: []const u8) !void {
 }
 
 fn copyRegularFile(src: []const u8, dst: []const u8) !void {
-    const in_file = try std.fs.openFileAbsolute(src, .{});
-    defer in_file.close();
+    const io = global_io.io();
+    const in_file = try std.Io.Dir.openFileAbsolute(io, src, .{});
+    defer in_file.close(io);
 
     try ensureParentDirRecursive(dst);
 
-    const out_file = try std.fs.createFileAbsolute(dst, .{ .truncate = true });
-    defer out_file.close();
+    const out_file = try std.Io.Dir.createFileAbsolute(io, dst, .{ .truncate = true });
+    defer out_file.close(io);
 
-    var buf: [8192]u8 = undefined;
-    while (true) {
-        const n = try in_file.read(&buf);
-        if (n == 0) break;
-        try out_file.writeAll(buf[0..n]);
-    }
+    var read_buf: [8192]u8 = undefined;
+    var in_reader = in_file.reader(io, &read_buf);
+    var write_buf: [8192]u8 = undefined;
+    var out_writer = out_file.writer(io, &write_buf);
+    _ = try in_reader.interface.streamRemaining(&out_writer.interface);
+    try out_writer.interface.flush();
 
     // Preserve source file mode (especially executable bit)
-    const stat = try in_file.stat();
-    out_file.chmod(stat.mode) catch {};
+    const stat = try in_file.stat(io);
+    out_file.setPermissions(io, stat.permissions) catch {};
 }
 
 /// Strip N leading path components from a relative path.
@@ -430,23 +443,24 @@ fn stripComponents(path: []const u8, count: u32) []const u8 {
 
 /// Walk a directory recursively and return all file relative paths
 fn walkDirRecursive(allocator: std.mem.Allocator, root: []const u8) !std.ArrayListUnmanaged([]const u8) {
-    var results: std.ArrayListUnmanaged([]const u8) = .{};
+    var results: std.ArrayListUnmanaged([]const u8) = .empty;
     try walkDirRecursiveInner(allocator, root, "", &results);
     return results;
 }
 
 fn walkDirRecursiveInner(allocator: std.mem.Allocator, root: []const u8, prefix: []const u8, results: *std.ArrayListUnmanaged([]const u8)) !void {
+    const io = global_io.io();
     const full_path = if (prefix.len > 0)
         try std.fs.path.join(allocator, &.{ root, prefix })
     else
         try allocator.dupe(u8, root);
     defer allocator.free(full_path);
 
-    var dir = std.fs.openDirAbsolute(full_path, .{ .iterate = true }) catch return;
-    defer dir.close();
+    var dir = std.Io.Dir.openDirAbsolute(io, full_path, .{ .iterate = true }) catch return;
+    defer dir.close(io);
 
     var iter = dir.iterate();
-    while (try iter.next()) |entry| {
+    while (try iter.next(io)) |entry| {
         const relative = if (prefix.len > 0)
             try std.fs.path.join(allocator, &.{ prefix, entry.name })
         else
@@ -469,19 +483,21 @@ const MARKER_NAME = ".hola-extracted";
 
 /// Build a fingerprint line: "path\tsize\tmtime_ns"
 fn buildFingerprint(alloc: std.mem.Allocator, archive_path: []const u8) ?[]const u8 {
-    const archive_file = std.fs.openFileAbsolute(archive_path, .{}) catch return null;
-    defer archive_file.close();
-    const stat = archive_file.stat() catch return null;
-    return std.fmt.allocPrint(alloc, "{s}\t{d}\t{d}", .{ archive_path, stat.size, stat.mtime }) catch null;
+    const io = global_io.io();
+    const archive_file = std.Io.Dir.openFileAbsolute(io, archive_path, .{}) catch return null;
+    defer archive_file.close(io);
+    const stat = archive_file.stat(io) catch return null;
+    return std.fmt.allocPrint(alloc, "{s}\t{d}\t{d}", .{ archive_path, stat.size, stat.mtime.toNanoseconds() }) catch null;
 }
 
 /// Check marker: fingerprint must match AND all recorded files must still exist.
 /// Marker format: first line = fingerprint, remaining lines = extracted file paths (relative to destination).
 fn checkMarker(destination: []const u8, archive_path: []const u8) bool {
+    const io = global_io.io();
     const alloc = std.heap.c_allocator;
     const marker_path = std.fs.path.join(alloc, &.{ destination, MARKER_NAME }) catch return false;
     defer alloc.free(marker_path);
-    const content = std.fs.cwd().readFileAlloc(alloc, marker_path, 1024 * 1024) catch return false;
+    const content = std.Io.Dir.cwd().readFileAlloc(io, marker_path, alloc, .limited(1024 * 1024)) catch return false;
     defer alloc.free(content);
 
     // First line is fingerprint
@@ -505,19 +521,24 @@ fn checkMarker(destination: []const u8, archive_path: []const u8) bool {
 
 /// Write marker: fingerprint + file list.
 fn writeMarker(destination: []const u8, archive_path: []const u8, files: []const []const u8) void {
+    const io = global_io.io();
     const alloc = std.heap.c_allocator;
     const marker_path = std.fs.path.join(alloc, &.{ destination, MARKER_NAME }) catch return;
     defer alloc.free(marker_path);
     const fingerprint = buildFingerprint(alloc, archive_path) orelse return;
     defer alloc.free(fingerprint);
-    const file = std.fs.createFileAbsolute(marker_path, .{ .truncate = true }) catch return;
-    defer file.close();
-    file.writeAll(fingerprint) catch {};
-    file.writeAll("\n") catch {};
+    const file = std.Io.Dir.createFileAbsolute(io, marker_path, .{ .truncate = true }) catch return;
+    defer file.close(io);
+    var marker_buf: [4096]u8 = undefined;
+    var marker_writer = file.writer(io, &marker_buf);
+    const w = &marker_writer.interface;
+    w.writeAll(fingerprint) catch {};
+    w.writeAll("\n") catch {};
     for (files) |rel| {
-        file.writeAll(rel) catch {};
-        file.writeAll("\n") catch {};
+        w.writeAll(rel) catch {};
+        w.writeAll("\n") catch {};
     }
+    w.flush() catch {};
 }
 
 pub fn detectArchiveType(path: []const u8) ArchiveType {

--- a/src/resources/file.zig
+++ b/src/resources/file.zig
@@ -3,6 +3,7 @@ const mruby = @import("../mruby.zig");
 const base = @import("../base_resource.zig");
 const git = @import("../git.zig");
 const logger = @import("../logger.zig");
+const global_io = @import("../global_io.zig");
 
 /// File resource data structure
 pub const Resource = struct {
@@ -84,6 +85,7 @@ pub const Resource = struct {
     const CreateResult = struct { was_updated: bool, output: ?[]const u8 };
 
     fn applyCreate(self: Resource) !CreateResult {
+        const io = global_io.io();
         try base.ensureParentDir(self.path);
         const is_abs = std.fs.path.isAbsolute(self.path);
 
@@ -94,12 +96,12 @@ pub const Resource = struct {
         // Check if file exists and content matches
         const file_exists = blk: {
             if (is_abs) {
-                std.fs.accessAbsolute(self.path, .{}) catch |err| switch (err) {
+                std.Io.Dir.accessAbsolute(io, self.path, .{}) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
             } else {
-                std.fs.cwd().access(self.path, .{}) catch |err| switch (err) {
+                std.Io.Dir.cwd().access(io, self.path, .{}) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
@@ -114,16 +116,18 @@ pub const Resource = struct {
         if (file_exists) {
             // Read existing file and compare content
             const existing_file = if (is_abs)
-                try std.fs.openFileAbsolute(self.path, .{})
+                try std.Io.Dir.openFileAbsolute(io, self.path, .{})
             else
-                try std.fs.cwd().openFile(self.path, .{});
-            defer existing_file.close();
+                try std.Io.Dir.cwd().openFile(io, self.path, .{});
+            defer existing_file.close(io);
 
-            existing_content = try existing_file.readToEndAlloc(std.heap.c_allocator, std.math.maxInt(usize));
+            var read_buf: [4096]u8 = undefined;
+            var existing_reader = existing_file.reader(io, &read_buf);
+            existing_content = try existing_reader.interface.allocRemaining(std.heap.c_allocator, .unlimited);
 
             if (self.attrs.mode) |_| {
-                const stat = try existing_file.stat();
-                current_mode = @intCast(stat.mode & 0o777);
+                const stat = try existing_file.stat(io);
+                current_mode = @intCast(stat.permissions.toMode() & 0o777);
             }
 
             if (std.mem.eql(u8, existing_content.?, self.content)) {
@@ -172,7 +176,7 @@ pub const Resource = struct {
         }
 
         const dir_path = std.fs.path.dirname(self.path);
-        const timestamp = std.time.nanoTimestamp();
+        const timestamp = std.Io.Timestamp.now(io, .real).toNanoseconds();
         const pid = std.c.getpid();
         const temp_name = try std.fmt.allocPrint(allocator, ".hola-tmp-{d}-{d}", .{ timestamp, pid });
         const temp_path = if (dir_path) |d|
@@ -181,30 +185,33 @@ pub const Resource = struct {
             temp_name;
 
         var temp_file = if (is_abs)
-            try std.fs.createFileAbsolute(temp_path, .{ .truncate = true, .exclusive = true })
+            try std.Io.Dir.createFileAbsolute(io, temp_path, .{ .truncate = true, .exclusive = true })
         else
-            try std.fs.cwd().createFile(temp_path, .{ .truncate = true, .exclusive = true });
+            try std.Io.Dir.cwd().createFile(io, temp_path, .{ .truncate = true, .exclusive = true });
 
         var temp_cleanup = true;
         var temp_file_closed = false;
         defer if (temp_cleanup) {
-            if (!temp_file_closed) temp_file.close();
+            if (!temp_file_closed) temp_file.close(io);
             if (is_abs) {
-                std.fs.deleteFileAbsolute(temp_path) catch {};
+                std.Io.Dir.deleteFileAbsolute(io, temp_path) catch {};
             } else {
-                std.fs.cwd().deleteFile(temp_path) catch {};
+                std.Io.Dir.cwd().deleteFile(io, temp_path) catch {};
             }
         };
 
-        try temp_file.writeAll(self.content);
-        try temp_file.sync();
-        temp_file.close();
+        var write_buf: [4096]u8 = undefined;
+        var temp_writer = temp_file.writer(io, &write_buf);
+        try temp_writer.interface.writeAll(self.content);
+        try temp_writer.interface.flush();
+        try temp_file.sync(io);
+        temp_file.close(io);
         temp_file_closed = true;
 
         if (is_abs) {
-            try std.fs.renameAbsolute(temp_path, self.path);
+            try std.Io.Dir.renameAbsolute(temp_path, self.path, io);
         } else {
-            try std.fs.cwd().rename(temp_path, self.path);
+            try std.Io.Dir.cwd().rename(temp_path, std.Io.Dir.cwd(), self.path, io);
         }
 
         // Temp file has been moved; avoid double cleanup
@@ -223,6 +230,7 @@ pub const Resource = struct {
     /// file is created; otherwise its bytes are left untouched. The `content`
     /// property is intentionally ignored for touch.
     fn applyTouch(self: Resource) !bool {
+        const io = global_io.io();
         try base.ensureParentDir(self.path);
         const is_abs = std.fs.path.isAbsolute(self.path);
 
@@ -232,12 +240,12 @@ pub const Resource = struct {
         // utimensat (checks inode ownership, not write permission).
         const exists = blk: {
             if (is_abs) {
-                std.fs.accessAbsolute(self.path, .{}) catch |err| switch (err) {
+                std.Io.Dir.accessAbsolute(io, self.path, .{}) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
             } else {
-                std.fs.cwd().access(self.path, .{}) catch |err| switch (err) {
+                std.Io.Dir.cwd().access(io, self.path, .{}) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
@@ -247,10 +255,10 @@ pub const Resource = struct {
 
         if (!exists) {
             const new_file = if (is_abs)
-                try std.fs.createFileAbsolute(self.path, .{})
+                try std.Io.Dir.createFileAbsolute(io, self.path, .{})
             else
-                try std.fs.cwd().createFile(self.path, .{});
-            new_file.close();
+                try std.Io.Dir.cwd().createFile(io, self.path, .{});
+            new_file.close(io);
         }
 
         // Path-based utimensat with times=null sets both atime and mtime
@@ -276,14 +284,15 @@ pub const Resource = struct {
     }
 
     fn applyDelete(self: Resource) !void {
+        const io = global_io.io();
         const is_abs = std.fs.path.isAbsolute(self.path);
         if (is_abs) {
-            std.fs.deleteFileAbsolute(self.path) catch |err| switch (err) {
+            std.Io.Dir.deleteFileAbsolute(io, self.path) catch |err| switch (err) {
                 error.FileNotFound => return,
                 else => return err,
             };
         } else {
-            std.fs.cwd().deleteFile(self.path) catch |err| switch (err) {
+            std.Io.Dir.cwd().deleteFile(io, self.path) catch |err| switch (err) {
                 error.FileNotFound => return,
                 else => return err,
             };

--- a/src/resources/file_edit.zig
+++ b/src/resources/file_edit.zig
@@ -5,6 +5,7 @@ const mruby = @import("../mruby.zig");
 const base = @import("../base_resource.zig");
 const regex = @import("../regex.zig");
 const logger = @import("../logger.zig");
+const global_io = @import("../global_io.zig");
 
 pub const Resource = struct {
     name: []const u8,
@@ -68,13 +69,15 @@ pub const Resource = struct {
 };
 
 fn applyEdit(res: Resource) !bool {
-    const file = std.fs.openFileAbsolute(res.path, .{}) catch |err| {
+    const io = global_io.io();
+    const file = std.Io.Dir.openFileAbsolute(io, res.path, .{}) catch |err| {
         logger.err("Failed to open file {s}: {}", .{ res.path, err });
         return err;
     };
-    defer file.close();
+    defer file.close(io);
 
-    const content = file.readToEndAlloc(res.allocator, std.math.maxInt(usize)) catch |err| {
+    var file_reader = file.reader(io, &.{});
+    const content = file_reader.interface.allocRemaining(res.allocator, .unlimited) catch |err| {
         logger.err("Failed to read file {s}: {}", .{ res.path, err });
         return err;
     };
@@ -102,7 +105,7 @@ fn applyEdit(res: Resource) !bool {
     if (res.backup) {
         const backup_path = try std.fmt.allocPrint(res.allocator, "{s}.bak", .{res.path});
         defer res.allocator.free(backup_path);
-        std.fs.copyFileAbsolute(res.path, backup_path, .{}) catch |err| {
+        std.Io.Dir.copyFileAbsolute(res.path, backup_path, io, .{}) catch |err| {
             logger.warn("Failed to create backup {s}: {}", .{ backup_path, err });
         };
     }
@@ -249,10 +252,11 @@ fn doInsertLineIfNoMatch(allocator: std.mem.Allocator, content: []const u8, patt
 }
 
 fn writeFile(res: Resource, content: []const u8) !void {
+    const io = global_io.io();
     try base.ensureParentDir(res.path);
 
     const dir_path = std.fs.path.dirname(res.path);
-    const timestamp = std.time.nanoTimestamp();
+    const timestamp = std.Io.Timestamp.now(io, .real).toNanoseconds();
     const pid = std.c.getpid();
 
     const temp_name = try std.fmt.allocPrint(res.allocator, ".hola-file-edit-{d}-{d}", .{ timestamp, pid });
@@ -264,14 +268,16 @@ fn writeFile(res: Resource, content: []const u8) !void {
         try res.allocator.dupe(u8, temp_name);
     defer res.allocator.free(temp_path);
 
-    var temp_file = try std.fs.createFileAbsolute(temp_path, .{ .truncate = true, .exclusive = true });
-    errdefer std.fs.deleteFileAbsolute(temp_path) catch {};
+    var temp_file = try std.Io.Dir.createFileAbsolute(io, temp_path, .{ .truncate = true, .exclusive = true });
+    errdefer std.Io.Dir.deleteFileAbsolute(io, temp_path) catch {};
 
-    try temp_file.writeAll(content);
-    try temp_file.sync();
-    temp_file.close();
+    var temp_writer = temp_file.writer(io, &.{});
+    try temp_writer.interface.writeAll(content);
+    try temp_writer.interface.flush();
+    try temp_file.sync(io);
+    temp_file.close(io);
 
-    try std.fs.renameAbsolute(temp_path, res.path);
+    try std.Io.Dir.renameAbsolute(temp_path, res.path, io);
 
     base.applyFileAttributes(res.path, .{
         .mode = res.mode,

--- a/src/resources/git.zig
+++ b/src/resources/git.zig
@@ -5,6 +5,7 @@ const logger = @import("../logger.zig");
 const git_client = @import("../git.zig");
 const http = @import("../http.zig");
 const AsyncExecutor = @import("../async_executor.zig").AsyncExecutor;
+const global_io = @import("../global_io.zig");
 
 const c = @cImport({
     @cInclude("git2.h");
@@ -110,7 +111,7 @@ pub const Resource = struct {
     fn isGitRepo(path: []const u8) bool {
         var git_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
         const git_dir = std.fmt.bufPrint(&git_dir_buf, "{s}/.git", .{path}) catch return false;
-        std.fs.accessAbsolute(git_dir, .{}) catch return false;
+        std.Io.Dir.accessAbsolute(global_io.io(), git_dir, .{}) catch return false;
         return true;
     }
 
@@ -127,11 +128,12 @@ pub const Resource = struct {
         try base.setFileOwnerAndGroup(dir_path, user, group);
 
         // Then recursively set ownership on all contents
-        var dir = try std.fs.openDirAbsolute(dir_path, .{ .iterate = true });
-        defer dir.close();
+        const io = global_io.io();
+        var dir = try std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true });
+        defer dir.close(io);
 
         var iter = dir.iterate();
-        while (try iter.next()) |entry| {
+        while (try iter.next(io)) |entry| {
             const full_path = try std.fs.path.join(allocator, &[_][]const u8{ dir_path, entry.name });
             defer allocator.free(full_path);
 
@@ -299,7 +301,7 @@ pub const Resource = struct {
             }
 
             // Priority 3: Fall back to default SSH key files (automatic discovery)
-            const home = std.posix.getenv("HOME") orelse "/tmp";
+            const home = global_io.getEnv("HOME") orelse "/tmp";
             const key_names = [_][]const u8{ "id_ed25519", "id_rsa", "id_ecdsa", "id_dsa" };
 
             for (key_names) |key_name| {
@@ -307,7 +309,7 @@ pub const Resource = struct {
                 const key_path = std.fmt.bufPrintZ(&key_path_buf, "{s}/.ssh/{s}", .{ home, key_name }) catch continue;
 
                 // Check if key file exists
-                std.fs.accessAbsolute(key_path, .{}) catch continue;
+                std.Io.Dir.accessAbsolute(global_io.io(), key_path, .{}) catch continue;
 
                 // Try this key
                 const key_path_c: [*c]const u8 = @ptrCast(key_path.ptr);
@@ -717,7 +719,7 @@ pub const Resource = struct {
                     const value = pair[eq_pos + 1 ..];
                     // Save original value
                     const key_z = try allocator.dupeZ(u8, key);
-                    const orig = std.posix.getenv(key);
+                    const orig = global_io.getEnv(key);
                     const orig_dup: ?[]const u8 = if (orig) |o| try allocator.dupe(u8, o) else null;
                     try saved.append(allocator, .{ .key = key_z, .original = orig_dup });
                     // Set new value
@@ -825,7 +827,7 @@ pub const Resource = struct {
         // and libgit2's check can fail under root-with-seteuid scenarios.
         _ = c.git_libgit2_opts(c.GIT_OPT_SET_OWNER_VALIDATION, @as(c_int, 0));
 
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        var gpa = std.heap.DebugAllocator(.{}){};
         defer _ = gpa.deinit();
         const allocator = gpa.allocator();
 
@@ -843,7 +845,7 @@ pub const Resource = struct {
 
         // Check if destination exists and is a git repo
         const dest_exists = blk: {
-            std.fs.accessAbsolute(self.destination, .{}) catch |err| switch (err) {
+            std.Io.Dir.accessAbsolute(global_io.io(), self.destination, .{}) catch |err| switch (err) {
                 error.FileNotFound => break :blk false,
                 else => return err,
             };
@@ -929,7 +931,7 @@ pub const Resource = struct {
     fn applyCheckout(self: Resource) !bool {
         // Similar to sync but don't update if already exists
         const dest_exists = blk: {
-            std.fs.accessAbsolute(self.destination, .{}) catch |err| switch (err) {
+            std.Io.Dir.accessAbsolute(global_io.io(), self.destination, .{}) catch |err| switch (err) {
                 error.FileNotFound => break :blk false,
                 else => return err,
             };
@@ -942,7 +944,7 @@ pub const Resource = struct {
         }
 
         // Clone the repository
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        var gpa = std.heap.DebugAllocator(.{}){};
         defer _ = gpa.deinit();
         const allocator = gpa.allocator();
 
@@ -978,7 +980,7 @@ pub const Resource = struct {
             var git_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
             const git_dir = try std.fmt.bufPrint(&git_dir_buf, "{s}/.git", .{self.destination});
 
-            std.fs.deleteTreeAbsolute(git_dir) catch |err| {
+            std.Io.Dir.cwd().deleteTree(global_io.io(), git_dir) catch |err| {
                 logger.warn("[git] failed to remove .git directory: {}", .{err});
             };
         }

--- a/src/resources/group.zig
+++ b/src/resources/group.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const mruby = @import("../mruby.zig");
 const base = @import("../base_resource.zig");
 const logger = @import("../logger.zig");
+const global_io = @import("../global_io.zig");
 
 /// Group resource data structure
 pub const Resource = struct {
@@ -76,8 +77,7 @@ pub const Resource = struct {
         const allocator = arena.allocator();
 
         const args = [_][]const u8{ "getent", "group", group_name };
-        const result = std.process.Child.run(.{
-            .allocator = allocator,
+        const result = std.process.run(allocator, global_io.io(), .{
             .argv = &args,
         }) catch |err| {
             logger.debug("getent command failed for group '{s}': {}", .{ group_name, err });
@@ -87,7 +87,7 @@ pub const Resource = struct {
         defer allocator.free(result.stderr);
 
         switch (result.term) {
-            .Exited => |code| return code == 0,
+            .exited => |code| return code == 0,
             else => return false,
         }
     }
@@ -99,30 +99,29 @@ pub const Resource = struct {
     ) ![]const u8 {
         var buf = try std.ArrayList(u8).initCapacity(allocator, 128);
         errdefer buf.deinit(allocator);
-        const writer = buf.writer(allocator);
 
-        try writer.writeAll(cmd);
+        try buf.appendSlice(allocator, cmd);
 
         if (std.mem.eql(u8, cmd, "groupadd")) {
             if (self.gid) |gid| {
-                try writer.print(" -g {d}", .{gid});
+                try buf.print(allocator, " -g {d}", .{gid});
             }
             if (self.system) {
-                try writer.writeAll(" -r");
+                try buf.appendSlice(allocator, " -r");
             }
             if (self.non_unique) {
-                try writer.writeAll(" -o");
+                try buf.appendSlice(allocator, " -o");
             }
         } else if (std.mem.eql(u8, cmd, "groupmod")) {
             if (self.gid) |gid| {
-                try writer.print(" -g {d}", .{gid});
+                try buf.print(allocator, " -g {d}", .{gid});
             }
             if (self.non_unique) {
-                try writer.writeAll(" -o");
+                try buf.appendSlice(allocator, " -o");
             }
         }
 
-        try writer.print(" {s}", .{self.group_name});
+        try buf.print(allocator, " {s}", .{self.group_name});
         return try buf.toOwnedSlice(allocator);
     }
 
@@ -130,8 +129,7 @@ pub const Resource = struct {
         logger.debug("Executing: {s}", .{cmd});
 
         const args = [_][]const u8{ "/bin/sh", "-c", cmd };
-        const result = try std.process.Child.run(.{
-            .allocator = allocator,
+        const result = try std.process.run(allocator, global_io.io(), .{
             .argv = &args,
         });
         defer allocator.free(result.stdout);
@@ -145,7 +143,7 @@ pub const Resource = struct {
         }
 
         switch (result.term) {
-            .Exited => |code| {
+            .exited => |code| {
                 if (code != 0) {
                     logger.err("Command exited with code {d}: {s}", .{ code, cmd });
                     // Print error details

--- a/src/resources/homebrew_package.zig
+++ b/src/resources/homebrew_package.zig
@@ -5,6 +5,7 @@ const logger = @import("../logger.zig");
 const builtin = @import("builtin");
 const AsyncExecutor = @import("../async_executor.zig").AsyncExecutor;
 const common = @import("package_common.zig");
+const global_io = @import("../global_io.zig");
 
 // Only compile on macOS
 comptime {
@@ -254,43 +255,36 @@ fn isInstalled(allocator: std.mem.Allocator, name: []const u8) !bool {
     const cmd = try std.fmt.allocPrint(allocator, "brew list --versions {s} 2>/dev/null", .{name});
     defer allocator.free(cmd);
 
-    var child = std.process.Child.init(&[_][]const u8{ "/bin/sh", "-c", cmd }, allocator);
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
+    const result = try std.process.run(allocator, global_io.io(), .{
+        .argv = &[_][]const u8{ "/bin/sh", "-c", cmd },
+        .stdout_limit = .limited(1024 * 1024),
+        .stderr_limit = .limited(1024 * 1024),
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
 
-    try child.spawn();
-    const stdout = try child.stdout.?.readToEndAlloc(allocator, 1024 * 1024);
-    defer allocator.free(stdout);
-    const stderr = try child.stderr.?.readToEndAlloc(allocator, 1024 * 1024);
-    defer allocator.free(stderr);
-
-    const term = try child.wait();
-    const exited_ok = switch (term) {
-        .Exited => |code| code == 0,
+    const exited_ok = switch (result.term) {
+        .exited => |code| code == 0,
         else => false,
     };
 
     // If command succeeded and there's output, package is installed
-    return exited_ok and stdout.len > 0;
+    return exited_ok and result.stdout.len > 0;
 }
 
 /// Execute a Homebrew command with appropriate error mapping based on action
 fn runCommand(allocator: std.mem.Allocator, cmd: []const u8, action: common.Action, packages: []const []const u8) !void {
-    var child = std.process.Child.init(&[_][]const u8{ "/bin/sh", "-c", cmd }, allocator);
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
+    // stdin is set to /dev/null (via std.process.run) to prevent interactive prompts
+    const result = try std.process.run(allocator, global_io.io(), .{
+        .argv = &[_][]const u8{ "/bin/sh", "-c", cmd },
+    });
 
-    // Set stdin to /dev/null to prevent any interactive prompts
-    child.stdin_behavior = .Ignore;
-
-    try child.spawn();
-
-    const stdout = try child.stdout.?.readToEndAlloc(allocator, std.math.maxInt(usize));
-    const stderr = try child.stderr.?.readToEndAlloc(allocator, std.math.maxInt(usize));
+    const stdout = result.stdout;
+    const stderr = result.stderr;
     defer allocator.free(stdout);
     defer allocator.free(stderr);
 
-    const term = try child.wait();
+    const term = result.term;
 
     // Log output (but don't display it)
     if (stdout.len > 0) {
@@ -309,7 +303,7 @@ fn runCommand(allocator: std.mem.Allocator, cmd: []const u8, action: common.Acti
 
     // Check exit status and return appropriate error based on action
     switch (term) {
-        .Exited => |code| {
+        .exited => |code| {
             if (code != 0) {
                 // Format package list for error message
                 const pkg_list = std.mem.join(allocator, ", ", packages) catch "unknown";
@@ -329,10 +323,10 @@ fn runCommand(allocator: std.mem.Allocator, cmd: []const u8, action: common.Acti
                 };
             }
         },
-        .Signal => |sig| {
+        .signal => |sig| {
             const pkg_list = std.mem.join(allocator, ", ", packages) catch "unknown";
             defer if (pkg_list.ptr != "unknown".ptr) allocator.free(pkg_list);
-            logger.err("[homebrew_package] command killed by signal {d} for package(s): {s}", .{ sig, pkg_list });
+            logger.err("[homebrew_package] command killed by signal {d} for package(s): {s}", .{ @intFromEnum(sig), pkg_list });
             return common.PackageError.CommandFailed;
         },
         else => {

--- a/src/resources/link.zig
+++ b/src/resources/link.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const mruby = @import("../mruby.zig");
 const base = @import("../base_resource.zig");
+const global_io = @import("../global_io.zig");
 
 /// Link resource data structure
 pub const Resource = struct {
@@ -70,18 +71,19 @@ pub const Resource = struct {
     }
 
     fn applyCreate(self: Resource) !bool {
+        const io = global_io.io();
         const is_abs = std.fs.path.isAbsolute(self.path);
 
         // Check if link already exists
         var link_buf: [std.fs.max_path_bytes]u8 = undefined;
         const link_exists = blk: {
             if (is_abs) {
-                _ = std.fs.readLinkAbsolute(self.path, &link_buf) catch |err| switch (err) {
+                _ = std.Io.Dir.readLinkAbsolute(io, self.path, &link_buf) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
             } else {
-                _ = std.fs.cwd().readLink(self.path, &link_buf) catch |err| switch (err) {
+                _ = std.Io.Dir.cwd().readLink(io, self.path, &link_buf) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
@@ -92,10 +94,11 @@ pub const Resource = struct {
         if (link_exists) {
             // Check if link points to correct target
             var target_buf: [std.fs.max_path_bytes]u8 = undefined;
-            const current_target = if (is_abs)
-                try std.fs.readLinkAbsolute(self.path, &target_buf)
+            const target_len = if (is_abs)
+                try std.Io.Dir.readLinkAbsolute(io, self.path, &target_buf)
             else
-                try std.fs.cwd().readLink(self.path, &target_buf);
+                try std.Io.Dir.cwd().readLink(io, self.path, &target_buf);
+            const current_target = target_buf[0..target_len];
 
             // Normalize paths for comparison
             const normalized_current = try normalizePath(std.heap.page_allocator, current_target);
@@ -108,23 +111,23 @@ pub const Resource = struct {
             } else {
                 // Delete existing link and create new one
                 if (is_abs) {
-                    try std.fs.deleteFileAbsolute(self.path);
+                    try std.Io.Dir.deleteFileAbsolute(io, self.path);
                 } else {
-                    try std.fs.cwd().deleteFile(self.path);
+                    try std.Io.Dir.cwd().deleteFile(io, self.path);
                 }
             }
         }
 
         // Create parent directory if it doesn't exist
         if (std.fs.path.dirname(self.path)) |dir| {
-            try std.fs.cwd().makePath(dir);
+            try std.Io.Dir.cwd().createDirPath(io, dir);
         }
 
         // Create symbolic link
         if (is_abs) {
-            try std.fs.symLinkAbsolute(self.target, self.path, .{});
+            try std.Io.Dir.symLinkAbsolute(io, self.target, self.path, .{});
         } else {
-            try std.fs.cwd().symLink(self.target, self.path, .{});
+            try std.Io.Dir.cwd().symLink(io, self.target, self.path, .{});
         }
 
         // Set ownership if specified (use lchown for symlinks)
@@ -137,36 +140,39 @@ pub const Resource = struct {
 
     /// Set ownership for a symbolic link (does not follow the link)
     fn setLinkOwnership(link_path: []const u8, owner: ?[]const u8, group: ?[]const u8) !void {
-        const c = @cImport({
-            @cInclude("unistd.h");
-        });
+        // A uid/gid of -1 leaves that field unchanged, matching the previous
+        // behaviour of preserving the current uid/gid when only one of
+        // owner/group is specified. Uses libc fchownat because zig 0.16.0's
+        // Io.Dir.setFileOwner declares an error set narrower than its
+        // Threaded implementation returns (compile error when referenced).
+        const uid: std.posix.uid_t = if (owner) |o| try base.getUserId(o) else @bitCast(@as(i32, -1));
+        const gid: std.posix.gid_t = if (group) |g| try base.getGroupId(g) else @bitCast(@as(i32, -1));
 
-        // Get current ownership using lstat (doesn't follow symlinks)
-        const stat = try std.posix.fstatat(std.posix.AT.FDCWD, link_path, std.posix.AT.SYMLINK_NOFOLLOW);
+        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        if (link_path.len >= path_buf.len) return error.ChownFailed;
+        @memcpy(path_buf[0..link_path.len], link_path);
+        path_buf[link_path.len] = 0;
 
-        const uid = if (owner) |o| try base.getUserId(o) else stat.uid;
-        const gid = if (group) |g| try base.getGroupId(g) else stat.gid;
-
-        // Use lchown to change ownership without following the link
-        const path_z = try std.posix.toPosixPath(link_path);
-        if (c.lchown(&path_z, uid, gid) != 0) {
+        // AT_SYMLINK_NOFOLLOW, i.e. lchown semantics.
+        if (std.c.fchownat(std.posix.AT.FDCWD, path_buf[0..link_path.len :0], uid, gid, std.posix.AT.SYMLINK_NOFOLLOW) != 0) {
             return error.ChownFailed;
         }
     }
 
     fn applyDelete(self: Resource) !void {
+        const io = global_io.io();
         const is_abs = std.fs.path.isAbsolute(self.path);
 
         // Check if link exists
         var link_buf: [std.fs.max_path_bytes]u8 = undefined;
         const link_exists = blk: {
             if (is_abs) {
-                _ = std.fs.readLinkAbsolute(self.path, &link_buf) catch |err| switch (err) {
+                _ = std.Io.Dir.readLinkAbsolute(io, self.path, &link_buf) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
             } else {
-                _ = std.fs.cwd().readLink(self.path, &link_buf) catch |err| switch (err) {
+                _ = std.Io.Dir.cwd().readLink(io, self.path, &link_buf) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
@@ -180,19 +186,20 @@ pub const Resource = struct {
 
         // Delete link
         if (is_abs) {
-            try std.fs.deleteFileAbsolute(self.path);
+            try std.Io.Dir.deleteFileAbsolute(io, self.path);
         } else {
-            try std.fs.cwd().deleteFile(self.path);
+            try std.Io.Dir.cwd().deleteFile(io, self.path);
         }
     }
 
     fn normalizePath(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {
+        const io = global_io.io();
         // Resolve relative paths and remove redundant components
         const resolved = if (std.fs.path.isAbsolute(path))
             try allocator.dupe(u8, path)
         else blk: {
             // For relative paths, resolve them relative to current working directory
-            const cwd = try std.process.getCwdAlloc(allocator);
+            const cwd = try std.process.currentPathAlloc(io, allocator);
             defer allocator.free(cwd);
             const full_path = try std.fs.path.join(allocator, &.{ cwd, path });
             break :blk full_path;

--- a/src/resources/macos_defaults.zig
+++ b/src/resources/macos_defaults.zig
@@ -13,6 +13,7 @@ comptime {
 // IMPORTANT: Use global CoreFoundation bindings to ensure consistent constant addresses across all modules
 const cf = @import("../cf.zig");
 const c = cf.c;
+const global_io = @import("../global_io.zig");
 
 // ============================================================================
 // C wrapper functions for CFPreferences operations
@@ -144,7 +145,7 @@ pub const Resource = struct {
     }
 
     fn applyWrite(self: Resource) !bool {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        var gpa = std.heap.DebugAllocator(.{}){};
         defer _ = gpa.deinit();
         const allocator = gpa.allocator();
 
@@ -198,49 +199,43 @@ pub const Resource = struct {
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
         defer arena.deinit();
         const arena_allocator = arena.allocator();
+        const io = global_io.io();
 
         // Kill Finder
-        var kill_proc = std.process.Child.init(&[_][]const u8{ "killall", "Finder" }, arena_allocator);
-        kill_proc.stdout_behavior = .Ignore;
-        kill_proc.stderr_behavior = .Ignore;
-        _ = kill_proc.spawnAndWait() catch {};
+        _ = std.process.run(arena_allocator, io, .{ .argv = &[_][]const u8{ "killall", "Finder" } }) catch {};
 
         // Finder will automatically restart
-        std.Thread.sleep(500_000_000); // 0.5 seconds
+        io.sleep(.fromNanoseconds(500_000_000), .awake) catch {}; // 0.5 seconds
     }
 
     fn restartDock(_: std.mem.Allocator) !void {
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
         defer arena.deinit();
         const arena_allocator = arena.allocator();
+        const io = global_io.io();
 
         // Kill Dock
-        var kill_proc = std.process.Child.init(&[_][]const u8{ "killall", "Dock" }, arena_allocator);
-        kill_proc.stdout_behavior = .Ignore;
-        kill_proc.stderr_behavior = .Ignore;
-        _ = kill_proc.spawnAndWait() catch {};
+        _ = std.process.run(arena_allocator, io, .{ .argv = &[_][]const u8{ "killall", "Dock" } }) catch {};
 
         // Dock will automatically restart
-        std.Thread.sleep(500_000_000); // 0.5 seconds
+        io.sleep(.fromNanoseconds(500_000_000), .awake) catch {}; // 0.5 seconds
     }
 
     fn restartSystemUIServer(_: std.mem.Allocator) !void {
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
         defer arena.deinit();
         const arena_allocator = arena.allocator();
+        const io = global_io.io();
 
         // Kill SystemUIServer
-        var kill_proc = std.process.Child.init(&[_][]const u8{ "killall", "SystemUIServer" }, arena_allocator);
-        kill_proc.stdout_behavior = .Ignore;
-        kill_proc.stderr_behavior = .Ignore;
-        _ = kill_proc.spawnAndWait() catch {};
+        _ = std.process.run(arena_allocator, io, .{ .argv = &[_][]const u8{ "killall", "SystemUIServer" } }) catch {};
 
         // SystemUIServer will automatically restart
-        std.Thread.sleep(500_000_000); // 0.5 seconds
+        io.sleep(.fromNanoseconds(500_000_000), .awake) catch {}; // 0.5 seconds
     }
 
     fn applyDelete(self: Resource) !void {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        var gpa = std.heap.DebugAllocator(.{}){};
         defer _ = gpa.deinit();
         const allocator = gpa.allocator();
 
@@ -318,15 +313,14 @@ pub const Resource = struct {
         const arena_alloc = arena.allocator();
 
         const cmd = try std.fmt.allocPrint(arena_alloc, "defaults read {s} {s}", .{ domain, key });
-        var proc = std.process.Child.init(&[_][]const u8{ "/bin/sh", "-c", cmd }, arena_alloc);
-        proc.stdout_behavior = .Pipe;
-        proc.stderr_behavior = .Ignore;
-        try proc.spawn();
-        const stdout = try proc.stdout.?.readToEndAlloc(arena_alloc, 1024);
-        const result = try proc.wait();
+        const run_result = try std.process.run(arena_alloc, global_io.io(), .{
+            .argv = &[_][]const u8{ "/bin/sh", "-c", cmd },
+            .stdout_limit = .limited(1024),
+        });
+        const stdout = run_result.stdout;
 
         // If the key doesn't exist, `defaults read` will exit with non-zero status
-        if (result.Exited != 0) {
+        if (run_result.term.exited != 0) {
             return null; // Key doesn't exist
         }
 

--- a/src/resources/macos_dock.zig
+++ b/src/resources/macos_dock.zig
@@ -4,6 +4,7 @@ const base = @import("../base_resource.zig");
 const plist = @import("../plist.zig");
 const logger = @import("../logger.zig");
 const builtin = @import("builtin");
+const global_io = @import("../global_io.zig");
 
 extern fn zig_mrb_nil_p(val: mruby.mrb_value) c_int;
 
@@ -60,12 +61,12 @@ pub const Resource = struct {
     }
 
     fn applyConfigure(self: Resource) !bool {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        var gpa = std.heap.DebugAllocator(.{}){};
         defer _ = gpa.deinit();
         const allocator = gpa.allocator();
 
         // Get Dock plist path - use actual Dock plist
-        const home_dir = std.posix.getenv("HOME") orelse return error.HomeNotFound;
+        const home_dir = global_io.getEnv("HOME") orelse return error.HomeNotFound;
         const dock_plist_path = try std.fmt.allocPrint(allocator, "{s}/Library/Preferences/com.apple.dock.plist", .{home_dir});
         defer allocator.free(dock_plist_path);
 
@@ -355,9 +356,7 @@ pub const Resource = struct {
 
             // Use CFPreferences API to set values (like dockutil does)
             // This is more reliable than directly modifying plist files
-            const c = @cImport({
-                @cInclude("CoreFoundation/CoreFoundation.h");
-            });
+            const c = @import("../cf.zig").c;
 
             const domain = c.CFStringCreateWithCString(null, "com.apple.dock", c.kCFStringEncodingUTF8);
             if (domain == null) return error.OutOfMemory;
@@ -386,7 +385,7 @@ pub const Resource = struct {
             try killDockWithSignal9();
 
             // Wait for Dock to fully exit
-            std.Thread.sleep(500_000_000); // 0.5 seconds
+            global_io.io().sleep(.fromNanoseconds(500_000_000), .awake) catch {}; // 0.5 seconds
 
             // NOW set the preferences (Dock is not running, so it can't overwrite)
             logger.debug("macos_dock: synchronizing preferences", .{});
@@ -403,7 +402,7 @@ pub const Resource = struct {
             }
 
             // Dock will automatically restart after being killed
-            std.Thread.sleep(1_000_000_000); // 1 second
+            global_io.io().sleep(.fromNanoseconds(1_000_000_000), .awake) catch {}; // 1 second
 
             logger.info("macos_dock: Dock restart completed", .{});
             return true;
@@ -552,9 +551,7 @@ pub const Resource = struct {
     }
 
     fn createAppEntry(allocator: std.mem.Allocator, app_path: []const u8) !plist.Value {
-        const c = @cImport({
-            @cInclude("CoreFoundation/CoreFoundation.h");
-        });
+        const c = @import("../cf.zig").c;
 
         // Create app entry structure
         var app_dict = plist.Dictionary.init(allocator);
@@ -577,7 +574,7 @@ pub const Resource = struct {
         defer allocator.free(decoded_path);
 
         // If the decoded path does not exist on disk, skip this app.
-        std.fs.accessAbsolute(decoded_path, .{}) catch |err| switch (err) {
+        std.Io.Dir.accessAbsolute(global_io.io(), decoded_path, .{}) catch |err| switch (err) {
             error.FileNotFound => return error.AppNotFound,
             else => return err,
         };
@@ -662,9 +659,7 @@ pub const Resource = struct {
     }
 
     fn readDockPrefWithCFPreferences(allocator: std.mem.Allocator, key: []const u8) !?plist.Value {
-        const c = @cImport({
-            @cInclude("CoreFoundation/CoreFoundation.h");
-        });
+        const c = @import("../cf.zig").c;
 
         // Convert key to CFString
         const key_cf = c.CFStringCreateWithCString(null, key.ptr, c.kCFStringEncodingUTF8);
@@ -719,9 +714,7 @@ pub const Resource = struct {
     /// the caller must force a write path to clean it up even if the AnyHost
     /// value already matches the desired state.
     fn currentHostHasShadow(key: []const u8) bool {
-        const c = @cImport({
-            @cInclude("CoreFoundation/CoreFoundation.h");
-        });
+        const c = @import("../cf.zig").c;
 
         const key_cf = c.CFStringCreateWithCString(null, key.ptr, c.kCFStringEncodingUTF8);
         if (key_cf == null) return false;
@@ -738,9 +731,7 @@ pub const Resource = struct {
     }
 
     fn updateDockPrefWithCFPreferences(_: std.mem.Allocator, key: []const u8, value: plist.Value) !void {
-        const c = @cImport({
-            @cInclude("CoreFoundation/CoreFoundation.h");
-        });
+        const c = @import("../cf.zig").c;
 
         // Convert key to CFString
         const key_cf = c.CFStringCreateWithCString(null, key.ptr, c.kCFStringEncodingUTF8);
@@ -796,51 +787,50 @@ pub const Resource = struct {
     fn restartDockGracefully() !void {
         // Use killall without -9 to allow Dock to terminate gracefully
         // This lets Dock save its state properly before exiting
-        var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-        defer arena.deinit();
-        const allocator = arena.allocator();
+        const io = global_io.io();
 
-        var proc = std.process.Child.init(&[_][]const u8{ "killall", "Dock" }, allocator);
-        proc.stdout_behavior = .Ignore;
-        proc.stderr_behavior = .Ignore;
-        _ = try proc.spawnAndWait();
+        var proc = try std.process.spawn(io, .{
+            .argv = &[_][]const u8{ "killall", "Dock" },
+            .stdout = .ignore,
+            .stderr = .ignore,
+        });
+        _ = proc.wait(io) catch {};
 
         // Wait a moment for Dock to restart
-        std.Thread.sleep(1_000_000_000); // 1 second
+        io.sleep(.fromNanoseconds(1_000_000_000), .awake) catch {}; // 1 second
     }
 
     fn killDockWithSignal9() !void {
         var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
         defer arena.deinit();
         const allocator = arena.allocator();
+        const io = global_io.io();
 
         // Use kill -9 to force kill Dock without allowing it to save state
         // Find Dock process PID first
-        var proc = std.process.Child.init(&[_][]const u8{ "pgrep", "-x", "Dock" }, allocator);
-        proc.stdout_behavior = .Pipe;
-        proc.stderr_behavior = .Ignore;
-        try proc.spawn();
+        var proc = try std.process.spawn(io, .{
+            .argv = &[_][]const u8{ "pgrep", "-x", "Dock" },
+            .stdout = .pipe,
+            .stderr = .ignore,
+        });
 
         const stdout = proc.stdout orelse {
-            _ = proc.wait() catch {};
+            _ = proc.wait(io) catch {};
             return;
         };
 
         var buf: [32]u8 = undefined;
-        const bytes_read = stdout.read(&buf) catch {
-            _ = proc.wait() catch {};
+        const bytes_read = std.posix.read(stdout.handle, &buf) catch {
+            _ = proc.wait(io) catch {};
             return;
         };
-        _ = proc.wait() catch {};
+        _ = proc.wait(io) catch {};
 
         if (bytes_read > 0) {
             // Parse PID and kill with signal 9
             const pid_str = std.mem.trim(u8, buf[0..bytes_read], " \n\r");
             if (pid_str.len > 0) {
-                var kill_proc = std.process.Child.init(&[_][]const u8{ "kill", "-9", pid_str }, allocator);
-                kill_proc.stdout_behavior = .Ignore;
-                kill_proc.stderr_behavior = .Ignore;
-                _ = kill_proc.spawnAndWait() catch {};
+                _ = std.process.run(allocator, io, .{ .argv = &[_][]const u8{ "kill", "-9", pid_str } }) catch {};
             }
         }
     }

--- a/src/resources/mount.zig
+++ b/src/resources/mount.zig
@@ -3,6 +3,7 @@ const mruby = @import("../mruby.zig");
 const base = @import("../base_resource.zig");
 const builtin = @import("builtin");
 const logger = @import("../logger.zig");
+const global_io = @import("../global_io.zig");
 
 pub const Resource = struct {
     mount_point: []const u8,
@@ -193,7 +194,7 @@ pub const Resource = struct {
         }
 
         // Read fstab, replace or append
-        const fstab_content = std.fs.cwd().readFileAlloc(allocator, "/etc/fstab", 1024 * 1024) catch |err| switch (err) {
+        const fstab_content = std.Io.Dir.cwd().readFileAlloc(global_io.io(), "/etc/fstab", allocator, .limited(1024 * 1024)) catch |err| switch (err) {
             error.FileNotFound => "",
             else => return err,
         };
@@ -257,7 +258,7 @@ pub const Resource = struct {
             return false;
         }
 
-        const fstab_content = std.fs.cwd().readFileAlloc(allocator, "/etc/fstab", 1024 * 1024) catch |err| switch (err) {
+        const fstab_content = std.Io.Dir.cwd().readFileAlloc(global_io.io(), "/etc/fstab", allocator, .limited(1024 * 1024)) catch |err| switch (err) {
             error.FileNotFound => return false,
             else => return err,
         };
@@ -312,12 +313,15 @@ pub const Resource = struct {
     }
 
     fn atomicWriteFstab(content: []const u8) !void {
+        const io = global_io.io();
         const tmp_path = "/etc/fstab.hola.tmp";
-        const file = try std.fs.createFileAbsolute(tmp_path, .{ .truncate = true });
-        defer file.close();
-        try file.writeAll(content);
+        const file = try std.Io.Dir.createFileAbsolute(io, tmp_path, .{ .truncate = true });
+        defer file.close(io);
+        var file_writer = file.writer(io, &.{});
+        try file_writer.interface.writeAll(content);
+        try file_writer.interface.flush();
 
-        try std.fs.renameAbsolute(tmp_path, "/etc/fstab");
+        try std.Io.Dir.renameAbsolute(tmp_path, "/etc/fstab", io);
     }
 
     pub fn actionFromString(action_str: []const u8) Action {
@@ -372,7 +376,7 @@ pub fn parseFstabFields(line: []const u8) ?FstabFields {
 }
 
 fn parseFstab(allocator: std.mem.Allocator, mount_point: []const u8) !?FstabFields {
-    const content = try std.fs.cwd().readFileAlloc(allocator, "/etc/fstab", 1024 * 1024);
+    const content = try std.Io.Dir.cwd().readFileAlloc(global_io.io(), "/etc/fstab", allocator, .limited(1024 * 1024));
 
     var result: ?FstabFields = null;
     var lines_iter = std.mem.splitScalar(u8, content, '\n');
@@ -407,20 +411,13 @@ pub fn parseMountOutputLine(line: []const u8, mount_point: []const u8) bool {
 }
 
 fn runCommand(allocator: std.mem.Allocator, argv: []const []const u8) ![]const u8 {
-    var child = std.process.Child.init(argv, allocator);
-    child.stdout_behavior = .Pipe;
-    child.stderr_behavior = .Pipe;
+    const result = try std.process.run(allocator, global_io.io(), .{ .argv = argv });
+    defer allocator.free(result.stderr);
+    const stdout = result.stdout;
+    const stderr = result.stderr;
 
-    try child.spawn();
-
-    const stdout = try child.stdout.?.readToEndAlloc(allocator, std.math.maxInt(usize));
-    const stderr = try child.stderr.?.readToEndAlloc(allocator, std.math.maxInt(usize));
-    defer allocator.free(stderr);
-
-    const term = try child.wait();
-
-    switch (term) {
-        .Exited => |code| {
+    switch (result.term) {
+        .exited => |code| {
             if (code != 0) {
                 logger.debug("[mount] command failed with code {d}\n", .{code});
                 if (stderr.len > 0) {

--- a/src/resources/remote_file.zig
+++ b/src/resources/remote_file.zig
@@ -6,6 +6,7 @@ const logger = @import("../logger.zig");
 const json_helpers = @import("../json.zig");
 const xdg_mod = @import("../xdg.zig");
 const AsyncExecutor = @import("../async_executor.zig").AsyncExecutor;
+const global_io = @import("../global_io.zig");
 
 /// Download outcome for downloadDirect
 const DownloadOutcome = struct {
@@ -164,16 +165,17 @@ pub const Resource = struct {
     }
 
     fn applyCreate(self: Resource) !bool {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        const io = global_io.io();
+        var gpa: std.heap.DebugAllocator(.{}) = .{};
         defer _ = gpa.deinit();
         const allocator = gpa.allocator();
 
         if (std.fs.path.dirname(self.path)) |dir| {
-            try std.fs.cwd().makePath(dir);
+            try std.Io.Dir.cwd().createDirPath(io, dir);
         }
 
         const local_exists = blk: {
-            std.fs.cwd().access(self.path, .{}) catch |err| switch (err) {
+            std.Io.Dir.cwd().access(io, self.path, .{}) catch |err| switch (err) {
                 error.FileNotFound => break :blk false,
                 else => return err,
             };
@@ -220,7 +222,7 @@ pub const Resource = struct {
             }
 
             // Move from temp to final location
-            try std.fs.cwd().rename(temp_path, self.path);
+            try std.Io.Dir.cwd().rename(temp_path, std.Io.Dir.cwd(), self.path, io);
 
             // Apply file attributes (mode, owner, group)
             base.applyFileAttributes(self.path, self.attrs) catch |err| {
@@ -326,6 +328,7 @@ pub const Resource = struct {
 
     /// Find a pre-downloaded file by matching the slugified final path
     fn findPreDownloadedFile(final_path: []const u8, allocator: std.mem.Allocator) !?[]const u8 {
+        const io = global_io.io();
         // Get the download temp directory
         const xdg_instance = xdg_mod.XDG.init(allocator);
         const temp_dir = try xdg_instance.getDownloadsDir();
@@ -339,7 +342,7 @@ pub const Resource = struct {
         const file_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ temp_dir, path_slug });
 
         // Check if file exists
-        std.fs.cwd().access(file_path, .{}) catch |err| switch (err) {
+        std.Io.Dir.cwd().access(io, file_path, .{}) catch |err| switch (err) {
             error.FileNotFound => {
                 allocator.free(file_path);
                 return error.FileNotFound;
@@ -354,28 +357,30 @@ pub const Resource = struct {
     }
 
     fn applyCreateIfMissing(self: Resource) !bool {
+        const io = global_io.io();
         // Check if file exists
-        const file = std.fs.cwd().openFile(self.path, .{}) catch |err| switch (err) {
+        const file = std.Io.Dir.cwd().openFile(io, self.path, .{}) catch |err| switch (err) {
             error.FileNotFound => {
                 const was_updated = try applyCreate(self);
                 return was_updated;
             },
             else => return err,
         };
-        defer file.close();
+        defer file.close(io);
         // File exists, do nothing
         return false; // File was up to date
     }
 
     fn applyDelete(self: Resource) !void {
+        const io = global_io.io();
         const is_abs = std.fs.path.isAbsolute(self.path);
         if (is_abs) {
-            std.fs.deleteFileAbsolute(self.path) catch |err| switch (err) {
+            std.Io.Dir.deleteFileAbsolute(io, self.path) catch |err| switch (err) {
                 error.FileNotFound => return, // Already deleted, that's fine
                 else => return err,
             };
         } else {
-            std.fs.cwd().deleteFile(self.path) catch |err| switch (err) {
+            std.Io.Dir.cwd().deleteFile(io, self.path) catch |err| switch (err) {
                 error.FileNotFound => return, // Already deleted, that's fine
                 else => return err,
             };
@@ -383,29 +388,30 @@ pub const Resource = struct {
     }
 
     fn applyTouch(self: Resource) !void {
+        const io = global_io.io();
         if (std.fs.path.dirname(self.path)) |dir| {
-            try std.fs.cwd().makePath(dir);
+            try std.Io.Dir.cwd().createDirPath(io, dir);
         }
 
         const is_abs = std.fs.path.isAbsolute(self.path);
         const file = if (is_abs)
-            try std.fs.createFileAbsolute(self.path, .{ .truncate = false })
+            try std.Io.Dir.createFileAbsolute(io, self.path, .{ .truncate = false })
         else
-            try std.fs.cwd().createFile(self.path, .{ .truncate = false });
-        defer file.close();
+            try std.Io.Dir.cwd().createFile(io, self.path, .{ .truncate = false });
+        defer file.close(io);
 
         // Update modification time to current time
-        const current_time = std.time.timestamp();
-        try file.updateTimes(current_time, current_time);
+        try file.setTimestampsNow(io);
     }
 
     fn needsDownload(self: Resource) !bool {
+        const io = global_io.io();
         // Check if local file exists
-        const local_file = std.fs.cwd().openFile(self.path, .{}) catch |err| switch (err) {
+        const local_file = std.Io.Dir.cwd().openFile(io, self.path, .{}) catch |err| switch (err) {
             error.FileNotFound => return true, // File doesn't exist, need to download
             else => return err,
         };
-        defer local_file.close();
+        defer local_file.close(io);
 
         // TODO: Add more sophisticated comparison (size, modification time, etag)
         // For now, always download if file exists
@@ -413,6 +419,7 @@ pub const Resource = struct {
     }
 
     fn downloadDirect(self: Resource, allocator: std.mem.Allocator, previous_etag: ?[]const u8, previous_last_modified: ?[]const u8) !DownloadOutcome {
+        const io = global_io.io();
         const temp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{self.path});
         defer allocator.free(temp_path);
 
@@ -459,7 +466,7 @@ pub const Resource = struct {
 
         if (download_result.status == .not_modified) {
             // Cleanup temp path if created (ignore missing)
-            std.fs.cwd().deleteFile(temp_path) catch {};
+            std.Io.Dir.cwd().deleteFile(io, temp_path) catch {};
             return DownloadOutcome{ .downloaded = false, .etag = null };
         }
 
@@ -468,7 +475,7 @@ pub const Resource = struct {
             const actual_checksum = try http.calculateSha256(allocator, temp_path);
             defer allocator.free(actual_checksum);
             if (!std.mem.eql(u8, actual_checksum, expected_checksum)) {
-                std.fs.cwd().deleteFile(temp_path) catch {};
+                std.Io.Dir.cwd().deleteFile(io, temp_path) catch {};
                 self.recordChecksumMismatch(expected_checksum, actual_checksum);
                 return error.ChecksumMismatch;
             }
@@ -483,7 +490,7 @@ pub const Resource = struct {
         if (self.force_unlink) {
             self.deleteTargetIfExists() catch {};
         }
-        try std.fs.cwd().rename(temp_path, self.path);
+        try std.Io.Dir.cwd().rename(temp_path, std.Io.Dir.cwd(), self.path, io);
 
         const etag_copy: ?[]const u8 = if (download_result.etag) |etag| try allocator.dupe(u8, etag) else null;
         const lm_copy: ?[]const u8 = if (download_result.last_modified) |lm| try allocator.dupe(u8, lm) else null;
@@ -502,34 +509,28 @@ pub const Resource = struct {
     }
 
     fn loadSavedEtag(self: Resource, allocator: std.mem.Allocator) !?[]const u8 {
+        const io = global_io.io();
         const etag_path = try self.getEtagPath(allocator);
         defer allocator.free(etag_path);
 
-        const file = std.fs.cwd().openFile(etag_path, .{}) catch |err| switch (err) {
+        return std.Io.Dir.cwd().readFileAlloc(io, etag_path, allocator, .unlimited) catch |err| switch (err) {
             error.FileNotFound => return null,
             else => return err,
         };
-        defer file.close();
-
-        const stat = try file.stat();
-        const buf = try allocator.alloc(u8, stat.size);
-        const read_len = try file.readAll(buf);
-        return buf[0..read_len];
     }
 
     fn saveEtag(self: Resource, allocator: std.mem.Allocator, etag: []const u8) !void {
         if (etag.len == 0) return;
 
+        const io = global_io.io();
         const etag_path = try self.getEtagPath(allocator);
         defer allocator.free(etag_path);
 
         if (std.fs.path.dirname(etag_path)) |dir| {
-            try std.fs.cwd().makePath(dir);
+            try std.Io.Dir.cwd().createDirPath(io, dir);
         }
 
-        const file = try std.fs.cwd().createFile(etag_path, .{ .truncate = true });
-        defer file.close();
-        try file.writeAll(etag);
+        try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = etag_path, .data = etag });
     }
 
     fn getLastModifiedPath(self: Resource, allocator: std.mem.Allocator) ![]const u8 {
@@ -544,42 +545,37 @@ pub const Resource = struct {
     }
 
     fn loadSavedLastModified(self: Resource, allocator: std.mem.Allocator) !?[]const u8 {
+        const io = global_io.io();
         const lm_path = try self.getLastModifiedPath(allocator);
         defer allocator.free(lm_path);
 
-        const file = std.fs.cwd().openFile(lm_path, .{}) catch |err| switch (err) {
+        return std.Io.Dir.cwd().readFileAlloc(io, lm_path, allocator, .unlimited) catch |err| switch (err) {
             error.FileNotFound => return null,
             else => return err,
         };
-        defer file.close();
-
-        const stat = try file.stat();
-        const buf = try allocator.alloc(u8, stat.size);
-        const read_len = try file.readAll(buf);
-        return buf[0..read_len];
     }
 
     fn saveLastModified(self: Resource, allocator: std.mem.Allocator, last_modified: []const u8) !void {
         if (last_modified.len == 0) return;
 
+        const io = global_io.io();
         const lm_path = try self.getLastModifiedPath(allocator);
         defer allocator.free(lm_path);
 
         if (std.fs.path.dirname(lm_path)) |dir| {
-            try std.fs.cwd().makePath(dir);
+            try std.Io.Dir.cwd().createDirPath(io, dir);
         }
 
-        const file = try std.fs.cwd().createFile(lm_path, .{ .truncate = true });
-        defer file.close();
-        try file.writeAll(last_modified);
+        try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = lm_path, .data = last_modified });
     }
 
     fn deleteTargetIfExists(self: Resource) !void {
+        const io = global_io.io();
         const is_abs = std.fs.path.isAbsolute(self.path);
         const result = if (is_abs)
-            std.fs.deleteFileAbsolute(self.path)
+            std.Io.Dir.deleteFileAbsolute(io, self.path)
         else
-            std.fs.cwd().deleteFile(self.path);
+            std.Io.Dir.cwd().deleteFile(io, self.path);
 
         result catch |err| switch (err) {
             error.FileNotFound => {},

--- a/src/resources/route.zig
+++ b/src/resources/route.zig
@@ -55,8 +55,8 @@ pub const Resource = struct {
 // Automatically strips CIDR suffix if present
 fn parseIp(ip: []const u8) !u32 {
     const clean_ip = if (std.mem.indexOf(u8, ip, "/")) |idx| ip[0..idx] else ip;
-    const parsed = try std.net.Address.parseIp4(clean_ip, 0);
-    return parsed.in.sa.addr; // This is network byte order
+    const parsed = try std.Io.net.IpAddress.parseIp4(clean_ip, 0);
+    return @bitCast(parsed.ip4.bytes); // This is network byte order
 }
 
 // Helper to parse CIDR or Netmask

--- a/src/resources/systemd_unit.zig
+++ b/src/resources/systemd_unit.zig
@@ -3,6 +3,7 @@ const mruby = @import("../mruby.zig");
 const base = @import("../base_resource.zig");
 const builtin = @import("builtin");
 const logger = @import("../logger.zig");
+const global_io = @import("../global_io.zig");
 
 /// Systemd unit resource data structure
 pub const Resource = struct {
@@ -88,18 +89,21 @@ pub const Resource = struct {
         defer arena.deinit();
         const allocator = arena.allocator();
 
+        const io = global_io.io();
+
         // Determine unit file path
         const unit_path = try getUnitPath(allocator, self.name);
 
         // Check if file exists and has same content
         const file_exists = blk: {
-            const file = std.fs.openFileAbsolute(unit_path, .{}) catch |err| switch (err) {
+            const file = std.Io.Dir.openFileAbsolute(io, unit_path, .{}) catch |err| switch (err) {
                 error.FileNotFound => break :blk false,
                 else => return err,
             };
-            defer file.close();
+            defer file.close(io);
 
-            const existing_content = try file.readToEndAlloc(allocator, 1024 * 1024); // 1MB max
+            var file_reader = file.reader(io, &.{});
+            const existing_content = try file_reader.interface.allocRemaining(allocator, .limited(1024 * 1024)); // 1MB max
             break :blk std.mem.eql(u8, existing_content, self.content.?);
         };
 
@@ -108,10 +112,12 @@ pub const Resource = struct {
         }
 
         // Write unit file
-        const file = try std.fs.createFileAbsolute(unit_path, .{ .truncate = true });
-        defer file.close();
+        const file = try std.Io.Dir.createFileAbsolute(io, unit_path, .{ .truncate = true });
+        defer file.close(io);
 
-        try file.writeAll(self.content.?);
+        var file_writer = file.writer(io, &.{});
+        try file_writer.interface.writeAll(self.content.?);
+        try file_writer.interface.flush();
 
         // Reload systemd daemon
         _ = try runSystemctl(allocator, &[_][]const u8{"daemon-reload"});
@@ -214,20 +220,13 @@ pub const Resource = struct {
             try argv.append(allocator, arg);
         }
 
-        var child = std.process.Child.init(argv.items, allocator);
-        child.stdout_behavior = .Pipe;
-        child.stderr_behavior = .Pipe;
+        const result = try std.process.run(allocator, global_io.io(), .{ .argv = argv.items });
+        defer allocator.free(result.stderr);
+        const stdout = result.stdout;
+        const stderr = result.stderr;
 
-        try child.spawn();
-
-        const stdout = try child.stdout.?.readToEndAlloc(allocator, std.math.maxInt(usize));
-        const stderr = try child.stderr.?.readToEndAlloc(allocator, std.math.maxInt(usize));
-        defer allocator.free(stderr);
-
-        const term = try child.wait();
-
-        switch (term) {
-            .Exited => |code| {
+        switch (result.term) {
+            .exited => |code| {
                 if (code != 0) {
                     logger.debug("[systemd_unit] systemctl {s} failed with code {d}\n", .{ args[0], code });
                     if (stderr.len > 0) {

--- a/src/resources/template.zig
+++ b/src/resources/template.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const mruby = @import("../mruby.zig");
 const base = @import("../base_resource.zig");
 const logger = @import("../logger.zig");
+const global_io = @import("../global_io.zig");
 
 /// Template resource data structure
 pub const Resource = struct {
@@ -96,15 +97,16 @@ pub const Resource = struct {
         defer std.heap.c_allocator.free(rendered_content);
 
         // Check if file exists and content matches
+        const io = global_io.io();
         const is_abs = std.fs.path.isAbsolute(self.path);
         const file_exists = blk: {
             if (is_abs) {
-                std.fs.accessAbsolute(self.path, .{}) catch |err| switch (err) {
+                std.Io.Dir.accessAbsolute(io, self.path, .{}) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
             } else {
-                std.fs.cwd().access(self.path, .{}) catch |err| switch (err) {
+                std.Io.Dir.cwd().access(io, self.path, .{}) catch |err| switch (err) {
                     error.FileNotFound => break :blk false,
                     else => return err,
                 };
@@ -115,19 +117,20 @@ pub const Resource = struct {
         if (file_exists) {
             // Read existing file and compare content
             const existing_file = if (is_abs)
-                try std.fs.openFileAbsolute(self.path, .{})
+                try std.Io.Dir.openFileAbsolute(io, self.path, .{})
             else
-                try std.fs.cwd().openFile(self.path, .{});
-            defer existing_file.close();
+                try std.Io.Dir.cwd().openFile(io, self.path, .{});
+            defer existing_file.close(io);
 
-            const existing_content = try existing_file.readToEndAlloc(std.heap.c_allocator, std.math.maxInt(usize));
+            var existing_reader = existing_file.reader(io, &.{});
+            const existing_content = try existing_reader.interface.allocRemaining(std.heap.c_allocator, .unlimited);
             defer std.heap.c_allocator.free(existing_content);
 
             if (std.mem.eql(u8, existing_content, rendered_content)) {
                 // Content matches, check attributes if specified
                 if (self.attrs.mode) |m| {
-                    const stat = try existing_file.stat();
-                    const current_mode = stat.mode & 0o777;
+                    const stat = try existing_file.stat(io);
+                    const current_mode = stat.permissions.toMode() & 0o777;
                     if (current_mode == m) {
                         return false; // File exists with same content and mode
                     }
@@ -140,19 +143,21 @@ pub const Resource = struct {
         // Write rendered content to target file
         try base.ensureParentDir(self.path);
         var file = if (is_abs)
-            try std.fs.createFileAbsolute(self.path, .{ .truncate = true })
+            try std.Io.Dir.createFileAbsolute(io, self.path, .{ .truncate = true })
         else
-            try std.fs.cwd().createFile(self.path, .{ .truncate = true });
+            try std.Io.Dir.cwd().createFile(io, self.path, .{ .truncate = true });
 
-        try file.writeAll(rendered_content);
+        var file_writer = file.writer(io, &.{});
+        try file_writer.interface.writeAll(rendered_content);
+        try file_writer.interface.flush();
 
         // Apply file mode if specified
         if (self.attrs.mode) |m| {
-            std.posix.fchmod(file.handle, @as(std.posix.mode_t, @intCast(m))) catch {};
+            file.setPermissions(io, .fromMode(@as(std.posix.mode_t, @intCast(m)))) catch {};
         }
 
         // Close file before changing ownership
-        file.close();
+        file.close(io);
 
         // Apply owner/group after file is closed
         if (self.attrs.owner != null or self.attrs.group != null) {
@@ -165,14 +170,15 @@ pub const Resource = struct {
     }
 
     fn applyDelete(self: Resource) !void {
+        const io = global_io.io();
         const is_abs = std.fs.path.isAbsolute(self.path);
         if (is_abs) {
-            std.fs.deleteFileAbsolute(self.path) catch |err| switch (err) {
+            std.Io.Dir.deleteFileAbsolute(io, self.path) catch |err| switch (err) {
                 error.FileNotFound => return,
                 else => return err,
             };
         } else {
-            std.fs.cwd().deleteFile(self.path) catch |err| switch (err) {
+            std.Io.Dir.cwd().deleteFile(io, self.path) catch |err| switch (err) {
                 error.FileNotFound => return,
                 else => return err,
             };
@@ -180,20 +186,22 @@ pub const Resource = struct {
     }
 
     fn readTemplateFile(source: []const u8) ![]u8 {
+        const io = global_io.io();
         // Try to find template file in templates/ directory
         const templates_dir = "templates";
         const template_path = try std.fmt.allocPrint(std.heap.c_allocator, "{s}/{s}", .{ templates_dir, source });
         defer std.heap.c_allocator.free(template_path);
 
         // Try to read from templates directory first
-        const content = std.fs.cwd().readFileAlloc(std.heap.c_allocator, template_path, std.math.maxInt(usize)) catch {
+        const content = std.Io.Dir.cwd().readFileAlloc(io, template_path, std.heap.c_allocator, .unlimited) catch {
             // If not found, try absolute path or current directory
             if (std.fs.path.isAbsolute(source)) {
-                var file = try std.fs.openFileAbsolute(source, .{});
-                defer file.close();
-                return try file.readToEndAlloc(std.heap.c_allocator, std.math.maxInt(usize));
+                var file = try std.Io.Dir.openFileAbsolute(io, source, .{});
+                defer file.close(io);
+                var file_reader = file.reader(io, &.{});
+                return try file_reader.interface.allocRemaining(std.heap.c_allocator, .unlimited);
             } else {
-                return try std.fs.cwd().readFileAlloc(std.heap.c_allocator, source, std.math.maxInt(usize));
+                return try std.Io.Dir.cwd().readFileAlloc(io, source, std.heap.c_allocator, .unlimited);
             }
         };
 
@@ -214,7 +222,7 @@ pub const Resource = struct {
         defer ruby_code.deinit(std.heap.c_allocator);
 
         // Set up variables in Ruby as local variables
-        try ruby_code.writer(std.heap.c_allocator).writeAll("_erb_result = ''\n");
+        try ruby_code.appendSlice(std.heap.c_allocator, "_erb_result = ''\n");
         for (variables) |var_| {
             // Convert variable name to valid Ruby identifier
             const safe_name = try sanitizeRubyIdentifier(var_.name);
@@ -223,28 +231,28 @@ pub const Resource = struct {
             // Generate Ruby code based on type
             if (std.mem.eql(u8, var_.var_type, "integer")) {
                 // Integer: convert string to integer
-                try ruby_code.writer(std.heap.c_allocator).print("{s} = {s}.to_i\n", .{ safe_name, var_.value });
+                try ruby_code.print(std.heap.c_allocator, "{s} = {s}.to_i\n", .{ safe_name, var_.value });
             } else if (std.mem.eql(u8, var_.var_type, "float")) {
                 // Float: convert string to float
-                try ruby_code.writer(std.heap.c_allocator).print("{s} = {s}.to_f\n", .{ safe_name, var_.value });
+                try ruby_code.print(std.heap.c_allocator, "{s} = {s}.to_f\n", .{ safe_name, var_.value });
             } else if (std.mem.eql(u8, var_.var_type, "boolean")) {
                 // Boolean: convert string to boolean
                 if (std.mem.eql(u8, var_.value, "true")) {
-                    try ruby_code.writer(std.heap.c_allocator).print("{s} = true\n", .{safe_name});
+                    try ruby_code.print(std.heap.c_allocator, "{s} = true\n", .{safe_name});
                 } else {
-                    try ruby_code.writer(std.heap.c_allocator).print("{s} = false\n", .{safe_name});
+                    try ruby_code.print(std.heap.c_allocator, "{s} = false\n", .{safe_name});
                 }
             } else if (std.mem.eql(u8, var_.var_type, "nil")) {
                 // Nil
-                try ruby_code.writer(std.heap.c_allocator).print("{s} = nil\n", .{safe_name});
+                try ruby_code.print(std.heap.c_allocator, "{s} = nil\n", .{safe_name});
             } else if (std.mem.eql(u8, var_.var_type, "array")) {
                 // Array: value is already a Ruby array literal string, just assign it
-                try ruby_code.writer(std.heap.c_allocator).print("{s} = {s}\n", .{ safe_name, var_.value });
+                try ruby_code.print(std.heap.c_allocator, "{s} = {s}\n", .{ safe_name, var_.value });
             } else {
                 // String: escape properly
                 const escaped_value = try escapeRubyString(var_.value);
                 defer std.heap.c_allocator.free(escaped_value);
-                try ruby_code.writer(std.heap.c_allocator).print("{s} = {s}\n", .{ safe_name, escaped_value });
+                try ruby_code.print(std.heap.c_allocator, "{s} = {s}\n", .{ safe_name, escaped_value });
             }
         }
 
@@ -272,7 +280,7 @@ pub const Resource = struct {
                     // Extract expression
                     const expr = std.mem.trim(u8, template_content[i + 3 .. j], " \t\n\r");
                     // Convert to Ruby: _erb_result << (expression).to_s
-                    try ruby_code.writer(std.heap.c_allocator).print("_erb_result << ({s}).to_s\n", .{expr});
+                    try ruby_code.print(std.heap.c_allocator, "_erb_result << ({s}).to_s\n", .{expr});
                     i = j + 2;
                     continue;
                 }
@@ -298,7 +306,7 @@ pub const Resource = struct {
                     // Extract code
                     const code = std.mem.trim(u8, template_content[i + 2 .. j], " \t\n\r");
                     // Execute code directly
-                    try ruby_code.writer(std.heap.c_allocator).print("{s}\n", .{code});
+                    try ruby_code.print(std.heap.c_allocator, "{s}\n", .{code});
                     i = j + 2;
                     continue;
                 }
@@ -323,7 +331,7 @@ pub const Resource = struct {
                 const text_block = template_content[text_start..text_end];
                 const escaped_text = try escapeRubyString(text_block);
                 defer std.heap.c_allocator.free(escaped_text);
-                try ruby_code.writer(std.heap.c_allocator).print("_erb_result << {s}\n", .{escaped_text});
+                try ruby_code.print(std.heap.c_allocator, "_erb_result << {s}\n", .{escaped_text});
                 i = text_end;
             } else {
                 i += 1;
@@ -331,7 +339,7 @@ pub const Resource = struct {
         }
 
         // Get result: _erb_result
-        try ruby_code.writer(std.heap.c_allocator).writeAll("_erb_result");
+        try ruby_code.appendSlice(std.heap.c_allocator, "_erb_result");
 
         // Execute Ruby code
         const code_str = try ruby_code.toOwnedSlice(std.heap.c_allocator);
@@ -391,13 +399,13 @@ pub const Resource = struct {
                     var var_found = false;
                     for (variables) |var_| {
                         if (std.mem.eql(u8, var_.name, var_name)) {
-                            try result.writer(std.heap.c_allocator).writeAll(var_.value);
+                            try result.appendSlice(std.heap.c_allocator, var_.value);
                             var_found = true;
                             break;
                         }
                     }
                     if (!var_found) {
-                        try result.writer(std.heap.c_allocator).writeAll(template_content[i .. j + 2]);
+                        try result.appendSlice(std.heap.c_allocator, template_content[i .. j + 2]);
                     }
                     i = j + 2;
                     continue;
@@ -423,7 +431,7 @@ pub const Resource = struct {
                 }
             }
 
-            try result.writer(std.heap.c_allocator).writeByte(template_content[i]);
+            try result.append(std.heap.c_allocator, template_content[i]);
             i += 1;
         }
 
@@ -434,25 +442,25 @@ pub const Resource = struct {
         var result = std.ArrayList(u8).initCapacity(std.heap.c_allocator, str.len * 2) catch std.ArrayList(u8).empty;
         defer result.deinit(std.heap.c_allocator);
 
-        try result.writer(std.heap.c_allocator).writeByte('"');
+        try result.append(std.heap.c_allocator, '"');
         for (str) |ch| {
             switch (ch) {
-                '\n' => try result.writer(std.heap.c_allocator).writeAll("\\n"),
-                '\r' => try result.writer(std.heap.c_allocator).writeAll("\\r"),
-                '\t' => try result.writer(std.heap.c_allocator).writeAll("\\t"),
-                '"' => try result.writer(std.heap.c_allocator).writeAll("\\\""),
-                '\\' => try result.writer(std.heap.c_allocator).writeAll("\\\\"),
-                '$' => try result.writer(std.heap.c_allocator).writeAll("\\$"),
+                '\n' => try result.appendSlice(std.heap.c_allocator, "\\n"),
+                '\r' => try result.appendSlice(std.heap.c_allocator, "\\r"),
+                '\t' => try result.appendSlice(std.heap.c_allocator, "\\t"),
+                '"' => try result.appendSlice(std.heap.c_allocator, "\\\""),
+                '\\' => try result.appendSlice(std.heap.c_allocator, "\\\\"),
+                '$' => try result.appendSlice(std.heap.c_allocator, "\\$"),
                 else => {
                     if (ch >= 32 and ch <= 126) {
-                        try result.writer(std.heap.c_allocator).writeByte(ch);
+                        try result.append(std.heap.c_allocator, ch);
                     } else {
-                        try result.writer(std.heap.c_allocator).print("\\x{x:0>2}", .{ch});
+                        try result.print(std.heap.c_allocator, "\\x{x:0>2}", .{ch});
                     }
                 },
             }
         }
-        try result.writer(std.heap.c_allocator).writeByte('"');
+        try result.append(std.heap.c_allocator, '"');
 
         return try result.toOwnedSlice(std.heap.c_allocator);
     }
@@ -468,25 +476,25 @@ pub const Resource = struct {
             if (first) {
                 // First char must be letter or underscore
                 if ((ch >= 'a' and ch <= 'z') or (ch >= 'A' and ch <= 'Z') or ch == '_') {
-                    try result.writer(std.heap.c_allocator).writeByte(ch);
+                    try result.append(std.heap.c_allocator, ch);
                     first = false;
                 } else {
-                    try result.writer(std.heap.c_allocator).writeByte('_');
+                    try result.append(std.heap.c_allocator, '_');
                     first = false;
                 }
             } else {
                 // Subsequent chars can be letter, digit, or underscore
                 if ((ch >= 'a' and ch <= 'z') or (ch >= 'A' and ch <= 'Z') or (ch >= '0' and ch <= '9') or ch == '_') {
-                    try result.writer(std.heap.c_allocator).writeByte(ch);
+                    try result.append(std.heap.c_allocator, ch);
                 } else {
-                    try result.writer(std.heap.c_allocator).writeByte('_');
+                    try result.append(std.heap.c_allocator, '_');
                 }
             }
         }
 
         // Ensure non-empty
         if (result.items.len == 0) {
-            try result.writer(std.heap.c_allocator).writeAll("var");
+            try result.appendSlice(std.heap.c_allocator, "var");
         }
 
         return try result.toOwnedSlice(std.heap.c_allocator);

--- a/src/resources/user.zig
+++ b/src/resources/user.zig
@@ -3,6 +3,7 @@ const mruby = @import("../mruby.zig");
 const base = @import("../base_resource.zig");
 const logger = @import("../logger.zig");
 const builtin = @import("builtin");
+const global_io = @import("../global_io.zig");
 
 /// User resource data structure
 pub const Resource = struct {
@@ -88,8 +89,7 @@ pub const Resource = struct {
         const allocator = arena.allocator();
 
         const args = [_][]const u8{ "id", "-u", username };
-        const result = std.process.Child.run(.{
-            .allocator = allocator,
+        const result = std.process.run(allocator, global_io.io(), .{
             .argv = &args,
         }) catch |err| {
             logger.debug("id command failed for user '{s}': {}", .{ username, err });
@@ -99,7 +99,7 @@ pub const Resource = struct {
         defer allocator.free(result.stderr);
 
         switch (result.term) {
-            .Exited => |code| return code == 0,
+            .exited => |code| return code == 0,
             else => return false,
         }
     }
@@ -114,69 +114,68 @@ pub const Resource = struct {
         // Simpler approach: build command string directly
         var buf = try std.ArrayList(u8).initCapacity(allocator, 256);
         errdefer buf.deinit(allocator);
-        const writer = buf.writer(allocator);
 
-        try writer.writeAll(cmd);
+        try buf.appendSlice(allocator, cmd);
 
         if (std.mem.eql(u8, cmd, "useradd")) {
             if (self.uid) |uid| {
-                try writer.print(" -u {d}", .{uid});
+                try buf.print(allocator, " -u {d}", .{uid});
             }
             if (self.gid) |gid| {
-                try writer.print(" -g {d}", .{gid});
+                try buf.print(allocator, " -g {d}", .{gid});
             }
             if (self.comment) |comment| {
-                try writer.print(" -c '{s}'", .{comment});
+                try buf.print(allocator, " -c '{s}'", .{comment});
             }
             if (self.home) |home| {
-                try writer.print(" -d '{s}'", .{home});
+                try buf.print(allocator, " -d '{s}'", .{home});
             }
             if (self.shell) |shell| {
-                try writer.print(" -s '{s}'", .{shell});
+                try buf.print(allocator, " -s '{s}'", .{shell});
             }
             if (self.password) |password| {
-                try writer.print(" -p '{s}'", .{password});
+                try buf.print(allocator, " -p '{s}'", .{password});
             }
             if (self.system) {
-                try writer.writeAll(" -r");
+                try buf.appendSlice(allocator, " -r");
             }
             if (self.manage_home) {
-                try writer.writeAll(" -m");
+                try buf.appendSlice(allocator, " -m");
             } else {
-                try writer.writeAll(" -M");
+                try buf.appendSlice(allocator, " -M");
             }
             if (self.non_unique) {
-                try writer.writeAll(" -o");
+                try buf.appendSlice(allocator, " -o");
             }
         } else if (std.mem.eql(u8, cmd, "usermod")) {
             if (self.uid) |uid| {
-                try writer.print(" -u {d}", .{uid});
+                try buf.print(allocator, " -u {d}", .{uid});
             }
             if (self.gid) |gid| {
-                try writer.print(" -g {d}", .{gid});
+                try buf.print(allocator, " -g {d}", .{gid});
             }
             if (self.comment) |comment| {
-                try writer.print(" -c '{s}'", .{comment});
+                try buf.print(allocator, " -c '{s}'", .{comment});
             }
             if (self.home) |home| {
-                try writer.print(" -d '{s}'", .{home});
+                try buf.print(allocator, " -d '{s}'", .{home});
             }
             if (self.shell) |shell| {
-                try writer.print(" -s '{s}'", .{shell});
+                try buf.print(allocator, " -s '{s}'", .{shell});
             }
             if (self.password) |password| {
-                try writer.print(" -p '{s}'", .{password});
+                try buf.print(allocator, " -p '{s}'", .{password});
             }
             if (self.non_unique) {
-                try writer.writeAll(" -o");
+                try buf.appendSlice(allocator, " -o");
             }
         } else if (std.mem.eql(u8, cmd, "userdel")) {
             if (self.manage_home) {
-                try writer.writeAll(" -r");
+                try buf.appendSlice(allocator, " -r");
             }
         }
 
-        try writer.print(" {s}", .{self.username});
+        try buf.print(allocator, " {s}", .{self.username});
         return try buf.toOwnedSlice(allocator);
     }
 
@@ -184,8 +183,7 @@ pub const Resource = struct {
         logger.debug("Executing: {s}", .{cmd});
 
         const args = [_][]const u8{ "/bin/sh", "-c", cmd };
-        const result = try std.process.Child.run(.{
-            .allocator = allocator,
+        const result = try std.process.run(allocator, global_io.io(), .{
             .argv = &args,
         });
         defer allocator.free(result.stdout);
@@ -199,7 +197,7 @@ pub const Resource = struct {
         }
 
         switch (result.term) {
-            .Exited => |code| {
+            .exited => |code| {
                 if (code != 0) {
                     logger.err("Command exited with code {d}: {s}", .{ code, cmd });
                     // Print error details

--- a/src/simple_dns.zig
+++ b/src/simple_dns.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const logger = @import("logger.zig");
+const global_io = @import("global_io.zig");
 
 /// Simple DNS query implementation for A and AAAA records
 /// This is a minimal implementation to support custom DNS servers
@@ -35,12 +36,13 @@ pub fn query(
     };
     defer allocator.free(ns_addr);
 
-    // Create UDP socket
-    const sock = try std.posix.socket(std.posix.AF.INET, std.posix.SOCK.DGRAM, std.posix.IPPROTO.UDP);
-    defer std.posix.close(sock);
+    // Create UDP socket (raw libc; zig 0.16 removed std.posix socket wrappers)
+    const sock = std.c.socket(std.posix.AF.INET, std.posix.SOCK.DGRAM, std.posix.IPPROTO.UDP);
+    if (sock < 0) return error.SocketFailed;
+    defer _ = std.c.close(sock);
 
     // Parse nameserver address
-    const ns_ip = std.net.Address.parseIp4(ns_addr, 53) catch {
+    const ns_ip = std.Io.net.IpAddress.parseIp4(ns_addr, 53) catch {
         return error.InvalidNameserver;
     };
 
@@ -49,8 +51,10 @@ pub fn query(
     const query_len = try buildDNSQuery(&query_buf, hostname, qtype);
 
     // Send query
-    const sent = try std.posix.sendto(sock, query_buf[0..query_len], 0, &ns_ip.any, ns_ip.getOsSockLen());
-    if (sent != query_len) {
+    var sa_storage: std.Io.Threaded.PosixAddress = undefined;
+    const sa_len = std.Io.Threaded.addressToPosix(&ns_ip, &sa_storage);
+    const sent = std.c.sendto(sock, &query_buf, query_len, 0, &sa_storage.any, sa_len);
+    if (sent < 0 or @as(usize, @intCast(sent)) != query_len) {
         return error.SendFailed;
     }
 
@@ -69,7 +73,9 @@ pub fn query(
         &std.mem.toBytes(timeout),
     );
 
-    const recv_len = try std.posix.recv(sock, &response_buf, 0);
+    const recv_result = std.c.recv(sock, &response_buf, response_buf.len, 0);
+    if (recv_result < 0) return error.RecvFailed;
+    const recv_len: usize = @intCast(recv_result);
 
     // Parse DNS response
     return try parseDNSResponse(allocator, response_buf[0..recv_len], qtype);
@@ -78,28 +84,47 @@ pub fn query(
 /// Resolve nameserver hostname to IP address
 fn resolveNameserver(allocator: std.mem.Allocator, nameserver: []const u8) ![]const u8 {
     // Check if it's already an IP address
-    if (std.net.Address.parseIp4(nameserver, 0)) |_| {
+    if (std.Io.net.IpAddress.parseIp4(nameserver, 0)) |_| {
         return try allocator.dupe(u8, nameserver);
     } else |_| {}
 
     // It's a hostname, resolve it using system resolver
-    const addr_list = try std.net.getAddressList(allocator, nameserver, 0);
-    defer addr_list.deinit();
+    var addrs: [max_lookup_results]std.Io.net.IpAddress = undefined;
+    const count = lookupHost(nameserver, &addrs) catch return error.NoIPv4Address;
 
-    for (addr_list.addrs) |addr| {
-        if (addr.any.family == std.posix.AF.INET) {
-            // Format IPv4 address
-            const addr_bytes = @as(*const [4]u8, @ptrCast(&addr.in.sa.addr));
-            return try std.fmt.allocPrint(allocator, "{d}.{d}.{d}.{d}", .{
-                addr_bytes[0],
-                addr_bytes[1],
-                addr_bytes[2],
-                addr_bytes[3],
-            });
+    for (addrs[0..count]) |addr| {
+        if (addr == .ip4) {
+            const b = addr.ip4.bytes;
+            return try std.fmt.allocPrint(allocator, "{d}.{d}.{d}.{d}", .{ b[0], b[1], b[2], b[3] });
         }
     }
 
     return error.NoIPv4Address;
+}
+
+pub const max_lookup_results = 16;
+
+/// Resolve a hostname with the system resolver, writing up to `out.len`
+/// addresses. Returns the number of addresses written. Replaces the removed
+/// `std.net.getAddressList`.
+pub fn lookupHost(hostname: []const u8, out: []std.Io.net.IpAddress) !usize {
+    const io = global_io.io();
+    const host = std.Io.net.HostName.init(hostname) catch return error.UnknownHostName;
+    var queue_buf: [16]std.Io.net.HostName.LookupResult = undefined;
+    var queue: std.Io.Queue(std.Io.net.HostName.LookupResult) = .init(&queue_buf);
+    try host.lookup(io, &queue, .{ .port = 0 });
+    var n: usize = 0;
+    while (n < out.len) {
+        const res = queue.getOne(io) catch break;
+        switch (res) {
+            .address => |a| {
+                out[n] = a;
+                n += 1;
+            },
+            .canonical_name => {},
+        }
+    }
+    return n;
 }
 
 /// Build DNS query packet

--- a/src/table.zig
+++ b/src/table.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const vaxis = @import("vaxis");
+const global_io = @import("global_io.zig");
 
 pub const Ansi = struct {
     pub const reset = vaxis.ctlseqs.sgr_reset;
@@ -46,22 +47,22 @@ pub const Column = struct {
 
 pub const Table = struct {
     allocator: std.mem.Allocator,
-    out: std.fs.File,
+    out: std.Io.File,
     colorize: bool,
     columns: []Column,
-    rows: std.ArrayListUnmanaged(Row) = .{},
-    buffer: std.ArrayListUnmanaged(u8) = .{},
+    rows: std.ArrayListUnmanaged(Row) = .empty,
+    buffer: std.ArrayListUnmanaged(u8) = .empty,
 
     const Row = struct {
         cells: []CellStyle,
     };
 
-    pub fn init(allocator: std.mem.Allocator, out: std.fs.File, columns: []const Column) !Table {
+    pub fn init(allocator: std.mem.Allocator, out: std.Io.File, columns: []const Column) !Table {
         const cols_copy = try allocator.dupe(Column, columns);
         return .{
             .allocator = allocator,
             .out = out,
-            .colorize = std.posix.isatty(out.handle),
+            .colorize = out.isTty(global_io.io()) catch false,
             .columns = cols_copy,
         };
     }
@@ -131,22 +132,22 @@ pub const Table = struct {
             const col = self.columns[i];
             try self.renderCell(cell, col);
         }
-        try self.out.writeAll("\n");
+        try self.out.writeStreamingAll(global_io.io(), "\n");
     }
 
     fn renderCell(self: *Table, cell: CellStyle, col: Column) !void {
         const width = col.width orelse 0;
 
         if (self.colorize) {
-            if (cell.bold) try self.out.writeAll(Ansi.bold);
-            if (cell.dim) try self.out.writeAll(Ansi.dim);
-            if (cell.color.len > 0) try self.out.writeAll(cell.color);
+            if (cell.bold) try self.out.writeStreamingAll(global_io.io(), Ansi.bold);
+            if (cell.dim) try self.out.writeStreamingAll(global_io.io(), Ansi.dim);
+            if (cell.color.len > 0) try self.out.writeStreamingAll(global_io.io(), cell.color);
         }
 
-        try self.out.writeAll(cell.text);
+        try self.out.writeStreamingAll(global_io.io(), cell.text);
 
         if (self.colorize and (cell.bold or cell.dim or cell.color.len > 0)) {
-            try self.out.writeAll(Ansi.reset);
+            try self.out.writeStreamingAll(global_io.io(), Ansi.reset);
         }
 
         // Calculate actual text width (without ANSI codes) for padding
@@ -163,75 +164,75 @@ pub const Table = struct {
     fn writeSpaces(self: *Table, count: usize) !void {
         var i: usize = 0;
         while (i < count) : (i += 1) {
-            try self.out.writeAll(" ");
+            try self.out.writeStreamingAll(global_io.io(), " ");
         }
     }
 };
 
 pub const SimpleTable = struct {
     allocator: std.mem.Allocator,
-    out: std.fs.File,
+    out: std.Io.File,
     colorize: bool,
 
-    pub fn init(allocator: std.mem.Allocator, out: std.fs.File) SimpleTable {
+    pub fn init(allocator: std.mem.Allocator, out: std.Io.File) SimpleTable {
         return .{
             .allocator = allocator,
             .out = out,
-            .colorize = std.posix.isatty(out.handle),
+            .colorize = out.isTty(global_io.io()) catch false,
         };
     }
 
     pub fn printHeader(self: SimpleTable, label: []const u8, detail: []const u8) !void {
         if (self.colorize) {
-            try self.out.writeAll(Ansi.dim);
-            try self.out.writeAll(label);
-            try self.out.writeAll(Ansi.reset);
-            try self.out.writeAll(" ");
-            try self.out.writeAll(detail);
-            try self.out.writeAll("\n");
+            try self.out.writeStreamingAll(global_io.io(), Ansi.dim);
+            try self.out.writeStreamingAll(global_io.io(), label);
+            try self.out.writeStreamingAll(global_io.io(), Ansi.reset);
+            try self.out.writeStreamingAll(global_io.io(), " ");
+            try self.out.writeStreamingAll(global_io.io(), detail);
+            try self.out.writeStreamingAll(global_io.io(), "\n");
         } else {
-            try self.out.writeAll(label);
-            try self.out.writeAll(" ");
-            try self.out.writeAll(detail);
-            try self.out.writeAll("\n");
+            try self.out.writeStreamingAll(global_io.io(), label);
+            try self.out.writeStreamingAll(global_io.io(), " ");
+            try self.out.writeStreamingAll(global_io.io(), detail);
+            try self.out.writeStreamingAll(global_io.io(), "\n");
         }
     }
 
     pub fn printSummary(self: SimpleTable, items: []const SummaryItem) !void {
         if (self.colorize) {
-            try self.out.writeAll(Ansi.dim);
-            try self.out.writeAll("[summary]");
-            try self.out.writeAll(Ansi.reset);
+            try self.out.writeStreamingAll(global_io.io(), Ansi.dim);
+            try self.out.writeStreamingAll(global_io.io(), "[summary]");
+            try self.out.writeStreamingAll(global_io.io(), Ansi.reset);
         } else {
-            try self.out.writeAll("[summary]");
+            try self.out.writeStreamingAll(global_io.io(), "[summary]");
         }
 
         for (items, 0..) |item, i| {
-            if (i > 0) try self.out.writeAll(" | ");
-            try self.out.writeAll(" ");
+            if (i > 0) try self.out.writeStreamingAll(global_io.io(), " | ");
+            try self.out.writeStreamingAll(global_io.io(), " ");
 
             if (self.colorize and item.color.len > 0) {
-                try self.out.writeAll(item.color);
+                try self.out.writeStreamingAll(global_io.io(), item.color);
             }
 
             var buf: [64]u8 = undefined;
             const text = try std.fmt.bufPrint(&buf, "{s} {d}", .{ item.label, item.value });
-            try self.out.writeAll(text);
+            try self.out.writeStreamingAll(global_io.io(), text);
 
             if (self.colorize and item.color.len > 0) {
-                try self.out.writeAll(Ansi.reset);
+                try self.out.writeStreamingAll(global_io.io(), Ansi.reset);
             }
         }
-        try self.out.writeAll("\n");
+        try self.out.writeStreamingAll(global_io.io(), "\n");
     }
 
     pub fn printDimmed(self: SimpleTable, text: []const u8) !void {
         if (self.colorize) {
-            try self.out.writeAll(Ansi.dim);
-            try self.out.writeAll(text);
-            try self.out.writeAll(Ansi.reset);
+            try self.out.writeStreamingAll(global_io.io(), Ansi.dim);
+            try self.out.writeStreamingAll(global_io.io(), text);
+            try self.out.writeStreamingAll(global_io.io(), Ansi.reset);
         } else {
-            try self.out.writeAll(text);
+            try self.out.writeStreamingAll(global_io.io(), text);
         }
     }
 
@@ -247,7 +248,7 @@ test "table basic" {
     var buffer = std.ArrayList(u8).init(allocator);
     defer buffer.deinit();
 
-    const out = std.fs.File{ .handle = undefined };
+    const out = std.Io.File{ .handle = undefined };
     var table = try Table.init(allocator, out, &.{
         .{ .width = 10 },
         .{ .width = 20 },

--- a/src/xdg.zig
+++ b/src/xdg.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const global_io = @import("global_io.zig");
 
 /// XDG Base Directory Specification paths for hola
 /// See: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
@@ -12,7 +13,7 @@ pub const XDG = struct {
     }
 
     fn getHomeDir(self: Self) ![]const u8 {
-        return std.process.getEnvVarOwned(self.allocator, "HOME") catch |err| {
+        return global_io.getEnvOwned(self.allocator, "HOME") catch |err| {
             if (err == error.EnvironmentVariableNotFound) {
                 std.debug.print("Error: HOME environment variable is not set\n", .{});
                 std.debug.print("Hint: if running with sudo, use 'sudo -E' or 'sudo --preserve-env=HOME' to preserve HOME\n", .{});
@@ -25,7 +26,7 @@ pub const XDG = struct {
     /// Default: ~/.config/hola
     /// Environment variable: XDG_CONFIG_HOME (if set, uses $XDG_CONFIG_HOME/hola)
     pub fn getConfigHome(self: Self) ![]const u8 {
-        if (std.process.getEnvVarOwned(self.allocator, "XDG_CONFIG_HOME")) |xdg_config| {
+        if (global_io.getEnvOwned(self.allocator, "XDG_CONFIG_HOME")) |xdg_config| {
             defer self.allocator.free(xdg_config);
             return std.fs.path.join(self.allocator, &.{ xdg_config, "hola" });
         } else |_| {
@@ -39,7 +40,7 @@ pub const XDG = struct {
     /// Default: ~/.local/share/hola
     /// Environment variable: XDG_DATA_HOME (if set, uses $XDG_DATA_HOME/hola)
     pub fn getDataHome(self: Self) ![]const u8 {
-        if (std.process.getEnvVarOwned(self.allocator, "XDG_DATA_HOME")) |xdg_data| {
+        if (global_io.getEnvOwned(self.allocator, "XDG_DATA_HOME")) |xdg_data| {
             defer self.allocator.free(xdg_data);
             return std.fs.path.join(self.allocator, &.{ xdg_data, "hola" });
         } else |_| {
@@ -53,7 +54,7 @@ pub const XDG = struct {
     /// Default: ~/.cache/hola
     /// Environment variable: XDG_CACHE_HOME (if set, uses $XDG_CACHE_HOME/hola)
     pub fn getCacheHome(self: Self) ![]const u8 {
-        if (std.process.getEnvVarOwned(self.allocator, "XDG_CACHE_HOME")) |xdg_cache| {
+        if (global_io.getEnvOwned(self.allocator, "XDG_CACHE_HOME")) |xdg_cache| {
             defer self.allocator.free(xdg_cache);
             return std.fs.path.join(self.allocator, &.{ xdg_cache, "hola" });
         } else |_| {
@@ -67,7 +68,7 @@ pub const XDG = struct {
     /// Default: ~/.local/state/hola
     /// Environment variable: XDG_STATE_HOME (if set, uses $XDG_STATE_HOME/hola)
     pub fn getStateHome(self: Self) ![]const u8 {
-        if (std.process.getEnvVarOwned(self.allocator, "XDG_STATE_HOME")) |xdg_state| {
+        if (global_io.getEnvOwned(self.allocator, "XDG_STATE_HOME")) |xdg_state| {
             defer self.allocator.free(xdg_state);
             return std.fs.path.join(self.allocator, &.{ xdg_state, "hola" });
         } else |_| {


### PR DESCRIPTION
Supersedes #27 (closed automatically when its stacked base branch was deleted after #26 merged; GitHub cannot reopen it). Content is identical — see #27 for the original description and green CI run.

## Summary

Migrates the codebase from Zig 0.15.2 to 0.16.0. Also fixes CI: `macos-latest` runners now ship an Xcode whose `libSystem.tbd` only declares `arm64e-macos`, which 0.15.2's linker cannot resolve; 0.16.0 handles it (this is why #26's checks were red on unmodified code).

### Commits

- **chore**: ignore the local zig package mirror
- **build**: zig 0.16.0 + dependency bumps (vaxis 0.6.0/uucode 0.2.0, clap 0.12.0, zeit 0.9.0, zig-toml 00c5715e — each the last revision supporting 0.16)
- **feat**: `std.process.Init` main convention + `src/global_io.zig` process-wide Io accessor
- **refactor(dns)**: resolver ported to `std.Io.net.HostName.lookup` (behavior note: zig's own resolver instead of libc getaddrinfo)
- **refactor**: bulk mechanical migration (~60 files) — fs/time/process/sync behind `std.Io`, Writergate fallout, unmanaged containers, libc fallbacks (`Io.Dir.setFileOwner` upstream bug, musl translate-c limits), CoreFoundation cImport consolidation with `_MACH_MESSAGE_H_` guard

### Verified

- macOS aarch64: build (Debug + ReleaseSmall), tests 9/9, fmt clean
- Cross-compile: x86_64-linux-musl, aarch64-linux-musl
- Linux runtime smoke (Alpine, static aarch64): `version` + full `provision` run
- macOS smoke: `provision`, `node-info`; host = macOS 26.5.1 + Xcode 26.6, no SDK workarounds

### Known behavior deltas

- DNS resolution path; custom-nameserver queries capped at 16 results
- `std.process.run` forces stdin `.ignore` on capture-and-wait helpers
- `chown` helpers pass `-1` to preserve ids (drops a TOCTOU)
- Guard-reap ECHILD no longer panics