### PR TITLE
fix(http): initialize libcurl global state once at startup

### DIFF
--- a/src/curl.zig
+++ b/src/curl.zig
@@ -153,6 +153,8 @@ pub const CURLVERSION_NOW = 10; // Current version of curl_version_info_data
 pub extern fn curl_version() [*:0]const u8;
 pub extern fn curl_version_info(age: c_int) *curl_version_info_data;
 
+pub const CURL_GLOBAL_ALL: c_long = 0x03;
+
 pub extern fn curl_global_init(flags: c_long) CURLcode;
 pub extern fn curl_global_cleanup() void;
 pub extern fn curl_easy_init() ?*CURL;

--- a/src/kms_client.zig
+++ b/src/kms_client.zig
@@ -93,12 +93,10 @@ pub const KMSClient = struct {
     allocator: std.mem.Allocator,
     config: KMSConfig,
 
+    // libcurl global state is initialized once at program startup (see
+    // main.zig); doing it per-client would tear down shared state while
+    // other transfers are still running.
     pub fn init(allocator: std.mem.Allocator, config: KMSConfig) !KMSClient {
-        const init_result = curl.curl_global_init(0x03);
-        if (init_result != .CURLE_OK) {
-            return KMSError.CurlInitFailed;
-        }
-
         return KMSClient{
             .allocator = allocator,
             .config = config,
@@ -107,7 +105,6 @@ pub const KMSClient = struct {
 
     pub fn deinit(self: *KMSClient) void {
         _ = self;
-        curl.curl_global_cleanup();
     }
 
     /// Encrypt plaintext using a KMS key

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const clap = @import("clap");
 const logger = @import("logger.zig");
 const global_io = @import("global_io.zig");
+const curl = @import("curl.zig");
 const help_formatter = @import("help_formatter.zig");
 pub const build_options = @import("build_options");
 const commands = @import("commands.zig");
@@ -23,6 +24,14 @@ pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
     global_io.set(init.io);
     global_io.setEnviron(init.environ_map);
+
+    // libcurl's lazy global initialization is not thread-safe; download
+    // workers create curl handles concurrently, so initialize it once here
+    // while the process is still single-threaded.
+    if (curl.curl_global_init(curl.CURL_GLOBAL_ALL) != .CURLE_OK) {
+        return error.CurlGlobalInitFailed;
+    }
+    defer curl.curl_global_cleanup();
 
     // Initialize logger (non-critical, continue if it fails)
     logger.initGlobal(allocator, null) catch {};
@@ -179,8 +188,6 @@ fn printMainHelp(unknown: ?[]const u8) !void {
 }
 
 fn printVersion() !void {
-    const curl = @import("curl.zig");
-
     // Get curl version info
     const curl_info = curl.getVersionInfo();
     const curl_ver = curl.parseVersion(curl_info.version_num);


### PR DESCRIPTION
## Problem

Two related issues with libcurl global state:

1. The main HTTP client never called `curl_global_init()`, relying on `curl_easy_init()`'s lazy fallback, which is documented as **not thread-safe**. The download manager spawns worker threads that each create easy handles, so when the first curl call of the process happened inside those workers (e.g. a provision consisting only of `remote_file` resources), multiple threads could race the global initialization, including OpenSSL setup.

2. `KMSClient` called `curl_global_init` in `init` and `curl_global_cleanup` in `deinit`. The pair is neither reference-counted nor thread-safe, so destroying one client while any other transfer was in flight tore down shared global state under it.

## Fix

- Call `curl_global_init(CURL_GLOBAL_ALL)` once in `main` while the process is still single-threaded, paired with `curl_global_cleanup` on exit.
- Add the `CURL_GLOBAL_ALL` constant to `curl.zig` (replacing the magic `0x03`).
- Drop the per-instance init/cleanup from `KMSClient`.

## Testing

- `zig build test` passes; `hola --version` and a provision run with the HTTP stack work as before.
- Debug-build cold start unaffected (~29ms including the new init).