### PR TITLE
fix(provision): join predownload thread before defers free shared state

### DIFF
--- a/src/provision.zig
+++ b/src/provision.zig
@@ -1149,6 +1149,13 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
         };
         download_thread = try std.Thread.spawn(.{}, DownloadThread.run, .{&download_mgr});
     }
+    // Join the worker before earlier defers tear down download_mgr,
+    // progress_ctx and display, which its progress callbacks dereference.
+    // On the happy path the thread has already been joined and cleared below.
+    defer if (download_thread) |thread| {
+        download_mgr.cancel();
+        thread.join();
+    };
 
     // Start resource execution phase
     try display.showSectionWithLevel("Executing Resources", 3);
@@ -1343,6 +1350,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     if (download_thread) |thread| {
         try display.showInfo("Waiting for remaining downloads to complete...");
         thread.join();
+        download_thread = null; // Prevent the early-exit defer from joining again
 
         // Show final stats
         const stats = download_mgr.getStats();


### PR DESCRIPTION
## Problem

The background thread spawned for `remote_file` predownloads was only joined at the end of the happy path. Any early error return between spawn and that join — a failed download (`error.DownloadFailed`), or a resource apply failure with `ignore_failure false` — unwound the enclosing defers, destroying `progress_ctx` and deinitializing `download_mgr` and `display` while the worker thread was still running. Its progress callbacks dereference all three: a use-after-free on exactly the paths where the user is being shown an error.

## Fix

Register a `defer` immediately after spawning that cancels remaining tasks (`download_mgr.cancel()`, so the worker exits promptly) and joins the thread. Being registered after the cleanup defers, it runs before them (LIFO), guaranteeing the worker has stopped before shared state is freed. The happy-path join now clears `download_thread` so the defer does not join twice.

## Testing

- Verified a provision run whose predownloads fail exits cleanly with the proper error (Debug build with leak-checked allocator, no crash).
- `zig build test` passes.