### PR TITLE
fix(directory): read recursive flag as mrb_bool to prevent unintended recursive delete

### DIFF
--- a/src/resources/directory.zig
+++ b/src/resources/directory.zig
@@ -225,7 +225,9 @@ pub fn zigAddResource(
     var mode_val: mruby.mrb_value = undefined;
     var owner_val: mruby.mrb_value = undefined;
     var group_val: mruby.mrb_value = undefined;
-    var recursive_val: mruby.mrb_value = undefined;
+    // Format `b` writes a single mrb_bool (u8), not a full mrb_value; using a
+    // wider type here would leave the high bytes uninitialized.
+    var recursive_val: mruby.mrb_bool = undefined;
     var action_val: mruby.mrb_value = undefined;
     var only_if_val: mruby.mrb_value = undefined;
     var not_if_val: mruby.mrb_value = undefined;
@@ -264,7 +266,7 @@ pub fn zigAddResource(
         null;
 
     // Parse recursive (boolean)
-    const recursive = mruby.mrb_test(recursive_val);
+    const recursive = recursive_val != 0;
 
     // Parse action (string)
     const action_cstr = mruby.mrb_str_to_cstr(mrb, action_val);


### PR DESCRIPTION
## Problem

`mrb_get_args` format `b` writes a single `mrb_bool` (u8), but `recursive_val` was declared as `mrb_value` (8 bytes, `undefined`-initialized). `mrb_test()` then read the 7 uninitialized high bytes, so the flag evaluated as true regardless of what the Ruby DSL passed.

A plain

```ruby
directory "/some/dir" do
  action :delete
end
```

(`recursive` defaults to false) could therefore recursively delete the whole subtree instead of failing on a non-empty directory — **silent data loss**.

This is the same `b`-format pitfall previously fixed in `macos_dock.zig`; this call site was missed.

## Fix

Declare the variable as `mruby.mrb_bool` and compare against zero, matching the existing pattern in `remote_file.zig`. Swept the repo for other `b` format specifiers paired with `mrb_value` — this was the only remaining one.

## Testing

Verified end to end with the built binary:
- Non-recursive `action :delete` on a non-empty directory now fails with `DirNotEmpty` and leaves the tree intact (previously deleted it).
- `recursive true` still deletes the tree.
- `zig build test` passes.