### PR TITLE
fix(git): null-terminate ssh_key path before passing to libgit2

### DIFF
--- a/src/resources/git.zig
+++ b/src/resources/git.zig
@@ -22,7 +22,7 @@ pub const Resource = struct {
     depth: ?u32, // Shallow clone depth (not yet supported by our git.zig)
     enable_checkout: bool, // Whether to checkout files (default: true)
     enable_submodules: bool, // Whether to update submodules (default: false)
-    ssh_key: ?[]const u8, // Path to SSH private key for authentication
+    ssh_key: ?[:0]const u8, // Path to SSH private key for authentication (sentinel-terminated: passed to libgit2 as C string)
     ssh_wrapper: ?[]const u8, // For compatibility with Chef (ignored - use ssh_key instead)
     enable_strict_host_key_checking: bool, // Verify SSH host keys (default: true for security)
     user: ?[]const u8, // File owner after clone (e.g., "deploy", "www-data")
@@ -245,7 +245,7 @@ pub const Resource = struct {
 
     /// Context for custom credentials and certificate callbacks
     const SshContext = struct {
-        ssh_key_path: ?[]const u8,
+        ssh_key_path: ?[:0]const u8,
         enable_strict_host_key_checking: bool,
         retries: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
     };
@@ -287,10 +287,9 @@ pub const Resource = struct {
             // Priority 1: If custom SSH key is explicitly provided, use it first
             if (ctx) |c_ctx| {
                 if (c_ctx.ssh_key_path) |key_path| {
-                    const private_key: [*c]const u8 = @ptrCast(key_path.ptr);
                     const public_key: [*c]const u8 = null; // libgit2 will derive from private key
                     const passphrase: [*c]const u8 = null; // No passphrase support yet
-                    return c.git_credential_ssh_key_new(out, user, public_key, private_key, passphrase);
+                    return c.git_credential_ssh_key_new(out, user, public_key, key_path.ptr, passphrase);
                 }
             }
 
@@ -1047,8 +1046,8 @@ pub fn zigAddResource(
     const depth: ?u32 = if (depth_int > 0) @intCast(depth_int) else null;
 
     const ssh_key_str = std.mem.span(mruby.mrb_str_to_cstr(mrb, ssh_key_val));
-    const ssh_key: ?[]const u8 = if (ssh_key_str.len > 0)
-        allocator.dupe(u8, ssh_key_str) catch return mruby.mrb_nil_value()
+    const ssh_key: ?[:0]const u8 = if (ssh_key_str.len > 0)
+        allocator.dupeZ(u8, ssh_key_str) catch return mruby.mrb_nil_value()
     else
         null;
     errdefer if (ssh_key) |key| allocator.free(key);


### PR DESCRIPTION
## Problem

Deploy tasks on production agents started failing at every `git` resource with an explicit `ssh_key`:

```
clone of git@github.com:... failed: failed to authenticate SSH session:
Unable to extract public key from private key file: Unable to open private key file
```

The key file on disk was intact, readable, and unchanged — yet libssh2 could not open it.

## Root cause

`ssh_key` was duplicated with `allocator.dupe` (no null terminator), and `credentialsCallback` handed its `.ptr` to `git_credential_ssh_key_new` as a C string. libssh2 then read past the end of the allocation until it happened to hit a zero byte, so the path it tried to `fopen` could carry trailing garbage.

Whether the byte after the allocation was zero depended entirely on allocator internals and heap history:

- **Before the 0.16 migration** the old allocator's layout happened to leave a zero there — the bug was latent.
- **After the 0.16 migration** (allocator changed in d2486f9) the long-running agent process reliably leaves garbage after the path, so every explicit-`ssh_key` clone fails. The same script still worked via one-shot `hola provision` (fresh heap), which made the failure look environment-specific.

Timeline that confirmed it in production: binary replaced on Jul 22, but the old agent process kept running pre-0.16 code from memory; the service restarted on Jul 30 and the very first deploy after the restart failed, as did every one since.

## Fix

Store `ssh_key` as a sentinel-terminated slice (`?[:0]const u8`, duplicated with `dupeZ`) and thread the sentinel type through `SshContext`, so the compiler enforces null termination end to end and the raw `@ptrCast` is gone. This matches how `repository`/`destination` are already handled (`dupZ` before touching C).

## Testing

- `zig build test` — 25/25 pass
- Deployed a ReleaseFast x86_64-linux build to the affected host: agent reconnects and clone with the same deploy key succeeds