### PR TITLE
feat(run): Rake-inspired task runner and reusable provision phases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ zig-out
 zig-pkg
 /indicatif
 /test_*
+/.hola-rake-test/
 /zig-cache

--- a/Holafile
+++ b/Holafile
@@ -14,7 +14,7 @@ GENERATED = "#{DEMO_DIR}/generated.txt"
 RULE_INPUT = "#{DEMO_DIR}/rule.in"
 RULE_OUTPUT = "#{DEMO_DIR}/rule.out"
 
-desc "Remove files created by this Rakefile"
+desc "Remove files created by this Holafile"
 require "rake/clean"
 CLEAN << DEMO_DIR
 

--- a/Holafile
+++ b/Holafile
@@ -25,7 +25,7 @@ task :prepare => DEMO_DIR
 
 desc "Create the input file when it is missing"
 file INPUT => DEMO_DIR do
-  Hola::Resources.file INPUT do
+  resources.file INPUT do
     content "hello from hola rake\n"
   end
 end
@@ -37,7 +37,7 @@ end
 
 desc "Create the input used by the suffix rule"
 file RULE_INPUT => DEMO_DIR do
-  Hola::Resources.file RULE_INPUT do
+  resources.file RULE_INPUT do
     content "suffix rule input\n"
   end
 end

--- a/README.md
+++ b/README.md
@@ -170,9 +170,10 @@ If you know Ruby, you already know this. If you don't, you can still read it.
 
 ### Project Tasks with `hola run`
 
-Put a `Rakefile` in a project to define repeatable development tasks. Hola finds it
+Put a `Holafile` in a project to define repeatable development tasks. Hola finds it
 from the current directory or any parent directory, then runs each resource as soon
-as it is declared:
+as it is declared. `holafile.rb` is also canonical; the Rake file names remain as
+legacy fallbacks and emit a migration warning when discovered implicitly:
 
 ```ruby
 directory ".cache"
@@ -207,7 +208,8 @@ hola run -n build                # Dry run
 hola run --trace build           # Trace task invocation
 ```
 
-The embedded task runtime covers the common Rake surface: dependencies, namespaces,
+The embedded mruby task runtime is inspired by Rake rather than compatible with it.
+It covers the common task surface: dependencies, namespaces,
 arguments, task enhancement and re-enabling, `Rake::Task[]`, `file`, `directory`, string
 suffix rules, `Dir.glob`, `FileList`, `rake/clean`, local `require`/
 `require_relative`, `FileUtils`, and streaming `sh` output. In task mode, `file`
@@ -240,7 +242,7 @@ task.
 ```bash
 hola apply             # Run Brewfile + mise.toml + symlinks
 hola provision         # Run provision.rb (advanced)
-hola run [task]        # Run Rake-compatible project tasks
+hola run [task]        # Run Rake-inspired project tasks
 hola <task>            # Shorthand for a project task
 ```
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,13 @@ hola run -T                      # List described tasks
 hola run -P                      # Show prerequisites
 hola run -n build                # Dry run
 hola run --trace build           # Trace task invocation
+hola run --output compact build  # Animated spinner for established scripts
 ```
+
+Normal output is the default, including on a TTY. It is append-only and shows
+resource actions, nested composite resources, live command streams, change details,
+and structured failure diagnostics. `--output compact` enables the animated spinner;
+the older `plain` and `pretty` mode names remain accepted as aliases.
 
 The embedded mruby task runtime is inspired by Rake rather than compatible with it.
 It covers the common task surface: dependencies, namespaces,

--- a/README.md
+++ b/README.md
@@ -168,6 +168,60 @@ No YAML hell. No cryptic property lists. Just readable code.
 
 If you know Ruby, you already know this. If you don't, you can still read it.
 
+### Project Tasks with `hola run`
+
+Put a `Rakefile` in a project to define repeatable development tasks. Hola finds it
+from the current directory or any parent directory, then runs each resource as soon
+as it is declared:
+
+```ruby
+directory ".cache"
+
+file ".cache/config" => ".cache" do
+  File.open(".cache/config", "wb") { |file| file.write("ready\n") }
+end
+
+desc "Build the project"
+task :build => ".cache/config" do
+  sh "zig build"
+end
+
+namespace :db do
+  task :migrate, [:environment] do |_task, args|
+    args.with_defaults :environment => "development"
+    sh "./bin/migrate #{args.environment}"
+  end
+end
+
+task :default => :build
+```
+
+```bash
+hola run                         # Run the default task
+hola run build                   # Run an explicit task
+hola build                       # Shorthand when it does not collide with a built-in
+hola run "db:migrate[staging]"   # Pass task arguments
+hola run -T                      # List described tasks
+hola run -P                      # Show prerequisites
+hola run -n build                # Dry run
+hola run --trace build           # Trace task invocation
+```
+
+The embedded task runtime covers the common Rake surface: dependencies, namespaces,
+arguments, task enhancement and re-enabling, `Rake::Task[]`, `file`, `directory`, string
+suffix rules, `Dir.glob`, `FileList`, `rake/clean`, local `require`/
+`require_relative`, `FileUtils`, and streaming `sh` output. In task mode, `file`
+and `directory` always have their standard Rake meanings; `file_task` remains as
+a compatibility alias for `file`. Hola's provision resources are available
+explicitly as `Hola::Resources.file` and `Hola::Resources.directory` when a task
+needs immediate resource convergence.
+
+This is an mruby runtime, not system Ruby. Regular expressions, native gems,
+backticks, `exit`, and the block form of `sh` are unavailable. Use `raise` or
+`abort` to stop a task. Delayed notifications are flushed after all requested
+tasks; subscriptions cannot target resources that are only declared by a later
+task.
+
 ---
 
 ## Performance
@@ -186,6 +240,8 @@ If you know Ruby, you already know this. If you don't, you can still read it.
 ```bash
 hola apply             # Run Brewfile + mise.toml + symlinks
 hola provision         # Run provision.rb (advanced)
+hola run [task]        # Run Rake-compatible project tasks
+hola <task>            # Shorthand for a project task
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -246,6 +246,56 @@ one stable namespace without forcing every call site to repeat the long prefix.
 Provision scripts retain their existing top-level resource DSL and may also use the
 namespace.
 
+#### Reusable provisioning phases
+
+A provisioning recipe may split its flat resource stream with `phase` markers.
+The marker changes the declaration context for the resources that follow it; it
+does not add another Ruby block or another output indentation level:
+
+```ruby
+# scripts/deploy.rb
+phase :prepare
+
+git "/srv/app/releases/next" do
+  repository "https://example.com/app.git"
+end
+
+execute "build application"
+
+phase :deploy
+
+link "/srv/app/current" do
+  to "/srv/app/releases/next"
+end
+
+execute "restart application"
+```
+
+The same recipe supports a complete unattended run or a single operator-selected
+stage:
+
+```bash
+hola provision scripts/deploy.rb
+hola provision --phase prepare scripts/deploy.rb
+hola provision --phase deploy scripts/deploy.rb
+```
+
+A Holafile can import those phases as namespaced tasks. No duplicate mise tasks or
+wrapper scripts are required:
+
+```ruby
+import_phases "scripts/deploy.rb", :as => :app
+
+task :release => ["app:prepare", "app:deploy"]
+task :default => :release
+```
+
+`hola run app:prepare` executes one phase, while `hola run release` composes both.
+Imported phases also appear in `hola run -T`. Recipes without a `phase` marker keep
+the existing flat provisioning behavior and the Chef-compatible top-level resource
+style. Agent tasks may provide an optional `"phase"` field; resource callback
+results include their phase name.
+
 This is an mruby runtime, not system Ruby. Regular expressions, native gems,
 backticks, `exit`, and the block form of `sh` are unavailable. Use `raise` or
 `abort` to stop a task. Delayed notifications are flushed after all requested

--- a/README.md
+++ b/README.md
@@ -170,10 +170,11 @@ If you know Ruby, you already know this. If you don't, you can still read it.
 
 ### Project Tasks with `hola run`
 
-Put a `Holafile` in a project to define repeatable development tasks. Hola finds it
-from the current directory or any parent directory, then runs each resource as soon
-as it is declared. `holafile.rb` is also canonical; the Rake file names remain as
-legacy fallbacks and emit a migration warning when discovered implicitly:
+Put a `Holafile` in a project to define repeatable, state-aware development tasks.
+Hola finds it from the current directory or any parent directory, then runs each
+resource as soon as it is declared. `holafile.rb` is also canonical; the Rake file
+names remain as legacy fallbacks and emit a migration warning when discovered
+implicitly:
 
 ```ruby
 directory ".cache"
@@ -214,9 +215,30 @@ arguments, task enhancement and re-enabling, `Rake::Task[]`, `file`, `directory`
 suffix rules, `Dir.glob`, `FileList`, `rake/clean`, local `require`/
 `require_relative`, `FileUtils`, and streaming `sh` output. In task mode, `file`
 and `directory` always have their standard Rake meanings; `file_task` remains as
-a compatibility alias for `file`. Hola's provision resources are available
-explicitly as `Hola::Resources.file` and `Hola::Resources.directory` when a task
-needs immediate resource convergence.
+a compatibility alias for `file`. Configuration resources enter through the
+explicit `resources` gateway and converge immediately when declared inside a task:
+
+```ruby
+task :configure do
+  resources do
+    directory "build"
+    file "build/version.txt" do
+      content VERSION
+    end
+  end
+end
+
+task :compile do
+  resources.execute "compile" do
+    command "zig build"
+  end
+end
+```
+
+The gateway delegates to the complete `Hola::Resources.*` API, so extensions have
+one stable namespace without forcing every call site to repeat the long prefix.
+Provision scripts retain their existing top-level resource DSL and may also use the
+namespace.
 
 This is an mruby runtime, not system Ruby. Regular expressions, native gems,
 backticks, `exit`, and the block form of `sh` are unavailable. Use `raise` or

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,126 @@
+# Integration fixture for `hola run`.
+#
+# Try:
+#   ./zig-out/bin/hola-macos-aarch64 run -T
+#   ./zig-out/bin/hola-macos-aarch64 run
+#   ./zig-out/bin/hola-macos-aarch64 run "db:migrate[staging,42]"
+#   ./zig-out/bin/hola-macos-aarch64 env_check HOLA_RAKE_ENV=demo
+
+require_relative "test/rake_helpers"
+
+DEMO_DIR = ".hola-rake-test"
+INPUT = "#{DEMO_DIR}/input.txt"
+GENERATED = "#{DEMO_DIR}/generated.txt"
+RULE_INPUT = "#{DEMO_DIR}/rule.in"
+RULE_OUTPUT = "#{DEMO_DIR}/rule.out"
+
+desc "Remove files created by this Rakefile"
+require "rake/clean"
+CLEAN << DEMO_DIR
+
+directory DEMO_DIR
+
+desc "Prepare the demonstration directory"
+task :prepare => DEMO_DIR
+
+desc "Create the input file when it is missing"
+file INPUT => DEMO_DIR do
+  Hola::Resources.file INPUT do
+    content "hello from hola rake\n"
+  end
+end
+
+desc "Generate a file from its prerequisite"
+file GENERATED => INPUT do |task|
+  sh "cp #{INPUT} #{task.name}"
+end
+
+desc "Create the input used by the suffix rule"
+file RULE_INPUT => DEMO_DIR do
+  Hola::Resources.file RULE_INPUT do
+    content "suffix rule input\n"
+  end
+end
+
+rule ".out" => ".in" do |task|
+  sh "cp #{task.source} #{task.name}"
+end
+
+desc "Exercise file tasks, prerequisites, suffix rules, and streaming sh"
+task :build => [:prepare, GENERATED, RULE_OUTPUT] do
+  sh "wc -c #{GENERATED} #{RULE_OUTPUT}"
+end
+
+namespace :db do
+  desc "Run a namespaced task with arguments and defaults"
+  task :migrate, [:environment, :version] do |_task, args|
+    args.with_defaults :environment => "development", :version => "latest"
+    puts "migrating #{args.environment} to #{args.version}"
+  end
+
+  desc "Invoke another task from inside a namespace"
+  task :setup => :migrate do
+    puts "database setup complete"
+  end
+end
+
+desc "Inspect project files with Dir.glob and FileList"
+task :glob_demo do
+  ruby_files = FileList["**/*.rb"].exclude(".hola-rake-test/**")
+  zig_files = Dir.glob("src/**/*.zig")
+  raise "expected Ruby files" if ruby_files.empty?
+  raise "expected Zig files" if zig_files.empty?
+  puts "Ruby files: #{ruby_files.length}; Zig files: #{zig_files.length}"
+end
+
+desc "Read a helper loaded with require_relative"
+task :helper_demo do
+  puts rake_helper_message
+end
+
+desc "Check command-line ENV assignments and per-command environment overrides"
+task :env_check, [:expected] do |_task, args|
+  args.with_defaults :expected => "demo"
+  raise "HOLA_RAKE_ENV does not match" unless ENV["HOLA_RAKE_ENV"] == args.expected
+  sh 'test "$HOLA_RAKE_ENV" = "$EXPECTED"', :env => {"EXPECTED" => args.expected}
+end
+
+desc "Demonstrate that redefining a task enhances its actions"
+task :enhanced do
+  puts "enhanced action one"
+end
+
+task :enhanced do
+  puts "enhanced action two"
+end
+
+desc "Invoke and re-enable a task programmatically"
+task :invoke_demo do
+  target = Rake::Task[:enhanced]
+  target.invoke
+  target.reenable
+  target.invoke
+end
+
+desc "Run multiple prerequisites through the multitask compatibility API"
+multitask :checks => [:glob_demo, :helper_demo]
+
+desc "Rescue a failed hola resource and continue"
+task :rescued_failure do
+  begin
+    sh "exit 7"
+  rescue Hola::ResourceError => error
+    puts "rescued: #{error.message}"
+  end
+end
+
+namespace :cycle do
+  task :a => :b
+  task :b => :a
+end
+
+desc "Intentionally fail to demonstrate circular-dependency detection"
+task :cycle_demo => "cycle:a"
+
+desc "Build the default fixture"
+task :default => :build

--- a/src/ansi_constants.zig
+++ b/src/ansi_constants.zig
@@ -5,6 +5,7 @@ pub const ANSI = struct {
     pub const DIM = "\x1b[2m";
     pub const RED = "\x1b[31m";
     pub const GREEN = "\x1b[32m";
+    pub const BRIGHT_GREEN = "\x1b[92m";
     pub const YELLOW = "\x1b[33m";
     pub const BLUE = "\x1b[34m";
     pub const MAGENTA = "\x1b[35m";

--- a/src/apply.zig
+++ b/src/apply.zig
@@ -96,10 +96,10 @@ const AptBootstrap = if (is_linux) struct {
 
     pub fn installPackagesParallel(allocator: std.mem.Allocator, config_root: []const u8) !void {
         // For apt we run installs sequentially: apt first, then mise.
-        var apt_display = try modern_display.ModernProvisionDisplay.init(allocator, false);
+        var apt_display = try modern_display.ModernProvisionDisplay.init(allocator, .normal);
         defer apt_display.deinit();
 
-        var mise_display = try modern_display.ModernProvisionDisplay.init(allocator, false);
+        var mise_display = try modern_display.ModernProvisionDisplay.init(allocator, .normal);
         defer mise_display.deinit();
 
         // Detect apt (apt-get preferred) at the platform layer so we can extend
@@ -135,7 +135,7 @@ fn runWithBootstrap(comptime Impl: type, allocator: std.mem.Allocator, opts: App
 
     // Use simple output for apply command (no spinner)
     // provision command will use its own spinner display
-    var display = try modern_display.ModernProvisionDisplay.init(allocator, false);
+    var display = try modern_display.ModernProvisionDisplay.init(allocator, .normal);
     defer display.deinit();
 
     // Print banner with version info using help formatter
@@ -192,7 +192,7 @@ fn runWithBootstrap(comptime Impl: type, allocator: std.mem.Allocator, opts: App
     }
 
     std.debug.print("\n", .{});
-    // provision.run() will use its own ModernProvisionDisplay with spinner and will show section
+    // provision.run() owns its resource display and section output.
     var prov_result = try provision.run(allocator, .{ .script_path = script_path });
     defer prov_result.deinit(allocator);
 
@@ -212,7 +212,7 @@ pub fn run(allocator: std.mem.Allocator, opts: ApplyOptions) !void {
 
 /// Step 1: Link dotfiles
 fn linkDotfiles(allocator: std.mem.Allocator, config_root: []const u8, dry_run: bool, display: *modern_display.ModernProvisionDisplay) !void {
-    try display.showSection("Linking Dotfiles");
+    try display.showSection("Linking dotfiles");
 
     // config_root is the dotfiles repository location
     // Check if it exists
@@ -247,13 +247,13 @@ fn linkDotfiles(allocator: std.mem.Allocator, config_root: []const u8, dry_run: 
     }
 
     // Call dotfiles.run() - it will output directly to stdout
-    // Since show_progress is false, output will be clean text
+    // Normal mode uses an append-only execution log.
     try dotfiles.run(allocator, options);
 }
 
 /// Step 2: Install homebrew (if not installed)
 fn installHomebrew(allocator: std.mem.Allocator, display: *modern_display.ModernProvisionDisplay) !void {
-    try display.showSection("Installing Foundation");
+    try display.showSection("Installing foundation");
 
     // Check if brew is already installed
     const brew_path = brew.findBrew(allocator) catch |err| switch (err) {
@@ -304,10 +304,10 @@ fn installPackagesParallelImpl(allocator: std.mem.Allocator, config_root: []cons
     // Note: Section display is handled in child functions to avoid thread safety issues
 
     // Create separate display instances for each thread to avoid thread safety issues
-    var brew_display = try modern_display.ModernProvisionDisplay.init(allocator, false);
+    var brew_display = try modern_display.ModernProvisionDisplay.init(allocator, .normal);
     defer brew_display.deinit();
 
-    var mise_display = try modern_display.ModernProvisionDisplay.init(allocator, false);
+    var mise_display = try modern_display.ModernProvisionDisplay.init(allocator, .normal);
     defer mise_display.deinit();
 
     // Spawn threads for parallel execution
@@ -324,7 +324,7 @@ fn installPackagesParallelImpl(allocator: std.mem.Allocator, config_root: []cons
 
 /// Install Homebrew packages from Brewfile using brew bundle --global
 fn installBrewPackages(allocator: std.mem.Allocator, _: []const u8, display: *modern_display.ModernProvisionDisplay) !void {
-    try display.showSection("Installing Packages (Parallel)");
+    try display.showSection("Installing packages (parallel)");
 
     const brew_path = try brew.findBrew(allocator);
     defer allocator.free(brew_path);

--- a/src/apt_bootstrap.zig
+++ b/src/apt_bootstrap.zig
@@ -23,7 +23,7 @@ pub fn installPackages(
     display: *modern_display.ModernProvisionDisplay,
     apt_path: []const u8,
 ) !void {
-    try display.showSection("Installing Packages (apt)");
+    try display.showSection("Installing packages (apt)");
 
     const apt_list_path = try std.fs.path.join(allocator, &.{ config_root, "packages.apt.txt" });
     defer allocator.free(apt_list_path);

--- a/src/async_executor.zig
+++ b/src/async_executor.zig
@@ -71,6 +71,7 @@ pub const AsyncExecutor = struct {
 
         // Wait for thread to complete
         thread.join();
+        if (global_poll_callback) |callback| callback() catch {};
 
         // Check result
         ctx.mutex.lockUncancelable(global_io.io());
@@ -156,6 +157,8 @@ pub const AsyncExecutor = struct {
 
         // Wait for thread to complete
         thread.join();
+        const final_callback = poll_callback orelse global_poll_callback;
+        if (final_callback) |callback| callback() catch {};
 
         // Check result
         ctx.mutex.lockUncancelable(global_io.io());

--- a/src/async_executor.zig
+++ b/src/async_executor.zig
@@ -1,5 +1,8 @@
 const std = @import("std");
 const global_io = @import("global_io.zig");
+const base = @import("base_resource.zig");
+
+const ERROR_DETAIL_CAPACITY = 1024;
 
 /// Global poll callback for UI updates during async execution
 threadlocal var global_poll_callback: ?*const fn () anyerror!void = null;
@@ -20,6 +23,9 @@ pub const AsyncExecutor = struct {
             status: std.atomic.Value(u8), // 0=running, 1=completed, 2=failed
             result: ?T = null,
             err: ?anyerror = null,
+            error_detail: [ERROR_DETAIL_CAPACITY]u8 = undefined,
+            error_detail_len: usize = 0,
+            command_diagnostic: base.CommandDiagnosticSnapshot = .{},
             mutex: std.Io.Mutex = .init,
 
             pub fn init() @This() {
@@ -44,6 +50,8 @@ pub const AsyncExecutor = struct {
                 const result = func() catch |err| {
                     context.mutex.lockUncancelable(global_io.io());
                     context.err = err;
+                    captureWorkerErrorDetail(&context.error_detail, &context.error_detail_len);
+                    context.command_diagnostic = base.snapshotCommandDiagnostic();
                     context.mutex.unlock(global_io.io());
                     context.status.store(2, .release);
                     return;
@@ -78,6 +86,8 @@ pub const AsyncExecutor = struct {
         defer ctx.mutex.unlock(global_io.io());
 
         if (ctx.status.load(.acquire) == 2) {
+            restoreWorkerErrorDetail(ctx.error_detail[0..ctx.error_detail_len]);
+            base.restoreCommandDiagnostic(&ctx.command_diagnostic);
             return ctx.err orelse error.UnknownError;
         }
 
@@ -109,6 +119,9 @@ pub const AsyncExecutor = struct {
             status: std.atomic.Value(u8),
             result: ?ResultType = null,
             err: ?anyerror = null,
+            error_detail: [ERROR_DETAIL_CAPACITY]u8 = undefined,
+            error_detail_len: usize = 0,
+            command_diagnostic: base.CommandDiagnosticSnapshot = .{},
             mutex: std.Io.Mutex = .init,
         };
 
@@ -123,6 +136,8 @@ pub const AsyncExecutor = struct {
                 const result = func(task_ctx.user_context) catch |err| {
                     task_ctx.mutex.lockUncancelable(global_io.io());
                     task_ctx.err = err;
+                    captureWorkerErrorDetail(&task_ctx.error_detail, &task_ctx.error_detail_len);
+                    task_ctx.command_diagnostic = base.snapshotCommandDiagnostic();
                     task_ctx.mutex.unlock(global_io.io());
                     task_ctx.status.store(2, .release);
                     return;
@@ -165,9 +180,37 @@ pub const AsyncExecutor = struct {
         defer ctx.mutex.unlock(global_io.io());
 
         if (ctx.status.load(.acquire) == 2) {
+            restoreWorkerErrorDetail(ctx.error_detail[0..ctx.error_detail_len]);
+            base.restoreCommandDiagnostic(&ctx.command_diagnostic);
             return ctx.err orelse error.UnknownError;
         }
 
         return ctx.result.?;
     }
 };
+
+fn captureWorkerErrorDetail(buffer: []u8, length: *usize) void {
+    const detail = base.getProvisionErrorDetail() orelse return;
+    const copy_len = @min(detail.len, buffer.len);
+    @memcpy(buffer[0..copy_len], detail[0..copy_len]);
+    length.* = copy_len;
+}
+
+fn restoreWorkerErrorDetail(detail: []const u8) void {
+    if (detail.len > 0) base.recordProvisionErrorDetailSlice(detail);
+}
+
+test "async executor propagates worker error detail" {
+    base.clearProvisionErrorDetail();
+    defer base.clearProvisionErrorDetail();
+
+    const Worker = struct {
+        fn fail() !void {
+            base.recordProvisionErrorDetailSlice("worker detail");
+            return error.CommandFailed;
+        }
+    };
+
+    try std.testing.expectError(error.CommandFailed, AsyncExecutor.execute(void, Worker.fail));
+    try std.testing.expectEqualStrings("worker detail", base.getProvisionErrorDetail().?);
+}

--- a/src/base_resource.zig
+++ b/src/base_resource.zig
@@ -146,17 +146,14 @@ pub const CommonProps = struct {
                 return "skipped due to only_if"; // command failed (non-zero exit)
             }
         } else if (self.only_if_block) |block| {
-            // Use funcall instead of yield to properly handle exceptions
-            const call_sym = mruby.mrb_intern_cstr(mrb, "call");
-            const result = mruby.mrb_funcall_argv(mrb, block, call_sym, 0, null);
-
-            // Check for exceptions during call
-            const exc = mruby.mrb_get_exception(mrb);
-            if (mruby.mrb_test(exc)) {
-                recordProvisionException(mrb, exc, "only_if block raised");
-                mruby.mrb_print_error(mrb);
-                return error.MRubyException;
-            }
+            const result = switch (mruby.callProtected(mrb, block, "call", &.{})) {
+                .ok => |value| value,
+                .raised => |exc| {
+                    recordProvisionException(mrb, exc, "only_if block raised");
+                    mruby.zig_mrb_print_exc(mrb, exc);
+                    return error.MRubyException;
+                },
+            };
 
             if (!mruby.mrb_test(result)) {
                 return "skipped due to only_if"; // only_if returned falsy
@@ -172,17 +169,14 @@ pub const CommonProps = struct {
                 return "skipped due to not_if"; // command succeeded (exit 0)
             }
         } else if (self.not_if_block) |block| {
-            // Use funcall instead of yield to properly handle exceptions
-            const call_sym = mruby.mrb_intern_cstr(mrb, "call");
-            const result = mruby.mrb_funcall_argv(mrb, block, call_sym, 0, null);
-
-            // Check for exceptions during call
-            const exc = mruby.mrb_get_exception(mrb);
-            if (mruby.mrb_test(exc)) {
-                recordProvisionException(mrb, exc, "not_if block raised");
-                mruby.mrb_print_error(mrb);
-                return error.MRubyException;
-            }
+            const result = switch (mruby.callProtected(mrb, block, "call", &.{})) {
+                .ok => |value| value,
+                .raised => |exc| {
+                    recordProvisionException(mrb, exc, "not_if block raised");
+                    mruby.zig_mrb_print_exc(mrb, exc);
+                    return error.MRubyException;
+                },
+            };
 
             if (mruby.mrb_test(result)) {
                 return "skipped due to not_if"; // not_if returned truthy

--- a/src/base_resource.zig
+++ b/src/base_resource.zig
@@ -18,16 +18,53 @@ const GUARD_REAP_GRACE_MS: i64 = 2000;
 // apply loop and the agent callback can then show details like the raised Ruby
 // exception, failed URL, HTTP status, or checksum mismatch.
 const PROVISION_ERROR_DETAIL_BUF_SIZE = 1024;
+const PROVISION_ERROR_TRACE_BUF_SIZE = 4 * 1024;
+const COMMAND_STDERR_SUMMARY_SIZE = 768;
+const COMMAND_OUTPUT_CAPTURE_SIZE = 8 * 1024;
 threadlocal var provision_error_detail_buf: [PROVISION_ERROR_DETAIL_BUF_SIZE]u8 = undefined;
 threadlocal var provision_error_detail_len: usize = 0;
+threadlocal var provision_error_trace_buf: [PROVISION_ERROR_TRACE_BUF_SIZE]u8 = undefined;
+threadlocal var provision_error_trace_len: usize = 0;
+threadlocal var command_term: ?std.process.Child.Term = null;
+threadlocal var command_timeout_s: ?u32 = null;
+threadlocal var command_stdout_buf: [COMMAND_OUTPUT_CAPTURE_SIZE]u8 = undefined;
+threadlocal var command_stdout_len: usize = 0;
+threadlocal var command_stderr_buf: [COMMAND_OUTPUT_CAPTURE_SIZE]u8 = undefined;
+threadlocal var command_stderr_len: usize = 0;
+
+pub const CommandDiagnostic = struct {
+    term: ?std.process.Child.Term,
+    timeout_s: ?u32,
+    stdout: ?[]const u8,
+    stderr: ?[]const u8,
+};
+
+pub const CommandDiagnosticSnapshot = struct {
+    term: ?std.process.Child.Term = null,
+    timeout_s: ?u32 = null,
+    stdout: [COMMAND_OUTPUT_CAPTURE_SIZE]u8 = undefined,
+    stdout_len: usize = 0,
+    stderr: [COMMAND_OUTPUT_CAPTURE_SIZE]u8 = undefined,
+    stderr_len: usize = 0,
+};
 
 pub fn clearProvisionErrorDetail() void {
     provision_error_detail_len = 0;
+    provision_error_trace_len = 0;
+    command_term = null;
+    command_timeout_s = null;
+    command_stdout_len = 0;
+    command_stderr_len = 0;
 }
 
 pub fn getProvisionErrorDetail() ?[]const u8 {
     if (provision_error_detail_len == 0) return null;
     return provision_error_detail_buf[0..provision_error_detail_len];
+}
+
+pub fn getProvisionErrorTrace() ?[]const u8 {
+    if (provision_error_trace_len == 0) return null;
+    return provision_error_trace_buf[0..provision_error_trace_len];
 }
 
 pub fn recordProvisionErrorDetailSlice(detail: []const u8) void {
@@ -43,6 +80,169 @@ pub fn recordProvisionErrorDetail(comptime fmt: []const u8, args: anytype) void 
         break :blk provision_error_detail_buf[0..fallback.len];
     };
     provision_error_detail_len = written.len;
+}
+
+/// Translate internal Zig errors into stable, familiar operator-facing text.
+/// Structured results may keep the original error name as a machine-readable
+/// code, but terminal output should read like the underlying OS/tool error.
+pub fn userFacingError(err: anyerror) []const u8 {
+    return switch (err) {
+        error.FileNotFound => "No such file or directory",
+        error.NotDir => "Not a directory",
+        error.IsDir => "Is a directory",
+        error.AccessDenied, error.PermissionDenied => "Permission denied",
+        error.ReadOnlyFileSystem => "Read-only file system",
+        error.PathAlreadyExists => "File exists",
+        error.DirNotEmpty => "Directory not empty",
+        error.NameTooLong => "File name too long",
+        error.SymLinkLoop => "Too many levels of symbolic links",
+        error.NoSpaceLeft => "No space left on device",
+        error.DiskQuota => "Disk quota exceeded",
+        error.FileTooBig => "File too large",
+        error.ProcessFdQuotaExceeded, error.SystemFdQuotaExceeded => "Too many open files",
+        error.DeviceBusy => "Device or resource busy",
+        error.CommandFailed => "Command failed",
+        error.CommandTimedOut => "Command timed out",
+        error.CommandKilled => "Command terminated",
+        error.CommandStopped => "Command stopped",
+        error.RubyBlockFailed => "Ruby block failed",
+        error.DownloadFailed => "Download failed",
+        error.ChecksumMismatch => "Checksum mismatch",
+        else => @errorName(err),
+    };
+}
+
+test "internal errors have operator-facing descriptions" {
+    try std.testing.expectEqualStrings("No such file or directory", userFacingError(error.FileNotFound));
+    try std.testing.expectEqualStrings("Not a directory", userFacingError(error.NotDir));
+    try std.testing.expectEqualStrings("Permission denied", userFacingError(error.AccessDenied));
+    try std.testing.expectEqualStrings("Command failed", userFacingError(error.CommandFailed));
+}
+
+/// Record a process failure with the exit status and a bounded, single-line
+/// stderr summary suitable for both the progress display and structured result.
+pub fn recordCommandFailure(term: std.process.Child.Term, stderr: []const u8) void {
+    recordCommandFailureOutput(term, "", stderr);
+}
+
+pub fn recordCommandFailureOutput(term: std.process.Child.Term, stdout: []const u8, stderr: []const u8) void {
+    storeCommandDiagnostic(term, null, stdout, stderr);
+    var stderr_buf: [COMMAND_STDERR_SUMMARY_SIZE]u8 = undefined;
+    const stderr_summary = normalizeCommandDiagnostic(stderr, &stderr_buf);
+
+    switch (term) {
+        .exited => |code| if (stderr_summary.len > 0)
+            recordProvisionErrorDetail("command exited with status {d}; stderr: {s}", .{ code, stderr_summary })
+        else
+            recordProvisionErrorDetail("command exited with status {d}", .{code}),
+        .signal => |signal| if (stderr_summary.len > 0)
+            recordProvisionErrorDetail("command terminated by signal {d}; stderr: {s}", .{ @intFromEnum(signal), stderr_summary })
+        else
+            recordProvisionErrorDetail("command terminated by signal {d}", .{@intFromEnum(signal)}),
+        .stopped => |signal| if (stderr_summary.len > 0)
+            recordProvisionErrorDetail("command stopped by signal {d}; stderr: {s}", .{ @intFromEnum(signal), stderr_summary })
+        else
+            recordProvisionErrorDetail("command stopped by signal {d}", .{@intFromEnum(signal)}),
+        .unknown => |status| if (stderr_summary.len > 0)
+            recordProvisionErrorDetail("command returned unknown status {d}; stderr: {s}", .{ status, stderr_summary })
+        else
+            recordProvisionErrorDetail("command returned unknown status {d}", .{status}),
+    }
+}
+
+pub fn recordCommandTimeout(seconds: u32, stderr: []const u8) void {
+    recordCommandTimeoutOutput(seconds, "", stderr);
+}
+
+pub fn recordCommandTimeoutOutput(seconds: u32, stdout: []const u8, stderr: []const u8) void {
+    storeCommandDiagnostic(null, seconds, stdout, stderr);
+    var stderr_buf: [COMMAND_STDERR_SUMMARY_SIZE]u8 = undefined;
+    const stderr_summary = normalizeCommandDiagnostic(stderr, &stderr_buf);
+    if (stderr_summary.len > 0) {
+        recordProvisionErrorDetail("command timed out after {d}s; stderr: {s}", .{ seconds, stderr_summary });
+    } else {
+        recordProvisionErrorDetail("command timed out after {d}s", .{seconds});
+    }
+}
+
+fn copyCommandOutput(destination: []u8, input: []const u8) usize {
+    const trimmed = std.mem.trim(u8, input, &std.ascii.whitespace);
+    const copy_len = @min(destination.len, trimmed.len);
+    @memcpy(destination[0..copy_len], trimmed[0..copy_len]);
+    return copy_len;
+}
+
+fn storeCommandDiagnostic(term: ?std.process.Child.Term, timeout_s: ?u32, stdout: []const u8, stderr: []const u8) void {
+    command_term = term;
+    command_timeout_s = timeout_s;
+    command_stdout_len = copyCommandOutput(&command_stdout_buf, stdout);
+    command_stderr_len = copyCommandOutput(&command_stderr_buf, stderr);
+}
+
+pub fn getCommandDiagnostic() ?CommandDiagnostic {
+    if (command_term == null and command_timeout_s == null and command_stdout_len == 0 and command_stderr_len == 0) return null;
+    return .{
+        .term = command_term,
+        .timeout_s = command_timeout_s,
+        .stdout = if (command_stdout_len > 0) command_stdout_buf[0..command_stdout_len] else null,
+        .stderr = if (command_stderr_len > 0) command_stderr_buf[0..command_stderr_len] else null,
+    };
+}
+
+pub fn snapshotCommandDiagnostic() CommandDiagnosticSnapshot {
+    var snapshot = CommandDiagnosticSnapshot{
+        .term = command_term,
+        .timeout_s = command_timeout_s,
+        .stdout_len = command_stdout_len,
+        .stderr_len = command_stderr_len,
+    };
+    @memcpy(snapshot.stdout[0..command_stdout_len], command_stdout_buf[0..command_stdout_len]);
+    @memcpy(snapshot.stderr[0..command_stderr_len], command_stderr_buf[0..command_stderr_len]);
+    return snapshot;
+}
+
+pub fn restoreCommandDiagnostic(snapshot: *const CommandDiagnosticSnapshot) void {
+    command_term = snapshot.term;
+    command_timeout_s = snapshot.timeout_s;
+    command_stdout_len = snapshot.stdout_len;
+    command_stderr_len = snapshot.stderr_len;
+    @memcpy(command_stdout_buf[0..command_stdout_len], snapshot.stdout[0..command_stdout_len]);
+    @memcpy(command_stderr_buf[0..command_stderr_len], snapshot.stderr[0..command_stderr_len]);
+}
+
+fn normalizeCommandDiagnostic(input: []const u8, output: []u8) []const u8 {
+    const trimmed = std.mem.trim(u8, input, &std.ascii.whitespace);
+    if (trimmed.len == 0 or output.len == 0) return "";
+
+    var output_len: usize = 0;
+    var pending_space = false;
+    var truncated = false;
+    for (trimmed) |byte| {
+        if (std.ascii.isWhitespace(byte)) {
+            pending_space = output_len > 0;
+            continue;
+        }
+
+        const required = @as(usize, @intFromBool(pending_space)) + 1;
+        const reserve: usize = if (output.len >= 3) 3 else 0;
+        if (output_len + required > output.len - reserve) {
+            truncated = true;
+            break;
+        }
+        if (pending_space) {
+            output[output_len] = ' ';
+            output_len += 1;
+            pending_space = false;
+        }
+        output[output_len] = byte;
+        output_len += 1;
+    }
+
+    if (truncated and output.len - output_len >= 3) {
+        @memcpy(output[output_len..][0..3], "...");
+        output_len += 3;
+    }
+    return output[0..output_len];
 }
 
 /// Capture a friendly summary of an mruby exception into the thread-local
@@ -66,6 +266,34 @@ pub fn recordProvisionException(mrb: *mruby.mrb_state, exc: mruby.mrb_value, pre
             break :blk provision_error_detail_buf[0..fallback.len];
         };
     provision_error_detail_len = written.len;
+    captureProvisionBacktrace(mrb, exc);
+}
+
+fn captureProvisionBacktrace(mrb: *mruby.mrb_state, exc: mruby.mrb_value) void {
+    provision_error_trace_len = 0;
+    const backtrace = switch (mruby.callProtected(mrb, exc, "backtrace", &.{})) {
+        .ok => |value| value,
+        .raised => return,
+    };
+    if (mruby.zig_mrb_array_p(backtrace) == 0) return;
+
+    const line_count: usize = @intCast(@max(mruby.mrb_ary_len(mrb, backtrace), 0));
+    for (0..@min(line_count, 32)) |index| {
+        const value = mruby.mrb_ary_ref(mrb, backtrace, @intCast(index));
+        if (mruby.zig_mrb_string_p(value) == 0) continue;
+        const line = std.mem.span(mruby.mrb_str_to_cstr(mrb, value));
+        const remaining = provision_error_trace_buf.len - provision_error_trace_len;
+        if (remaining <= 1) break;
+        const copy_len = @min(line.len, remaining - 1);
+        @memcpy(provision_error_trace_buf[provision_error_trace_len..][0..copy_len], line[0..copy_len]);
+        provision_error_trace_len += copy_len;
+        provision_error_trace_buf[provision_error_trace_len] = '\n';
+        provision_error_trace_len += 1;
+        if (copy_len < line.len) break;
+    }
+    if (provision_error_trace_len > 0 and provision_error_trace_buf[provision_error_trace_len - 1] == '\n') {
+        provision_error_trace_len -= 1;
+    }
 }
 
 /// Result of applying a resource

--- a/src/commands.zig
+++ b/src/commands.zig
@@ -4,6 +4,7 @@ pub const git_clone = @import("commands/git_clone.zig");
 pub const link = @import("commands/link.zig");
 pub const apply = @import("commands/apply.zig");
 pub const provision = @import("commands/provision.zig");
+pub const run = @import("commands/run.zig");
 pub const node_info = @import("commands/node_info.zig");
 pub const agent = @import("commands/agent.zig");
 pub const applescript = if (builtin.os.tag == .macos) @import("commands/applescript.zig") else struct {};

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -171,6 +171,20 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
         }
         break :blk "unknown";
     };
+    const phase: ?[]const u8 = blk: {
+        if (obj.get("phase")) |value| {
+            if (value != .string or value.string.len == 0) {
+                const detail = "'phase' field must be a non-empty string";
+                std.debug.print("[agent] {s}\n", .{detail});
+                if (callback_url) |cb| {
+                    sendCallback(allocator, cb, data, "error", "InvalidPhase", detail, null, endpoint, tls_auth);
+                }
+                return;
+            }
+            break :blk value.string;
+        }
+        break :blk null;
+    };
     // Extract params field as JSON string for data_bag injection
     const params_json: ?[]const u8 = blk: {
         if (obj.get("params")) |v| {
@@ -204,7 +218,7 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
     var prov_result = provision_cmd.runScript(allocator, url, .normal, params_json, secrets_json, .{
         .cert = if (use_tls_for_download) tls_auth.cert else null,
         .key = if (use_tls_for_download) tls_auth.key else null,
-    }) catch |err| {
+    }, phase) catch |err| {
         std.debug.print("[agent] provision failed: {}\n", .{err});
         if (callback_url) |cb| {
             sendCallback(allocator, cb, data, "error", @errorName(err), base_resource.getProvisionErrorDetail(), null, endpoint, tls_auth);
@@ -254,6 +268,9 @@ fn buildCallbackBody(allocator: std.mem.Allocator, event_data: []const u8, statu
             var res_obj: std.json.ObjectMap = .empty;
             try res_obj.put(aa, "type", .{ .string = rr.type_name });
             try res_obj.put(aa, "name", .{ .string = rr.name });
+            if (rr.phase) |phase_name| {
+                try res_obj.put(aa, "phase", .{ .string = phase_name });
+            }
             try res_obj.put(aa, "action", .{ .string = rr.action });
             try res_obj.put(aa, "updated", .{ .bool = rr.was_updated });
             if (rr.skipped) {
@@ -723,9 +740,10 @@ fn printHelp(reason: ?[]const u8) !void {
         \\                           connections are only detected by TCP keepalive / send errors.
         \\
         \\Task JSON Format:
-        \\  {"url": "https://r2.example.com/task.rb", "callback": "https://example.com/done", ...}
+        \\  {"url": "https://r2.example.com/task.rb", "phase": "deploy", "callback": "https://example.com/done", ...}
         \\
         \\  - url       (required) Provision script URL
+        \\  - phase     (optional) Execute only this provisioning phase
         \\  - callback  (optional) Callback URL for this task (overrides --callback)
         \\  - ...       All other fields are passed through to callback
         \\
@@ -752,10 +770,12 @@ test "buildCallbackBody with ProvisionResult" {
 
     const type1 = try allocator.dupe(u8, "file");
     const name1 = try allocator.dupe(u8, "/tmp/config");
+    const phase1 = try allocator.dupe(u8, "prepare");
     const action1 = try allocator.dupe(u8, "create");
     try resource_results.append(allocator, .{
         .type_name = type1,
         .name = name1,
+        .phase = phase1,
         .action = action1,
         .was_updated = true,
         .skipped = false,
@@ -802,6 +822,7 @@ test "buildCallbackBody with ProvisionResult" {
     try std.testing.expect(std.mem.indexOf(u8, body, "\"duration_ms\":142") != null);
     try std.testing.expect(std.mem.indexOf(u8, body, "\"resources\":[") != null);
     try std.testing.expect(std.mem.indexOf(u8, body, "\"/tmp/config\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"phase\":\"prepare\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, body, "\"skip_reason\":\"up to date\"") != null);
     // url, callback, and secrets should be removed
     try std.testing.expect(std.mem.indexOf(u8, body, "\"url\":") == null);
@@ -812,6 +833,7 @@ test "buildCallbackBody with ProvisionResult" {
     // Free the duped strings
     allocator.free(type1);
     allocator.free(name1);
+    allocator.free(phase1);
     allocator.free(action1);
     allocator.free(type2);
     allocator.free(name2);

--- a/src/commands/agent.zig
+++ b/src/commands/agent.zig
@@ -201,7 +201,7 @@ fn handleTaskJson(allocator: std.mem.Allocator, data: []const u8, default_callba
 
     // Only pass mTLS credentials if script URL matches agent endpoint origin
     const use_tls_for_download = originMatches(url, endpoint);
-    var prov_result = provision_cmd.runScript(allocator, url, false, params_json, secrets_json, .{
+    var prov_result = provision_cmd.runScript(allocator, url, .normal, params_json, secrets_json, .{
         .cert = if (use_tls_for_download) tls_auth.cert else null,
         .key = if (use_tls_for_download) tls_auth.key else null,
     }) catch |err| {

--- a/src/commands/common.zig
+++ b/src/commands/common.zig
@@ -1,0 +1,132 @@
+const std = @import("std");
+const http = @import("../http.zig");
+const global_io = @import("../global_io.zig");
+const logger = @import("../logger.zig");
+
+pub const TlsClientAuth = struct {
+    cert: ?[]const u8 = null,
+    key: ?[]const u8 = null,
+};
+
+pub const PROVISION_FETCH_TIMEOUT_S: u32 = 300;
+
+pub const BagArgs = struct {
+    data_bag: ?[]const u8 = null,
+    data_bag_url: ?[]const u8 = null,
+    secrets_bag: ?[]const u8 = null,
+    secrets_bag_url: ?[]const u8 = null,
+    client_cert: ?[]const u8 = null,
+    client_key: ?[]const u8 = null,
+};
+
+pub const ResolvedBags = struct {
+    allocator: std.mem.Allocator,
+    data_bag: ?[]const u8,
+    secrets_bag: ?[]const u8,
+    tls_auth: TlsClientAuth,
+    owned_data_bag: ?[]const u8 = null,
+    owned_secrets_bag: ?[]const u8 = null,
+
+    pub fn deinit(self: *ResolvedBags) void {
+        if (self.owned_data_bag) |value| self.allocator.free(value);
+        if (self.owned_secrets_bag) |value| self.allocator.free(value);
+        self.* = undefined;
+    }
+};
+
+pub fn parseOutputMode(output_mode: ?[]const u8) !bool {
+    if (output_mode) |mode| {
+        if (std.mem.eql(u8, mode, "plain")) return false;
+        if (std.mem.eql(u8, mode, "pretty")) return true;
+        std.debug.print("Invalid output mode: {s}\nValid modes: pretty, plain\n", .{mode});
+        return error.InvalidOutputMode;
+    }
+    return std.Io.File.stdout().isTty(global_io.io()) catch false;
+}
+
+/// Fetch JSON content from a URL, using optional mTLS credentials.
+/// Returns an owned response body.
+pub fn fetchJsonFromUrl(allocator: std.mem.Allocator, url: []const u8, tls_auth: TlsClientAuth) ![]const u8 {
+    _ = std.Uri.parse(url) catch |err| {
+        std.debug.print("Error: Invalid URL: {}\n", .{err});
+        return error.FetchFailed;
+    };
+
+    var url_buf: [512]u8 = undefined;
+    const display_url = http.maskUrlPassword(url, &url_buf);
+    std.debug.print("[fetch] Fetching JSON from {s}\n", .{display_url});
+
+    const config = http.Config{
+        .max_timeout_s = PROVISION_FETCH_TIMEOUT_S,
+        .client_cert = tls_auth.cert,
+        .client_key = tls_auth.key,
+    };
+    var client = http.Client.init(allocator, config) catch |err| {
+        std.debug.print("\nError: Failed to initialize HTTP client: {}\n", .{err});
+        return error.FetchFailed;
+    };
+    defer client.deinit();
+
+    const response = client.get(url, null) catch |err| {
+        std.debug.print("\nError: Failed to fetch JSON from URL: {}\n", .{err});
+        if (http.getLastError()) |detail| {
+            var detail_buf: [1024]u8 = undefined;
+            std.debug.print("  {s}\n", .{http.redactPassword(url, detail, &detail_buf)});
+        }
+        std.debug.print("URL: {s}\n", .{display_url});
+        return error.FetchFailed;
+    };
+    defer {
+        var mutable_response = response;
+        mutable_response.deinit();
+    }
+
+    if (response.status < 200 or response.status >= 300) {
+        std.debug.print("\nError: HTTP {d} when fetching JSON from {s}\n", .{ response.status, display_url });
+        return error.FetchFailed;
+    }
+    return allocator.dupe(u8, response.body) catch return error.FetchFailed;
+}
+
+pub fn resolveBags(allocator: std.mem.Allocator, args: BagArgs) !ResolvedBags {
+    if (args.data_bag != null and args.data_bag_url != null) {
+        std.debug.print("Error: --data-bag and --data-bag-url are mutually exclusive\n", .{});
+        return error.InvalidArguments;
+    }
+    if (args.secrets_bag != null and args.secrets_bag_url != null) {
+        std.debug.print("Error: --secrets-bag and --secrets-bag-url are mutually exclusive\n", .{});
+        return error.InvalidArguments;
+    }
+
+    const tls_auth = TlsClientAuth{ .cert = args.client_cert, .key = args.client_key };
+    try http.validateClientAuthFiles(tls_auth.cert, tls_auth.key);
+
+    var owned_data_bag: ?[]const u8 = null;
+    errdefer if (owned_data_bag) |value| allocator.free(value);
+    if (args.data_bag_url) |url| {
+        owned_data_bag = fetchJsonFromUrl(allocator, url, tls_auth) catch |err| {
+            std.debug.print("Failed to fetch data_bag from URL\n", .{});
+            if (logger.getLogPath()) |log_path| std.debug.print("Log file: {s}\n", .{log_path});
+            return err;
+        };
+    }
+
+    var owned_secrets_bag: ?[]const u8 = null;
+    errdefer if (owned_secrets_bag) |value| allocator.free(value);
+    if (args.secrets_bag_url) |url| {
+        owned_secrets_bag = fetchJsonFromUrl(allocator, url, tls_auth) catch |err| {
+            std.debug.print("Failed to fetch secrets_bag from URL\n", .{});
+            if (logger.getLogPath()) |log_path| std.debug.print("Log file: {s}\n", .{log_path});
+            return err;
+        };
+    }
+
+    return .{
+        .allocator = allocator,
+        .data_bag = owned_data_bag orelse args.data_bag,
+        .secrets_bag = owned_secrets_bag orelse args.secrets_bag,
+        .tls_auth = tls_auth,
+        .owned_data_bag = owned_data_bag,
+        .owned_secrets_bag = owned_secrets_bag,
+    };
+}

--- a/src/commands/common.zig
+++ b/src/commands/common.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const http = @import("../http.zig");
 const global_io = @import("../global_io.zig");
 const logger = @import("../logger.zig");
+const modern_display = @import("../modern_provision_display.zig");
 
 pub const TlsClientAuth = struct {
     cert: ?[]const u8 = null,
@@ -34,14 +35,14 @@ pub const ResolvedBags = struct {
     }
 };
 
-pub fn parseOutputMode(output_mode: ?[]const u8) !bool {
+pub fn parseOutputMode(output_mode: ?[]const u8) !modern_display.OutputMode {
     if (output_mode) |mode| {
-        if (std.mem.eql(u8, mode, "plain")) return false;
-        if (std.mem.eql(u8, mode, "pretty")) return true;
-        std.debug.print("Invalid output mode: {s}\nValid modes: pretty, plain\n", .{mode});
+        if (std.mem.eql(u8, mode, "normal") or std.mem.eql(u8, mode, "plain")) return .normal;
+        if (std.mem.eql(u8, mode, "compact") or std.mem.eql(u8, mode, "pretty")) return .compact;
+        std.debug.print("Invalid output mode: {s}\nValid modes: normal, compact\n", .{mode});
         return error.InvalidOutputMode;
     }
-    return std.Io.File.stdout().isTty(global_io.io()) catch false;
+    return .normal;
 }
 
 /// Fetch JSON content from a URL, using optional mTLS credentials.
@@ -129,4 +130,13 @@ pub fn resolveBags(allocator: std.mem.Allocator, args: BagArgs) !ResolvedBags {
         .owned_data_bag = owned_data_bag,
         .owned_secrets_bag = owned_secrets_bag,
     };
+}
+
+test "output mode defaults to normal and keeps legacy aliases" {
+    try std.testing.expectEqual(modern_display.OutputMode.normal, try parseOutputMode(null));
+    try std.testing.expectEqual(modern_display.OutputMode.normal, try parseOutputMode("normal"));
+    try std.testing.expectEqual(modern_display.OutputMode.normal, try parseOutputMode("plain"));
+    try std.testing.expectEqual(modern_display.OutputMode.compact, try parseOutputMode("compact"));
+    try std.testing.expectEqual(modern_display.OutputMode.compact, try parseOutputMode("pretty"));
+    try std.testing.expectError(error.InvalidOutputMode, parseOutputMode("verbose"));
 }

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -3,6 +3,7 @@ const clap = @import("clap");
 const provision = @import("../provision.zig");
 const http = @import("../http.zig");
 const global_io = @import("../global_io.zig");
+const common = @import("common.zig");
 
 const params = clap.parseParamsComptime(
     \\-h, --help            Show help for provision
@@ -28,58 +29,7 @@ const parsers = .{
 /// Download a remote script to a temp file, run provision, then clean up.
 /// Accepts both local paths and HTTP(S) URLs.
 /// params_json: optional JSON string to inject as data_bag (agent mode).
-const TlsClientAuth = struct {
-    cert: ?[]const u8 = null,
-    key: ?[]const u8 = null,
-};
-
-const PROVISION_FETCH_TIMEOUT_S: u32 = 300;
-
-/// Fetch JSON content from a URL, using optional mTLS credentials.
-/// Returns the response body as an owned slice that the caller must free.
-fn fetchJsonFromUrl(allocator: std.mem.Allocator, url: []const u8, tls_auth: TlsClientAuth) ![]const u8 {
-    _ = std.Uri.parse(url) catch |err| {
-        std.debug.print("Error: Invalid URL: {}\n", .{err});
-        return error.FetchFailed;
-    };
-
-    var url_buf: [512]u8 = undefined;
-    const display_url = http.maskUrlPassword(url, &url_buf);
-
-    std.debug.print("[fetch] Fetching JSON from {s}\n", .{display_url});
-
-    const cfg = http.Config{
-        .max_timeout_s = PROVISION_FETCH_TIMEOUT_S,
-        .client_cert = tls_auth.cert,
-        .client_key = tls_auth.key,
-    };
-    var client = http.Client.init(allocator, cfg) catch |err| {
-        std.debug.print("\nError: Failed to initialize HTTP client: {}\n", .{err});
-        return error.FetchFailed;
-    };
-    defer client.deinit();
-
-    const response = client.get(url, null) catch |err| {
-        std.debug.print("\nError: Failed to fetch JSON from URL: {}\n", .{err});
-        if (http.getLastError()) |detail| {
-            var detail_buf: [1024]u8 = undefined;
-            std.debug.print("  {s}\n", .{http.redactPassword(url, detail, &detail_buf)});
-        }
-        std.debug.print("URL: {s}\n", .{display_url});
-        return error.FetchFailed;
-    };
-    defer {
-        var mut_resp = response;
-        mut_resp.deinit();
-    }
-
-    if (response.status < 200 or response.status >= 300) {
-        std.debug.print("\nError: HTTP {d} when fetching JSON from {s}\n", .{ response.status, display_url });
-        return error.FetchFailed;
-    }
-
-    return allocator.dupe(u8, response.body) catch return error.FetchFailed;
-}
+pub const TlsClientAuth = common.TlsClientAuth;
 
 pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, use_pretty_output: bool, params_json: ?[]const u8, secrets_json: ?[]const u8, tls_auth: TlsClientAuth) !provision.ProvisionResult {
     const is_url = std.mem.startsWith(u8, script_path_or_url, "http://") or
@@ -115,7 +65,7 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, u
         temp_file_path = temp_file;
 
         const cfg = http.Config{
-            .max_timeout_s = PROVISION_FETCH_TIMEOUT_S,
+            .max_timeout_s = common.PROVISION_FETCH_TIMEOUT_S,
             .client_cert = tls_auth.cert,
             .client_key = tls_auth.key,
         };
@@ -188,70 +138,19 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void
 
     const script_path_or_url = res.positionals[0] orelse return printHelp("Missing provision file path or URL.");
 
-    var use_pretty_output = std.Io.File.stdout().isTty(global_io.io()) catch false;
-    if (res.args.output) |output_mode| {
-        if (std.mem.eql(u8, output_mode, "plain")) {
-            use_pretty_output = false;
-        } else if (std.mem.eql(u8, output_mode, "pretty")) {
-            use_pretty_output = true;
-        } else {
-            std.debug.print("Invalid output mode: {s}\n", .{output_mode});
-            std.debug.print("Valid modes: pretty, plain\n", .{});
-            return error.InvalidOutputMode;
-        }
-    }
-
-    // Validate mutual exclusivity
-    if (res.args.@"data-bag" != null and res.args.@"data-bag-url" != null) {
-        std.debug.print("Error: --data-bag and --data-bag-url are mutually exclusive\n", .{});
-        return error.InvalidArguments;
-    }
-    if (res.args.@"secrets-bag" != null and res.args.@"secrets-bag-url" != null) {
-        std.debug.print("Error: --secrets-bag and --secrets-bag-url are mutually exclusive\n", .{});
-        return error.InvalidArguments;
-    }
-
+    const use_pretty_output = try common.parseOutputMode(res.args.output);
     const logger = @import("../logger.zig");
-    const tls_auth = TlsClientAuth{
-        .cert = res.args.@"client-cert",
-        .key = res.args.@"client-key",
-    };
-    // Fail fast (with a specific reason) if cert/key aren't readable by us;
-    // libcurl would otherwise report only a generic "unable to set private
-    // key file" without distinguishing permission vs not-found. Message is
-    // already printed inside the helper.
-    http.validateClientAuthFiles(tls_auth.cert, tls_auth.key) catch std.process.exit(1);
+    var bags = try common.resolveBags(allocator, .{
+        .data_bag = res.args.@"data-bag",
+        .data_bag_url = res.args.@"data-bag-url",
+        .secrets_bag = res.args.@"secrets-bag",
+        .secrets_bag_url = res.args.@"secrets-bag-url",
+        .client_cert = res.args.@"client-cert",
+        .client_key = res.args.@"client-key",
+    });
+    defer bags.deinit();
 
-    // Resolve data_bag: from URL or inline JSON
-    var fetched_data_bag: ?[]const u8 = null;
-    defer if (fetched_data_bag) |p| allocator.free(p);
-    if (res.args.@"data-bag-url") |url| {
-        fetched_data_bag = fetchJsonFromUrl(allocator, url, tls_auth) catch {
-            std.debug.print("Failed to fetch data_bag from URL\n", .{});
-            if (logger.getLogPath()) |log_path| {
-                std.debug.print("Log file: {s}\n", .{log_path});
-            }
-            return error.FetchFailed;
-        };
-    }
-
-    // Resolve secrets_bag: from URL or inline JSON
-    var fetched_secrets_bag: ?[]const u8 = null;
-    defer if (fetched_secrets_bag) |s| allocator.free(s);
-    if (res.args.@"secrets-bag-url") |url| {
-        fetched_secrets_bag = fetchJsonFromUrl(allocator, url, tls_auth) catch {
-            std.debug.print("Failed to fetch secrets_bag from URL\n", .{});
-            if (logger.getLogPath()) |log_path| {
-                std.debug.print("Log file: {s}\n", .{log_path});
-            }
-            return error.FetchFailed;
-        };
-    }
-
-    const effective_data_bag = fetched_data_bag orelse res.args.@"data-bag";
-    const effective_secrets_bag = fetched_secrets_bag orelse res.args.@"secrets-bag";
-
-    var result = runScript(allocator, script_path_or_url, use_pretty_output, effective_data_bag, effective_secrets_bag, tls_auth) catch |err| {
+    var result = runScript(allocator, script_path_or_url, use_pretty_output, bags.data_bag, bags.secrets_bag, bags.tls_auth) catch |err| {
         if (err == error.MRubyException) {
             if (logger.getLogPath()) |log_path| {
                 std.debug.print("\nLog file: {s}\n", .{log_path});

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -1,13 +1,15 @@
 const std = @import("std");
 const clap = @import("clap");
 const provision = @import("../provision.zig");
+const modern_display = @import("../modern_provision_display.zig");
 const http = @import("../http.zig");
 const global_io = @import("../global_io.zig");
 const common = @import("common.zig");
+const base_resource = @import("../base_resource.zig");
 
 const params = clap.parseParamsComptime(
     \\-h, --help            Show help for provision
-    \\-o, --output <MODE>   Output mode: pretty or plain (auto-detect: pretty if TTY)
+    \\-o, --output <MODE>   Output mode: normal (default) or compact
     \\    --data-bag <JSON>        JSON string to inject as data_bag
     \\    --data-bag-url <URL>     Fetch data_bag JSON from URL
     \\    --secrets-bag <JSON>     JSON string to inject as secrets_bag
@@ -31,7 +33,7 @@ const parsers = .{
 /// params_json: optional JSON string to inject as data_bag (agent mode).
 pub const TlsClientAuth = common.TlsClientAuth;
 
-pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, use_pretty_output: bool, params_json: ?[]const u8, secrets_json: ?[]const u8, tls_auth: TlsClientAuth) !provision.ProvisionResult {
+pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, output_mode: modern_display.OutputMode, params_json: ?[]const u8, secrets_json: ?[]const u8, tls_auth: TlsClientAuth) !provision.ProvisionResult {
     const is_url = std.mem.startsWith(u8, script_path_or_url, "http://") or
         std.mem.startsWith(u8, script_path_or_url, "https://");
 
@@ -117,7 +119,7 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, u
 
     return try provision.run(allocator, .{
         .script_path = script_path,
-        .use_pretty_output = use_pretty_output,
+        .output_mode = output_mode,
         .params_json = params_json,
         .secrets_json = secrets_json,
     });
@@ -138,7 +140,7 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void
 
     const script_path_or_url = res.positionals[0] orelse return printHelp("Missing provision file path or URL.");
 
-    const use_pretty_output = try common.parseOutputMode(res.args.output);
+    const output_mode = try common.parseOutputMode(res.args.output);
     const logger = @import("../logger.zig");
     var bags = try common.resolveBags(allocator, .{
         .data_bag = res.args.@"data-bag",
@@ -150,14 +152,14 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void
     });
     defer bags.deinit();
 
-    var result = runScript(allocator, script_path_or_url, use_pretty_output, bags.data_bag, bags.secrets_bag, bags.tls_auth) catch |err| {
+    var result = runScript(allocator, script_path_or_url, output_mode, bags.data_bag, bags.secrets_bag, bags.tls_auth) catch |err| {
         if (err == error.MRubyException) {
             if (logger.getLogPath()) |log_path| {
                 std.debug.print("\nLog file: {s}\n", .{log_path});
             }
             std.process.exit(1);
         }
-        std.debug.print("Provision failed: {}\n", .{err});
+        std.debug.print("Provision failed: {s}\n", .{base_resource.userFacingError(err)});
         if (logger.getLogPath()) |log_path| {
             std.debug.print("Log file: {s}\n", .{log_path});
         }
@@ -181,7 +183,7 @@ fn printHelp(reason: ?[]const u8) !void {
         \\Supports both local files and remote URLs.
         \\
         \\Options:
-        \\  -o, --output MODE          Output mode: pretty or plain (auto-detect: pretty if TTY)
+        \\  -o, --output MODE          Output mode: normal (default) or compact
         \\      --data-bag JSON        JSON string to inject as data_bag
         \\      --data-bag-url URL     Fetch data_bag JSON from URL
         \\      --secrets-bag JSON     JSON string to inject as secrets_bag
@@ -208,7 +210,7 @@ fn printHelp(reason: ?[]const u8) !void {
         \\    --client-cert cert.pem --client-key key.pem provision.rb
         \\
         \\  # With output mode
-        \\  hola provision --output plain provision.rb
+        \\  hola provision --output compact provision.rb
         \\
         \\Ruby DSL:
         \\  file \"/tmp/config\" do

--- a/src/commands/provision.zig
+++ b/src/commands/provision.zig
@@ -10,6 +10,7 @@ const base_resource = @import("../base_resource.zig");
 const params = clap.parseParamsComptime(
     \\-h, --help            Show help for provision
     \\-o, --output <MODE>   Output mode: normal (default) or compact
+    \\    --phase <NAME>     Execute only the named phase
     \\    --data-bag <JSON>        JSON string to inject as data_bag
     \\    --data-bag-url <URL>     Fetch data_bag JSON from URL
     \\    --secrets-bag <JSON>     JSON string to inject as secrets_bag
@@ -23,6 +24,7 @@ const params = clap.parseParamsComptime(
 const parsers = .{
     .path = clap.parsers.string,
     .MODE = clap.parsers.string,
+    .NAME = clap.parsers.string,
     .JSON = clap.parsers.string,
     .PATH = clap.parsers.string,
     .URL = clap.parsers.string,
@@ -33,7 +35,7 @@ const parsers = .{
 /// params_json: optional JSON string to inject as data_bag (agent mode).
 pub const TlsClientAuth = common.TlsClientAuth;
 
-pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, output_mode: modern_display.OutputMode, params_json: ?[]const u8, secrets_json: ?[]const u8, tls_auth: TlsClientAuth) !provision.ProvisionResult {
+pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, output_mode: modern_display.OutputMode, params_json: ?[]const u8, secrets_json: ?[]const u8, tls_auth: TlsClientAuth, phase: ?[]const u8) !provision.ProvisionResult {
     const is_url = std.mem.startsWith(u8, script_path_or_url, "http://") or
         std.mem.startsWith(u8, script_path_or_url, "https://");
 
@@ -120,6 +122,7 @@ pub fn runScript(allocator: std.mem.Allocator, script_path_or_url: []const u8, o
     return try provision.run(allocator, .{
         .script_path = script_path,
         .output_mode = output_mode,
+        .phase = phase,
         .params_json = params_json,
         .secrets_json = secrets_json,
     });
@@ -152,7 +155,8 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void
     });
     defer bags.deinit();
 
-    var result = runScript(allocator, script_path_or_url, output_mode, bags.data_bag, bags.secrets_bag, bags.tls_auth) catch |err| {
+    var result = runScript(allocator, script_path_or_url, output_mode, bags.data_bag, bags.secrets_bag, bags.tls_auth, res.args.phase) catch |err| {
+        if (err == error.UnknownPhase) std.process.exit(1);
         if (err == error.MRubyException) {
             if (logger.getLogPath()) |log_path| {
                 std.debug.print("\nLog file: {s}\n", .{log_path});
@@ -184,6 +188,7 @@ fn printHelp(reason: ?[]const u8) !void {
         \\
         \\Options:
         \\  -o, --output MODE          Output mode: normal (default) or compact
+        \\      --phase NAME           Execute only the named phase
         \\      --data-bag JSON        JSON string to inject as data_bag
         \\      --data-bag-url URL     Fetch data_bag JSON from URL
         \\      --secrets-bag JSON     JSON string to inject as secrets_bag
@@ -211,6 +216,7 @@ fn printHelp(reason: ?[]const u8) !void {
         \\
         \\  # With output mode
         \\  hola provision --output compact provision.rb
+        \\  hola provision --phase deploy scripts/deploy.rb
         \\
         \\Ruby DSL:
         \\  file \"/tmp/config\" do

--- a/src/commands/run.zig
+++ b/src/commands/run.zig
@@ -304,6 +304,7 @@ fn printHelp() !void {
         \\Examples:
         \\  hola run
         \\  hola run build
+        \\  hola run app:prepare        # Phase imported by the Holafile
         \\  hola run "db:migrate[production]"
         \\  hola build                 # implicit task fallback
         \\
@@ -311,6 +312,7 @@ fn printHelp() !void {
         \\  Top-level file and directory use standard Rake semantics. Enter the
         \\  resource DSL with resources.<name> or a resources do ... end block.
         \\  The stable underlying API is Hola::Resources.<name>.
+        \\  import_phases "recipe.rb", :as => :app exposes recipe phases as tasks.
         \\  file_task remains available as a compatibility alias for file.
         \\  Dir.glob, FileList, suffix rules, local require/require_relative, and
         \\  rake/clean are supported. Regexp, native gems, backticks, exit, and the

--- a/src/commands/run.zig
+++ b/src/commands/run.zig
@@ -14,7 +14,7 @@ const params = clap.parseParamsComptime(
     \\-P, --prerequisites          Show task prerequisites
     \\-n, --dry-run                Show tasks without executing actions
     \\-t, --trace                  Trace task invocation and execution
-    \\-o, --output <MODE>          Output mode: pretty or plain
+    \\-o, --output <MODE>          Output mode: normal (default) or compact
     \\    --data-bag <JSON>        JSON string to inject as data_bag
     \\    --data-bag-url <URL>     Fetch data_bag JSON from URL
     \\    --secrets-bag <JSON>     JSON string to inject as secrets_bag
@@ -143,7 +143,7 @@ fn fromParsed(parsed: anytype) RunArgs {
 
 fn runWithArgs(allocator: std.mem.Allocator, args: RunArgs, leading_task: ?[]const u8) !u8 {
     const io = global_io.io();
-    const use_pretty_output = try common.parseOutputMode(args.output);
+    const output_mode = try common.parseOutputMode(args.output);
     var bags = try common.resolveBags(allocator, .{
         .data_bag = args.data_bag,
         .data_bag_url = args.data_bag_url,
@@ -192,7 +192,7 @@ fn runWithArgs(allocator: std.mem.Allocator, args: RunArgs, leading_task: ?[]con
     session.mrb.setGlobal("$hola_run_prerequisites", if (args.list_prerequisites) mruby.zig_mrb_true_value() else mruby.zig_mrb_false_value());
     session.mrb.setGlobal("$hola_run_dry", if (args.dry_run) mruby.zig_mrb_true_value() else mruby.zig_mrb_false_value());
     session.mrb.setGlobal("$hola_run_trace", if (args.trace) mruby.zig_mrb_true_value() else mruby.zig_mrb_false_value());
-    session.mrb.setGlobal("$hola_run_pretty", if (use_pretty_output) mruby.zig_mrb_true_value() else mruby.zig_mrb_false_value());
+    session.mrb.setGlobal("$hola_run_pretty", if (output_mode == .compact) mruby.zig_mrb_true_value() else mruby.zig_mrb_false_value());
     session.mrb.setGlobal("$hola_run_capture_output", if (!args.list_tasks and !args.list_prerequisites) mruby.zig_mrb_true_value() else mruby.zig_mrb_false_value());
     try session.loadTaskPrelude();
 
@@ -202,7 +202,7 @@ fn runWithArgs(allocator: std.mem.Allocator, args: RunArgs, leading_task: ?[]con
 
     var display: ?modern_display.ModernProvisionDisplay = null;
     if (!args.list_tasks and !args.list_prerequisites) {
-        display = try modern_display.ModernProvisionDisplay.init(allocator, use_pretty_output);
+        display = try modern_display.ModernProvisionDisplay.init(allocator, output_mode);
         session.runner.attachDisplay(&display.?);
         display.?.setTotalResources(0);
         session.runner.start_time = std.Io.Timestamp.now(io, .real).toNanoseconds();
@@ -293,7 +293,7 @@ fn printHelp() !void {
         \\  -P, --prerequisites  Show task prerequisites
         \\  -n, --dry-run        Trace tasks without executing their actions
         \\  -t, --trace          Trace task invocation and execution
-        \\  -o, --output MODE    Output mode: pretty or plain
+        \\  -o, --output MODE    Output mode: normal (default) or compact
         \\      --data-bag JSON        Inject data_bag JSON
         \\      --data-bag-url URL     Fetch data_bag JSON
         \\      --secrets-bag JSON     Inject secrets_bag JSON

--- a/src/commands/run.zig
+++ b/src/commands/run.zig
@@ -8,7 +8,8 @@ const mruby = @import("../mruby.zig");
 
 const params = clap.parseParamsComptime(
     \\-h, --help                   Show help for run
-    \\-f, --rakefile <PATH>        Use PATH as the Rakefile
+    \\-f, --holafile <PATH>        Use PATH as the Holafile
+    \\    --rakefile <PATH>        Legacy alias for --holafile
     \\-T, --tasks                  List described tasks
     \\-P, --prerequisites          Show task prerequisites
     \\-n, --dry-run                Show tasks without executing actions
@@ -32,13 +33,24 @@ const parsers = .{
     .task = clap.parsers.string,
 };
 
-pub const RAKEFILE_NAMES = [_][]const u8{ "Rakefile", "rakefile", "Rakefile.rb", "rakefile.rb" };
-pub const RunError = error{ NoRakefile, TaskFailed };
+pub const TASKFILE_NAMES = [_]struct {
+    name: []const u8,
+    legacy: bool,
+}{
+    .{ .name = "Holafile", .legacy = false },
+    .{ .name = "holafile.rb", .legacy = false },
+    .{ .name = "Rakefile", .legacy = true },
+    .{ .name = "rakefile", .legacy = true },
+    .{ .name = "Rakefile.rb", .legacy = true },
+    .{ .name = "rakefile.rb", .legacy = true },
+};
+pub const RunError = error{ NoTaskFile, TaskFailed };
 
 pub const Located = struct {
     allocator: std.mem.Allocator,
     dir: []const u8,
     path: []const u8,
+    legacy: bool,
 
     pub fn deinit(self: *Located) void {
         self.allocator.free(self.dir);
@@ -48,7 +60,7 @@ pub const Located = struct {
 };
 
 const RunArgs = struct {
-    rakefile: ?[]const u8,
+    task_file: ?[]const u8,
     list_tasks: bool,
     list_prerequisites: bool,
     dry_run: bool,
@@ -77,8 +89,8 @@ pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void
     if (parsed.args.help != 0) return printHelp();
     const args = fromParsed(parsed);
     const exit_code = runWithArgs(allocator, args, null) catch |err| switch (err) {
-        error.NoRakefile => blk: {
-            printNoRakefile();
+        error.NoTaskFile => blk: {
+            printNoTaskFile();
             break :blk @as(u8, 1);
         },
         else => return err,
@@ -102,7 +114,7 @@ pub fn runImplicit(allocator: std.mem.Allocator, first_task: []const u8, iter: *
         return;
     }
     const exit_code = runWithArgs(allocator, fromParsed(parsed), first_task) catch |err| switch (err) {
-        error.NoRakefile => return error.NoRakefile,
+        error.NoTaskFile => return error.NoTaskFile,
         else => {
             std.debug.print("hola run failed: {}\n", .{err});
             return error.TaskFailed;
@@ -113,7 +125,7 @@ pub fn runImplicit(allocator: std.mem.Allocator, first_task: []const u8, iter: *
 
 fn fromParsed(parsed: anytype) RunArgs {
     return .{
-        .rakefile = parsed.args.rakefile,
+        .task_file = parsed.args.holafile orelse parsed.args.rakefile,
         .list_tasks = parsed.args.tasks != 0,
         .list_prerequisites = parsed.args.prerequisites != 0,
         .dry_run = parsed.args.@"dry-run" != 0,
@@ -145,8 +157,8 @@ fn runWithArgs(allocator: std.mem.Allocator, args: RunArgs, leading_task: ?[]con
     const original_cwd = try std.Io.Dir.cwd().realPathFileAlloc(io, ".", allocator);
     defer allocator.free(original_cwd);
 
-    var located = if (args.rakefile) |rakefile| blk: {
-        const canonical_path = try std.Io.Dir.cwd().realPathFileAlloc(io, rakefile, allocator);
+    var located = if (args.task_file) |task_file| blk: {
+        const canonical_path = try std.Io.Dir.cwd().realPathFileAlloc(io, task_file, allocator);
         defer allocator.free(canonical_path);
         const path = try allocator.dupe(u8, canonical_path);
         errdefer allocator.free(path);
@@ -155,9 +167,14 @@ fn runWithArgs(allocator: std.mem.Allocator, args: RunArgs, leading_task: ?[]con
             .allocator = allocator,
             .dir = try allocator.dupe(u8, parent),
             .path = path,
+            .legacy = false,
         };
-    } else (try findRakefile(allocator, io, original_cwd)) orelse return error.NoRakefile;
+    } else (try findTaskFile(allocator, io, original_cwd)) orelse return error.NoTaskFile;
     defer located.deinit();
+
+    if (args.task_file == null and located.legacy) {
+        printLegacyTaskFileWarning(std.fs.path.basename(located.path));
+    }
 
     try std.Io.Threaded.chdir(located.dir);
     if (!std.mem.eql(u8, original_cwd, located.dir)) {
@@ -181,7 +198,7 @@ fn runWithArgs(allocator: std.mem.Allocator, args: RunArgs, leading_task: ?[]con
 
     const argv = mrubyArgv(mrb, allocator, leading_task, args.tasks);
     session.mrb.setGlobal("$hola_run_argv", argv);
-    session.mrb.setGlobal("$hola_rakefile", mruby.mrb_str_new(mrb, located.path.ptr, @intCast(located.path.len)));
+    session.mrb.setGlobal("$hola_taskfile", mruby.mrb_str_new(mrb, located.path.ptr, @intCast(located.path.len)));
 
     var display: ?modern_display.ModernProvisionDisplay = null;
     if (!args.list_tasks and !args.list_prerequisites) {
@@ -197,7 +214,7 @@ fn runWithArgs(allocator: std.mem.Allocator, args: RunArgs, leading_task: ?[]con
     };
 
     session.evalScript(located.path) catch {
-        std.debug.print("rake aborted!\nFailed to load {s}\n", .{located.path});
+        std.debug.print("hola aborted!\nFailed to load {s}\n", .{located.path});
         return 1;
     };
     session.evalString("Hola::Rake.main") catch return 1;
@@ -224,18 +241,23 @@ fn mrubyArgv(mrb: *mruby.mrb_state, allocator: std.mem.Allocator, leading_task: 
     return argv;
 }
 
-pub fn findRakefile(allocator: std.mem.Allocator, io: std.Io, start_dir: []const u8) !?Located {
+pub fn findTaskFile(allocator: std.mem.Allocator, io: std.Io, start_dir: []const u8) !?Located {
     var current = try allocator.dupe(u8, start_dir);
     errdefer allocator.free(current);
 
     while (true) {
-        for (RAKEFILE_NAMES) |name| {
-            const candidate = try std.fs.path.join(allocator, &.{ current, name });
+        for (TASKFILE_NAMES) |task_file| {
+            const candidate = try std.fs.path.join(allocator, &.{ current, task_file.name });
             std.Io.Dir.cwd().access(io, candidate, .{}) catch {
                 allocator.free(candidate);
                 continue;
             };
-            return .{ .allocator = allocator, .dir = current, .path = candidate };
+            return .{
+                .allocator = allocator,
+                .dir = current,
+                .path = candidate,
+                .legacy = task_file.legacy,
+            };
         }
 
         const parent = std.fs.path.dirname(current) orelse break;
@@ -248,8 +270,12 @@ pub fn findRakefile(allocator: std.mem.Allocator, io: std.Io, start_dir: []const
     return null;
 }
 
-fn printNoRakefile() void {
-    std.debug.print("No Rakefile found (looking for: Rakefile, rakefile, Rakefile.rb, rakefile.rb)\n", .{});
+fn printNoTaskFile() void {
+    std.debug.print("No Holafile found (looking for: Holafile, holafile.rb; legacy: Rakefile, rakefile, Rakefile.rb, rakefile.rb)\n", .{});
+}
+
+fn printLegacyTaskFileWarning(name: []const u8) void {
+    std.debug.print("warning: using legacy {s}; rename it to Holafile (Hola's task DSL is Rake-inspired, not Rake-compatible)\n", .{name});
 }
 
 fn printHelp() !void {
@@ -257,11 +283,12 @@ fn printHelp() !void {
         \\run
         \\  hola run [OPTIONS] [TASK[ARGS] ...]
         \\
-        \\Run Rake-compatible tasks backed by hola resources and embedded mruby.
+        \\Run Rake-inspired tasks backed by hola resources and embedded mruby.
         \\
         \\Options:
         \\  -h, --help           Show this help
-        \\  -f, --rakefile PATH  Use an explicit Rakefile
+        \\  -f, --holafile PATH  Use an explicit Holafile
+        \\      --rakefile PATH  Legacy alias for --holafile
         \\  -T, --tasks          List tasks with descriptions
         \\  -P, --prerequisites  Show task prerequisites
         \\  -n, --dry-run        Trace tasks without executing their actions
@@ -291,18 +318,51 @@ fn printHelp() !void {
     );
 }
 
-test "findRakefile searches parent directories in precedence order" {
+test "findTaskFile prefers Holafile while searching parent directories" {
     const allocator = std.testing.allocator;
     const io = global_io.io();
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try tmp.dir.createDir(io, "project", .default_dir);
     try tmp.dir.createDir(io, "project/nested", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "project/Holafile", .data = "task :default" });
     try tmp.dir.writeFile(io, .{ .sub_path = "project/Rakefile", .data = "task :default" });
     const nested = try tmp.dir.realPathFileAlloc(io, "project/nested", allocator);
     defer allocator.free(nested);
 
-    var located = (try findRakefile(allocator, io, nested)) orelse return error.TestExpectedRakefile;
+    var located = (try findTaskFile(allocator, io, nested)) orelse return error.TestExpectedHolafile;
     defer located.deinit();
-    try std.testing.expect(std.mem.endsWith(u8, located.path, "/project/Rakefile"));
+    try std.testing.expect(std.mem.endsWith(u8, located.path, "/project/Holafile"));
+    try std.testing.expect(!located.legacy);
+
+    try tmp.dir.writeFile(io, .{ .sub_path = "project/nested/Rakefile", .data = "task :default" });
+    var nearest = (try findTaskFile(allocator, io, nested)) orelse return error.TestExpectedRakefile;
+    defer nearest.deinit();
+    try std.testing.expect(std.mem.endsWith(u8, nearest.path, "/project/nested/Rakefile"));
+    try std.testing.expect(nearest.legacy);
+}
+
+test "findTaskFile supports canonical and legacy fallback names" {
+    const allocator = std.testing.allocator;
+    const io = global_io.io();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(io, "canonical", .default_dir);
+    try tmp.dir.createDir(io, "legacy", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "canonical/holafile.rb", .data = "task :default" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "legacy/Rakefile.rb", .data = "task :default" });
+
+    const canonical_dir = try tmp.dir.realPathFileAlloc(io, "canonical", allocator);
+    defer allocator.free(canonical_dir);
+    var canonical = (try findTaskFile(allocator, io, canonical_dir)) orelse return error.TestExpectedHolafile;
+    defer canonical.deinit();
+    try std.testing.expect(std.mem.endsWith(u8, canonical.path, "/canonical/holafile.rb"));
+    try std.testing.expect(!canonical.legacy);
+
+    const legacy_dir = try tmp.dir.realPathFileAlloc(io, "legacy", allocator);
+    defer allocator.free(legacy_dir);
+    var legacy = (try findTaskFile(allocator, io, legacy_dir)) orelse return error.TestExpectedRakefile;
+    defer legacy.deinit();
+    try std.testing.expect(std.mem.endsWith(u8, legacy.path, "/legacy/Rakefile.rb"));
+    try std.testing.expect(legacy.legacy);
 }

--- a/src/commands/run.zig
+++ b/src/commands/run.zig
@@ -308,8 +308,9 @@ fn printHelp() !void {
         \\  hola build                 # implicit task fallback
         \\
         \\Compatibility notes:
-        \\  file and directory use standard Rake semantics in task mode. Hola's
-        \\  provision variants are Hola::Resources.file and .directory.
+        \\  Top-level file and directory use standard Rake semantics. Enter the
+        \\  resource DSL with resources.<name> or a resources do ... end block.
+        \\  The stable underlying API is Hola::Resources.<name>.
         \\  file_task remains available as a compatibility alias for file.
         \\  Dir.glob, FileList, suffix rules, local require/require_relative, and
         \\  rake/clean are supported. Regexp, native gems, backticks, exit, and the

--- a/src/commands/run.zig
+++ b/src/commands/run.zig
@@ -1,0 +1,308 @@
+const std = @import("std");
+const clap = @import("clap");
+const provision = @import("../provision.zig");
+const modern_display = @import("../modern_provision_display.zig");
+const global_io = @import("../global_io.zig");
+const common = @import("common.zig");
+const mruby = @import("../mruby.zig");
+
+const params = clap.parseParamsComptime(
+    \\-h, --help                   Show help for run
+    \\-f, --rakefile <PATH>        Use PATH as the Rakefile
+    \\-T, --tasks                  List described tasks
+    \\-P, --prerequisites          Show task prerequisites
+    \\-n, --dry-run                Show tasks without executing actions
+    \\-t, --trace                  Trace task invocation and execution
+    \\-o, --output <MODE>          Output mode: pretty or plain
+    \\    --data-bag <JSON>        JSON string to inject as data_bag
+    \\    --data-bag-url <URL>     Fetch data_bag JSON from URL
+    \\    --secrets-bag <JSON>     JSON string to inject as secrets_bag
+    \\    --secrets-bag-url <URL>  Fetch secrets_bag JSON from URL
+    \\    --client-cert <PATH>     Client certificate for mTLS
+    \\    --client-key <PATH>      Client private key for mTLS
+    \\<task>...
+    \\
+);
+
+const parsers = .{
+    .PATH = clap.parsers.string,
+    .MODE = clap.parsers.string,
+    .JSON = clap.parsers.string,
+    .URL = clap.parsers.string,
+    .task = clap.parsers.string,
+};
+
+pub const RAKEFILE_NAMES = [_][]const u8{ "Rakefile", "rakefile", "Rakefile.rb", "rakefile.rb" };
+pub const RunError = error{ NoRakefile, TaskFailed };
+
+pub const Located = struct {
+    allocator: std.mem.Allocator,
+    dir: []const u8,
+    path: []const u8,
+
+    pub fn deinit(self: *Located) void {
+        self.allocator.free(self.dir);
+        self.allocator.free(self.path);
+        self.* = undefined;
+    }
+};
+
+const RunArgs = struct {
+    rakefile: ?[]const u8,
+    list_tasks: bool,
+    list_prerequisites: bool,
+    dry_run: bool,
+    trace: bool,
+    output: ?[]const u8,
+    data_bag: ?[]const u8,
+    data_bag_url: ?[]const u8,
+    secrets_bag: ?[]const u8,
+    secrets_bag_url: ?[]const u8,
+    client_cert: ?[]const u8,
+    client_key: ?[]const u8,
+    tasks: []const []const u8,
+};
+
+pub fn run(allocator: std.mem.Allocator, iter: *std.process.Args.Iterator) !void {
+    var diag = clap.Diagnostic{};
+    var parsed = clap.parseEx(clap.Help, &params, parsers, iter, .{
+        .allocator = allocator,
+        .diagnostic = &diag,
+    }) catch |err| {
+        try diag.reportToFile(global_io.io(), std.Io.File.stderr(), err);
+        std.process.exit(1);
+    };
+    defer parsed.deinit();
+
+    if (parsed.args.help != 0) return printHelp();
+    const args = fromParsed(parsed);
+    const exit_code = runWithArgs(allocator, args, null) catch |err| switch (err) {
+        error.NoRakefile => blk: {
+            printNoRakefile();
+            break :blk @as(u8, 1);
+        },
+        else => return err,
+    };
+    if (exit_code != 0) std.process.exit(exit_code);
+}
+
+pub fn runImplicit(allocator: std.mem.Allocator, first_task: []const u8, iter: *std.process.Args.Iterator) RunError!void {
+    var diag = clap.Diagnostic{};
+    var parsed = clap.parseEx(clap.Help, &params, parsers, iter, .{
+        .allocator = allocator,
+        .diagnostic = &diag,
+    }) catch |err| {
+        diag.reportToFile(global_io.io(), std.Io.File.stderr(), err) catch {};
+        return error.TaskFailed;
+    };
+    defer parsed.deinit();
+
+    if (parsed.args.help != 0) {
+        printHelp() catch {};
+        return;
+    }
+    const exit_code = runWithArgs(allocator, fromParsed(parsed), first_task) catch |err| switch (err) {
+        error.NoRakefile => return error.NoRakefile,
+        else => {
+            std.debug.print("hola run failed: {}\n", .{err});
+            return error.TaskFailed;
+        },
+    };
+    if (exit_code != 0) return error.TaskFailed;
+}
+
+fn fromParsed(parsed: anytype) RunArgs {
+    return .{
+        .rakefile = parsed.args.rakefile,
+        .list_tasks = parsed.args.tasks != 0,
+        .list_prerequisites = parsed.args.prerequisites != 0,
+        .dry_run = parsed.args.@"dry-run" != 0,
+        .trace = parsed.args.trace != 0,
+        .output = parsed.args.output,
+        .data_bag = parsed.args.@"data-bag",
+        .data_bag_url = parsed.args.@"data-bag-url",
+        .secrets_bag = parsed.args.@"secrets-bag",
+        .secrets_bag_url = parsed.args.@"secrets-bag-url",
+        .client_cert = parsed.args.@"client-cert",
+        .client_key = parsed.args.@"client-key",
+        .tasks = parsed.positionals[0],
+    };
+}
+
+fn runWithArgs(allocator: std.mem.Allocator, args: RunArgs, leading_task: ?[]const u8) !u8 {
+    const io = global_io.io();
+    const use_pretty_output = try common.parseOutputMode(args.output);
+    var bags = try common.resolveBags(allocator, .{
+        .data_bag = args.data_bag,
+        .data_bag_url = args.data_bag_url,
+        .secrets_bag = args.secrets_bag,
+        .secrets_bag_url = args.secrets_bag_url,
+        .client_cert = args.client_cert,
+        .client_key = args.client_key,
+    });
+    defer bags.deinit();
+
+    const original_cwd = try std.Io.Dir.cwd().realPathFileAlloc(io, ".", allocator);
+    defer allocator.free(original_cwd);
+
+    var located = if (args.rakefile) |rakefile| blk: {
+        const canonical_path = try std.Io.Dir.cwd().realPathFileAlloc(io, rakefile, allocator);
+        defer allocator.free(canonical_path);
+        const path = try allocator.dupe(u8, canonical_path);
+        errdefer allocator.free(path);
+        const parent = std.fs.path.dirname(path) orelse original_cwd;
+        break :blk Located{
+            .allocator = allocator,
+            .dir = try allocator.dupe(u8, parent),
+            .path = path,
+        };
+    } else (try findRakefile(allocator, io, original_cwd)) orelse return error.NoRakefile;
+    defer located.deinit();
+
+    try std.Io.Threaded.chdir(located.dir);
+    if (!std.mem.eql(u8, original_cwd, located.dir)) {
+        std.debug.print("(in {s})\n", .{located.dir});
+    }
+
+    const session = try provision.Session.open(allocator, .{
+        .params_json = bags.data_bag,
+        .secrets_json = bags.secrets_bag,
+        .mode = .task,
+    });
+    defer session.close();
+    const mrb = session.mrb.mrb orelse return error.MRubyNotInitialized;
+    session.mrb.setGlobal("$hola_run_list", if (args.list_tasks) mruby.zig_mrb_true_value() else mruby.zig_mrb_false_value());
+    session.mrb.setGlobal("$hola_run_prerequisites", if (args.list_prerequisites) mruby.zig_mrb_true_value() else mruby.zig_mrb_false_value());
+    session.mrb.setGlobal("$hola_run_dry", if (args.dry_run) mruby.zig_mrb_true_value() else mruby.zig_mrb_false_value());
+    session.mrb.setGlobal("$hola_run_trace", if (args.trace) mruby.zig_mrb_true_value() else mruby.zig_mrb_false_value());
+    session.mrb.setGlobal("$hola_run_pretty", if (use_pretty_output) mruby.zig_mrb_true_value() else mruby.zig_mrb_false_value());
+    session.mrb.setGlobal("$hola_run_capture_output", if (!args.list_tasks and !args.list_prerequisites) mruby.zig_mrb_true_value() else mruby.zig_mrb_false_value());
+    try session.loadTaskPrelude();
+
+    const argv = mrubyArgv(mrb, allocator, leading_task, args.tasks);
+    session.mrb.setGlobal("$hola_run_argv", argv);
+    session.mrb.setGlobal("$hola_rakefile", mruby.mrb_str_new(mrb, located.path.ptr, @intCast(located.path.len)));
+
+    var display: ?modern_display.ModernProvisionDisplay = null;
+    if (!args.list_tasks and !args.list_prerequisites) {
+        display = try modern_display.ModernProvisionDisplay.init(allocator, use_pretty_output);
+        session.runner.attachDisplay(&display.?);
+        display.?.setTotalResources(0);
+        session.runner.start_time = std.Io.Timestamp.now(io, .real).toNanoseconds();
+        try display.?.startTimer(session.runner.start_time);
+    }
+    defer if (display) |*active_display| {
+        session.runner.detachDisplay();
+        active_display.deinit();
+    };
+
+    session.evalScript(located.path) catch {
+        std.debug.print("rake aborted!\nFailed to load {s}\n", .{located.path});
+        return 1;
+    };
+    session.evalString("Hola::Rake.main") catch return 1;
+
+    const status = session.mrb.getGlobal("$hola_run_status");
+    const exit_code: u8 = if (!mruby.mrb_test(status)) 1 else @intCast(mruby.mrb_fixnum(mrb, status));
+    if (display) |*active_display| {
+        if (exit_code != 0) active_display.markRunFailed();
+        try active_display.showTaskSummaryWithDuration(0, 0);
+    }
+    return exit_code;
+}
+
+fn mrubyArgv(mrb: *mruby.mrb_state, allocator: std.mem.Allocator, leading_task: ?[]const u8, tasks: []const []const u8) mruby.mrb_value {
+    _ = allocator;
+    const count = tasks.len + @intFromBool(leading_task != null);
+    const argv = mruby.mrb_ary_new_capa(mrb, @intCast(count));
+    if (leading_task) |task_name| {
+        mruby.mrb_ary_push(mrb, argv, mruby.mrb_str_new(mrb, task_name.ptr, @intCast(task_name.len)));
+    }
+    for (tasks) |task_name| {
+        mruby.mrb_ary_push(mrb, argv, mruby.mrb_str_new(mrb, task_name.ptr, @intCast(task_name.len)));
+    }
+    return argv;
+}
+
+pub fn findRakefile(allocator: std.mem.Allocator, io: std.Io, start_dir: []const u8) !?Located {
+    var current = try allocator.dupe(u8, start_dir);
+    errdefer allocator.free(current);
+
+    while (true) {
+        for (RAKEFILE_NAMES) |name| {
+            const candidate = try std.fs.path.join(allocator, &.{ current, name });
+            std.Io.Dir.cwd().access(io, candidate, .{}) catch {
+                allocator.free(candidate);
+                continue;
+            };
+            return .{ .allocator = allocator, .dir = current, .path = candidate };
+        }
+
+        const parent = std.fs.path.dirname(current) orelse break;
+        if (std.mem.eql(u8, parent, current)) break;
+        const next = try allocator.dupe(u8, parent);
+        allocator.free(current);
+        current = next;
+    }
+    allocator.free(current);
+    return null;
+}
+
+fn printNoRakefile() void {
+    std.debug.print("No Rakefile found (looking for: Rakefile, rakefile, Rakefile.rb, rakefile.rb)\n", .{});
+}
+
+fn printHelp() !void {
+    try std.Io.File.stdout().writeStreamingAll(global_io.io(),
+        \\run
+        \\  hola run [OPTIONS] [TASK[ARGS] ...]
+        \\
+        \\Run Rake-compatible tasks backed by hola resources and embedded mruby.
+        \\
+        \\Options:
+        \\  -h, --help           Show this help
+        \\  -f, --rakefile PATH  Use an explicit Rakefile
+        \\  -T, --tasks          List tasks with descriptions
+        \\  -P, --prerequisites  Show task prerequisites
+        \\  -n, --dry-run        Trace tasks without executing their actions
+        \\  -t, --trace          Trace task invocation and execution
+        \\  -o, --output MODE    Output mode: pretty or plain
+        \\      --data-bag JSON        Inject data_bag JSON
+        \\      --data-bag-url URL     Fetch data_bag JSON
+        \\      --secrets-bag JSON     Inject secrets_bag JSON
+        \\      --secrets-bag-url URL  Fetch secrets_bag JSON
+        \\      --client-cert PATH     Client certificate for mTLS bag URLs
+        \\      --client-key PATH      Client private key for mTLS bag URLs
+        \\
+        \\Examples:
+        \\  hola run
+        \\  hola run build
+        \\  hola run "db:migrate[production]"
+        \\  hola build                 # implicit task fallback
+        \\
+        \\Compatibility notes:
+        \\  file and directory use standard Rake semantics in task mode. Hola's
+        \\  provision variants are Hola::Resources.file and .directory.
+        \\  file_task remains available as a compatibility alias for file.
+        \\  Dir.glob, FileList, suffix rules, local require/require_relative, and
+        \\  rake/clean are supported. Regexp, native gems, backticks, exit, and the
+        \\  sh block form are not available in the embedded mruby runtime.
+        \\
+    );
+}
+
+test "findRakefile searches parent directories in precedence order" {
+    const allocator = std.testing.allocator;
+    const io = global_io.io();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(io, "project", .default_dir);
+    try tmp.dir.createDir(io, "project/nested", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "project/Rakefile", .data = "task :default" });
+    const nested = try tmp.dir.realPathFileAlloc(io, "project/nested", allocator);
+    defer allocator.free(nested);
+
+    var located = (try findRakefile(allocator, io, nested)) orelse return error.TestExpectedRakefile;
+    defer located.deinit();
+    try std.testing.expect(std.mem.endsWith(u8, located.path, "/project/Rakefile"));
+}

--- a/src/env_access.zig
+++ b/src/env_access.zig
@@ -69,6 +69,9 @@ pub fn zig_env_set(mrb: *mruby.mrb_state, _: mruby.mrb_value) callconv(.c) mruby
     if (result != 0) {
         return mruby.mrb_nil_value();
     }
+    if (global_io.environMap()) |map| {
+        map.put(key_ptr[0..@intCast(key_len)], value) catch return mruby.mrb_nil_value();
+    }
 
     return mruby.mrb_str_new(mrb, value.ptr, @intCast(value.len));
 }
@@ -92,6 +95,9 @@ pub fn zig_env_delete(mrb: *mruby.mrb_state, _: mruby.mrb_value) callconv(.c) mr
 
     // Unset environment variable using libc
     _ = c.unsetenv(key_z.ptr);
+    if (global_io.environMap()) |map| {
+        _ = map.swapRemove(key_ptr[0..@intCast(key_len)]);
+    }
 
     return mruby.mrb_nil_value();
 }

--- a/src/glob.zig
+++ b/src/glob.zig
@@ -26,6 +26,12 @@ fn matchRecursive(pattern: []const u8, text: []const u8) bool {
         if (pattern_idx + 1 < pattern.len and pattern[pattern_idx] == '*' and pattern[pattern_idx + 1] == '*') {
             pattern_idx += 2;
 
+            // A globstar followed by a separator may also match zero
+            // directories ("**/*.rb" matches "Rakefile.rb").
+            if (pattern_idx < pattern.len and pattern[pattern_idx] == '/') {
+                if (matchRecursive(pattern[pattern_idx + 1 ..], text[text_idx..])) return true;
+            }
+
             // ** at the end matches everything
             if (pattern_idx >= pattern.len) {
                 return true;
@@ -137,6 +143,56 @@ fn matchRecursive(pattern: []const u8, text: []const u8) bool {
     return pattern_idx >= pattern.len and text_idx >= text.len;
 }
 
+pub fn expand(allocator: std.mem.Allocator, io: std.Io, pattern: []const u8) !std.ArrayList([]const u8) {
+    var matches = std.ArrayList([]const u8).empty;
+    errdefer freeMatches(allocator, &matches);
+
+    const wildcard_index = std.mem.indexOfAny(u8, pattern, "*?[") orelse {
+        std.Io.Dir.cwd().access(io, pattern, .{}) catch return matches;
+        try matches.append(allocator, try allocator.dupe(u8, pattern));
+        return matches;
+    };
+
+    const root_slice = if (std.mem.lastIndexOfScalar(u8, pattern[0..wildcard_index], '/')) |separator|
+        if (separator == 0) "/" else pattern[0..separator]
+    else
+        ".";
+
+    var root = if (std.fs.path.isAbsolute(root_slice))
+        std.Io.Dir.openDirAbsolute(io, root_slice, .{ .iterate = true }) catch return matches
+    else
+        std.Io.Dir.cwd().openDir(io, root_slice, .{ .iterate = true }) catch return matches;
+    defer root.close(io);
+
+    var walker = try root.walk(allocator);
+    defer walker.deinit();
+    while (try walker.next(io)) |entry| {
+        const candidate = if (std.mem.eql(u8, root_slice, "."))
+            try allocator.dupe(u8, entry.path)
+        else
+            try std.fs.path.join(allocator, &.{ root_slice, entry.path });
+        if (match(pattern, candidate)) {
+            try matches.append(allocator, candidate);
+        } else {
+            allocator.free(candidate);
+        }
+    }
+
+    const Sort = struct {
+        fn lessThan(_: void, left: []const u8, right: []const u8) bool {
+            return std.mem.lessThan(u8, left, right);
+        }
+    };
+    std.mem.sort([]const u8, matches.items, {}, Sort.lessThan);
+    return matches;
+}
+
+pub fn freeMatches(allocator: std.mem.Allocator, matches: *std.ArrayList([]const u8)) void {
+    for (matches.items) |item| allocator.free(item);
+    matches.deinit(allocator);
+    matches.* = .empty;
+}
+
 test "glob matching" {
     try std.testing.expect(match("*.txt", "file.txt"));
     try std.testing.expect(match("*.txt", "test.txt"));
@@ -144,6 +200,7 @@ test "glob matching" {
     try std.testing.expect(!match("*.txt", "dir/file.txt"));
 
     try std.testing.expect(match("**/*.txt", "dir/file.txt"));
+    try std.testing.expect(match("**/*.txt", "file.txt"));
     try std.testing.expect(match("**/*.txt", "a/b/c/file.txt"));
     try std.testing.expect(match("**", "any/path/here"));
 
@@ -164,4 +221,26 @@ test "glob matching" {
     try std.testing.expect(match(".git*", ".git"));
     try std.testing.expect(match(".git*", ".gitignore"));
     try std.testing.expect(match(".git*", ".github"));
+}
+
+test "glob expansion walks recursively and returns sorted matches" {
+    const allocator = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDir(io, "nested", .default_dir);
+    try tmp.dir.writeFile(io, .{ .sub_path = "root.rb", .data = "" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "nested/child.rb", .data = "" });
+    try tmp.dir.writeFile(io, .{ .sub_path = "nested/child.txt", .data = "" });
+    const root = try tmp.dir.realPathFileAlloc(io, ".", allocator);
+    defer allocator.free(root);
+    const pattern = try std.fmt.allocPrint(allocator, "{s}/**/*.rb", .{root});
+    defer allocator.free(pattern);
+
+    var matches = try expand(allocator, io, pattern);
+    defer freeMatches(allocator, &matches);
+    try std.testing.expectEqual(@as(usize, 2), matches.items.len);
+    try std.testing.expect(std.mem.endsWith(u8, matches.items[0], "/nested/child.rb"));
+    try std.testing.expect(std.mem.endsWith(u8, matches.items[1], "/root.rb"));
 }

--- a/src/global_io.zig
+++ b/src/global_io.zig
@@ -7,6 +7,7 @@
 //! standalone tools), falls back to the blocking single-threaded
 //! implementation from std.
 const std = @import("std");
+const builtin = @import("builtin");
 
 var override: ?std.Io = null;
 
@@ -15,7 +16,9 @@ pub fn set(new_io: std.Io) void {
 }
 
 pub fn io() std.Io {
-    return override orelse std.Io.Threaded.global_single_threaded.io();
+    if (override) |value| return value;
+    if (builtin.is_test) return std.testing.io;
+    return std.Io.Threaded.global_single_threaded.io();
 }
 
 var environ_map: ?*std.process.Environ.Map = null;

--- a/src/http/download/manager.zig
+++ b/src/http/download/manager.zig
@@ -349,9 +349,11 @@ test "Manager task queue operations" {
 
     // Add multiple tasks
     for (0..3) |i| {
+        const id = try std.fmt.allocPrint(allocator, "task-{d}", .{i});
+        defer allocator.free(id);
         const task = try Task.init(
             allocator,
-            try std.fmt.allocPrint(allocator, "task-{d}", .{i}),
+            id,
             "https://example.com/file.zip",
             "file.zip",
             "/tmp/file.zip.tmp",

--- a/src/indicatif/multi_progress.zig
+++ b/src/indicatif/multi_progress.zig
@@ -158,6 +158,11 @@ pub const MultiProgress = struct {
         self.mutex.lockUncancelable(global_io.io());
         defer self.mutex.unlock(global_io.io());
 
+        if (!self.draw_enabled) {
+            std.debug.print("{s}\n", .{msg});
+            return;
+        }
+
         // Build the entire sequence (clear + message + redraw) in a single buffer
         var output_aw: std.Io.Writer.Allocating = .init(self.allocator);
         defer output_aw.deinit();
@@ -176,11 +181,6 @@ pub const MultiProgress = struct {
 
         // 2. Print message
         try writer.print("{s}\n", .{msg});
-
-        // 3. Redraw all bars
-        if (self.last_total_lines > 0) {
-            try writer.print("\x1b[{d}F", .{self.last_total_lines});
-        }
 
         var bar_aw: std.Io.Writer.Allocating = .init(self.allocator);
         defer bar_aw.deinit();

--- a/src/indicatif/multi_progress.zig
+++ b/src/indicatif/multi_progress.zig
@@ -8,6 +8,9 @@ pub const MultiProgress = struct {
     bars: std.ArrayList(*ProgressBar) = .empty,
     mutex: std.Io.Mutex = .init,
     draw_enabled: bool = true,
+    /// Finished leading bars that have already been written permanently to the
+    /// terminal. Only the remaining suffix participates in cursor-based redraws.
+    committed_bars: usize = 0,
     last_total_lines: usize = 0,
 
     const Self = @This();
@@ -44,6 +47,9 @@ pub const MultiProgress = struct {
         for (self.bars.items, 0..) |b, i| {
             if (b == bar) {
                 _ = self.bars.orderedRemove(i);
+                if (i < self.committed_bars) {
+                    self.committed_bars -= 1;
+                }
                 bar.draw_enabled = true;
                 break;
             }
@@ -58,6 +64,9 @@ pub const MultiProgress = struct {
         // Find and remove the bar from its current position
         for (self.bars.items, 0..) |b, i| {
             if (b == bar) {
+                // A committed bar is already part of terminal history and can
+                // no longer be reordered visually.
+                if (i < self.committed_bars) return;
                 _ = self.bars.orderedRemove(i);
                 // Add it back at the end
                 self.bars.append(self.allocator, bar) catch return;
@@ -88,7 +97,7 @@ pub const MultiProgress = struct {
 
         // Draw each progress bar
         var total_lines: usize = 0;
-        for (self.bars.items) |bar| {
+        for (self.bars.items[self.committed_bars..]) |bar| {
             bar_aw.clearRetainingCapacity();
 
             try bar.style.format(bar.state, bar.width, &bar_aw.writer);
@@ -103,7 +112,7 @@ pub const MultiProgress = struct {
             total_lines += 1;
         }
 
-        self.last_total_lines = self.bars.items.len;
+        self.last_total_lines = self.bars.items.len - self.committed_bars;
 
         // Single atomic write to terminal
         std.debug.print("{s}", .{output_aw.written()});
@@ -153,7 +162,9 @@ pub const MultiProgress = struct {
         try self.clearInternal();
     }
 
-    /// Print a message above all progress bars
+    /// Print a message between terminal history and the live progress area.
+    /// Finished leading bars are committed before the message so later redraws
+    /// cannot move task headings or completed resource rows below live output.
     pub fn println(self: *Self, msg: []const u8) !void {
         self.mutex.lockUncancelable(global_io.io());
         defer self.mutex.unlock(global_io.io());
@@ -179,27 +190,34 @@ pub const MultiProgress = struct {
             try writer.print("\x1b[{d}F", .{self.last_total_lines});
         }
 
-        // 2. Print message
-        try writer.print("{s}\n", .{msg});
-
         var bar_aw: std.Io.Writer.Allocating = .init(self.allocator);
         defer bar_aw.deinit();
         try bar_aw.ensureTotalCapacity(512);
 
+        var commit_end = self.committed_bars;
+        while (commit_end < self.bars.items.len and self.bars.items[commit_end].isFinished()) {
+            commit_end += 1;
+        }
+
+        // 2. Permanently write the finished prefix, followed by the message.
+        for (self.bars.items[self.committed_bars..commit_end]) |bar| {
+            bar_aw.clearRetainingCapacity();
+            try bar.style.format(bar.state, bar.width, &bar_aw.writer);
+            try writer.print("\x1b[K{s}\n", .{bar_aw.written()});
+        }
+        try writer.print("{s}\n", .{msg});
+
+        // 3. Redraw only bars that are still part of the live area.
         var total_lines: usize = 0;
-        for (self.bars.items) |bar| {
+        for (self.bars.items[commit_end..]) |bar| {
             bar_aw.clearRetainingCapacity();
             try bar.style.format(bar.state, bar.width, &bar_aw.writer);
             try writer.print("\x1b[K{s}\n", .{bar_aw.written()});
             total_lines += 1;
         }
 
-        while (total_lines < self.last_total_lines) {
-            try writer.writeAll("\x1b[K\n");
-            total_lines += 1;
-        }
-
-        self.last_total_lines = self.bars.items.len;
+        self.committed_bars = commit_end;
+        self.last_total_lines = total_lines;
 
         // Single atomic write
         std.debug.print("{s}", .{output_aw.written()});

--- a/src/main.zig
+++ b/src/main.zig
@@ -98,6 +98,10 @@ fn dispatchCommand(command: []const u8, allocator: std.mem.Allocator, iter: *std
         try commands.provision.run(allocator, iter);
         return;
     }
+    if (std.mem.eql(u8, command, "run")) {
+        try commands.run.run(allocator, iter);
+        return;
+    }
     if (std.mem.eql(u8, command, "apply")) {
         try commands.apply.run(allocator, iter);
         return;
@@ -111,14 +115,20 @@ fn dispatchCommand(command: []const u8, allocator: std.mem.Allocator, iter: *std
         return;
     }
 
-    try printMainHelp(command);
+    commands.run.runImplicit(allocator, command, iter) catch |err| switch (err) {
+        error.NoRakefile => {
+            try printMainHelp(command);
+            std.process.exit(1);
+        },
+        error.TaskFailed => std.process.exit(1),
+    };
 }
 
 fn printMainHelp(unknown: ?[]const u8) !void {
     const gpa = std.heap.page_allocator;
 
     if (unknown) |cmd| {
-        const error_msg = try std.fmt.allocPrint(gpa, "Unknown command \"{s}\"", .{cmd});
+        const error_msg = try std.fmt.allocPrint(gpa, "Unknown command or task \"{s}\"", .{cmd});
         defer gpa.free(error_msg);
         help_formatter.HelpFormatter.printError(error_msg);
         help_formatter.HelpFormatter.newline();
@@ -149,6 +159,7 @@ fn printMainHelp(unknown: ?[]const u8) !void {
         .{ .command = "dock", .description = "Show current macOS Dock configuration" },
         .{ .command = "applescript", .description = "Execute AppleScript via macOS system API" },
         .{ .command = "provision", .description = "Run infrastructure-as-code scripts" },
+        .{ .command = "run", .description = "Run Rake-compatible project tasks" },
         .{ .command = "node-info", .description = "Display complete node information (like Chef Ohai)" },
         .{ .command = "apply", .description = "Execute full bootstrap sequence" },
         .{ .command = "agent", .description = "Connect to SSE endpoint and run provision on events" },
@@ -166,6 +177,7 @@ fn printMainHelp(unknown: ?[]const u8) !void {
         .{ .prefix = "AppleScript:", .command = "applescript \"1 + 1\"" },
         .{ .prefix = "AppleScript file:", .command = "applescript --file script.applescript" },
         .{ .prefix = "Infrastructure:", .command = "provision provision.rb" },
+        .{ .prefix = "Project task:", .command = "run build" },
         .{ .prefix = "Node information:", .command = "node-info" },
         .{ .prefix = "Full bootstrap:", .command = "apply --github user/dotfiles" },
         .{ .prefix = "Dry run:", .command = "apply --dry-run" },

--- a/src/main.zig
+++ b/src/main.zig
@@ -116,7 +116,7 @@ fn dispatchCommand(command: []const u8, allocator: std.mem.Allocator, iter: *std
     }
 
     commands.run.runImplicit(allocator, command, iter) catch |err| switch (err) {
-        error.NoRakefile => {
+        error.NoTaskFile => {
             try printMainHelp(command);
             std.process.exit(1);
         },
@@ -159,7 +159,7 @@ fn printMainHelp(unknown: ?[]const u8) !void {
         .{ .command = "dock", .description = "Show current macOS Dock configuration" },
         .{ .command = "applescript", .description = "Execute AppleScript via macOS system API" },
         .{ .command = "provision", .description = "Run infrastructure-as-code scripts" },
-        .{ .command = "run", .description = "Run Rake-compatible project tasks" },
+        .{ .command = "run", .description = "Run Rake-inspired project tasks" },
         .{ .command = "node-info", .description = "Display complete node information (like Chef Ohai)" },
         .{ .command = "apply", .description = "Execute full bootstrap sequence" },
         .{ .command = "agent", .description = "Connect to SSE endpoint and run provision on events" },

--- a/src/modern_provision_display.zig
+++ b/src/modern_provision_display.zig
@@ -5,6 +5,7 @@ const ansi = @import("ansi_term");
 const ansi_constants = @import("ansi_constants.zig");
 const ANSI = ansi_constants.ANSI;
 const http = @import("http.zig");
+const output_channel = @import("output_channel.zig");
 
 const AnsiStyle = ansi.style.Style;
 const AnsiColor = ansi.style.Color;
@@ -43,6 +44,7 @@ pub const ModernProvisionDisplay = struct {
     updated_count: usize = 0,
     skipped_count: usize = 0,
     failed_count: usize = 0,
+    run_failed: bool = false,
     timer_spinner: ?*indicatif.ProgressBar = null,
     timer_message: ?[]u8 = null,
     start_time: i128 = 0,
@@ -130,6 +132,19 @@ pub const ModernProvisionDisplay = struct {
         self.total_resources = total;
     }
 
+    fn formatCounter(self: *Self, buffer: []u8) []const u8 {
+        if (self.total_resources == 0) {
+            return std.fmt.bufPrint(buffer, "[{d}]", .{self.executed_count}) catch "[?]";
+        }
+
+        const total_digits = std.math.log10_int(self.total_resources) + 1;
+        const current_digits = std.math.log10_int(self.executed_count) + 1;
+        const padding = if (total_digits > current_digits) total_digits - current_digits else 0;
+        var padding_buffer: [32]u8 = undefined;
+        @memset(padding_buffer[0..padding], ' ');
+        return std.fmt.bufPrint(buffer, "[{s}{d}/{d}]", .{ padding_buffer[0..padding], self.executed_count, self.total_resources }) catch "[?]";
+    }
+
     /// Start the timer spinner
     pub fn startTimer(self: *Self, start_time: i128) !void {
         self.start_time = start_time;
@@ -190,14 +205,28 @@ pub const ModernProvisionDisplay = struct {
             self.allocator.free(old_msg);
         }
 
-        const base_msg = try std.fmt.allocPrint(
-            self.allocator,
-            "✓ Completed in {d}.{d:0>3}s - {d} updated, {d} skipped",
-            .{ elapsed_s, @as(u64, @intCast(elapsed_ms_part)), self.updated_count, self.skipped_count },
-        );
+        const succeeded = !self.run_failed and self.failed_count == 0;
+        const base_msg = if (succeeded)
+            try std.fmt.allocPrint(
+                self.allocator,
+                "✓ Completed in {d}.{d:0>3}s - {d} updated, {d} skipped",
+                .{ elapsed_s, @as(u64, @intCast(elapsed_ms_part)), self.updated_count, self.skipped_count },
+            )
+        else if (self.failed_count > 0)
+            try std.fmt.allocPrint(
+                self.allocator,
+                "✗ Completed in {d}.{d:0>3}s - {d} updated, {d} skipped, {d} failed",
+                .{ elapsed_s, @as(u64, @intCast(elapsed_ms_part)), self.updated_count, self.skipped_count, self.failed_count },
+            )
+        else
+            try std.fmt.allocPrint(
+                self.allocator,
+                "✗ Completed in {d}.{d:0>3}s - task failed",
+                .{ elapsed_s, @as(u64, @intCast(elapsed_ms_part)) },
+            );
         defer self.allocator.free(base_msg);
 
-        const colored_msg = try self.makeColoredMessage(.Green, true, base_msg);
+        const colored_msg = try self.makeColoredMessage(if (succeeded) .Green else .Red, true, base_msg);
         try self.download_finished_messages.append(self.allocator, colored_msg);
 
         if (self.timer_spinner) |spinner| {
@@ -217,6 +246,16 @@ pub const ModernProvisionDisplay = struct {
 
     /// Show section header with custom level (2 = ##, 3 = ###, 4 = ####)
     pub fn showSectionWithLevel(self: *Self, header: []const u8, level: u8) !void {
+        try self.showSectionInternal(header, level, true);
+    }
+
+    /// Show a task header without interpreting task names as provision section
+    /// categories (for example, a task named "download").
+    pub fn showTaskSection(self: *Self, name: []const u8) !void {
+        try self.showSectionInternal(name, 2, false);
+    }
+
+    fn showSectionInternal(self: *Self, header: []const u8, level: u8, deduplicate: bool) !void {
         // Use markdown-style prefixes but optimized for terminal
         // Level 2: ## with bold
         // Level 3: ### without bold
@@ -239,8 +278,8 @@ pub const ModernProvisionDisplay = struct {
         }
 
         // Check if this section already exists
-        const is_download_section = std.mem.indexOf(u8, header, "Download") != null;
-        const is_resource_section = std.mem.indexOf(u8, header, "Executing") != null or std.mem.indexOf(u8, header, "Resource") != null;
+        const is_download_section = deduplicate and std.mem.indexOf(u8, header, "Download") != null;
+        const is_resource_section = deduplicate and (std.mem.indexOf(u8, header, "Executing") != null or std.mem.indexOf(u8, header, "Resource") != null);
 
         if (is_download_section and self.download_section_spinner != null) {
             // Section already exists, don't create duplicate
@@ -252,7 +291,7 @@ pub const ModernProvisionDisplay = struct {
         }
 
         // Add an empty line before section (except for the first section)
-        if (self.download_section_spinner != null or self.resource_section_spinner != null) {
+        if (self.section_messages.items.len > 0) {
             const empty_spinner = try self.mp.addSpinner();
             const empty_msg = try self.allocator.dupe(u8, "");
             const empty_style = try indicatif.ProgressStyle.withTemplate(self.allocator, "{msg}");
@@ -295,6 +334,23 @@ pub const ModernProvisionDisplay = struct {
         if (!self.show_progress) {
             std.debug.print("\x1b[34mℹ\x1b[0m {s}\n", .{message});
         }
+    }
+
+    pub fn printLine(self: *Self, text: []const u8) !void {
+        if (!self.show_progress) {
+            std.debug.print("{s}\n", .{text});
+            return;
+        }
+        try self.mp.println(text);
+    }
+
+    pub fn printCommandLine(self: *Self, stream: output_channel.Stream, line: []const u8) !void {
+        const message = switch (stream) {
+            .stdout => try std.fmt.allocPrint(self.allocator, "   {s}", .{line}),
+            .stderr => try std.fmt.allocPrint(self.allocator, "{s}   {s}{s}", .{ ANSI.RED, line, ANSI.RESET }),
+        };
+        defer self.allocator.free(message);
+        try self.printLine(message);
     }
 
     /// Pre-create download spinners so they always occupy the top rows
@@ -500,15 +556,8 @@ pub const ModernProvisionDisplay = struct {
         defer if (skip_reason != null) self.allocator.free(suffix);
 
         if (!self.show_progress) {
-            const total_digits = if (self.total_resources > 0) std.math.log10_int(self.total_resources) + 1 else 1;
-            const current_digits = std.math.log10_int(self.executed_count) + 1;
-            const padding = if (total_digits > current_digits) total_digits - current_digits else 0;
-            var i: usize = 0;
-            var padding_str: [16]u8 = undefined;
-            while (i < padding) : (i += 1) {
-                padding_str[i] = ' ';
-            }
-            std.debug.print("{s}\x1b[32m✓ [{s}{d}/{d}]  {s}[{s}] action {s}{s}\x1b[0m\n", .{ INDENT_RESOURCE, padding_str[0..padding], self.executed_count, self.total_resources, resource_type, resource_name, action, suffix });
+            var counter_buffer: [64]u8 = undefined;
+            std.debug.print("{s}\x1b[32m✓ {s}  {s}[{s}] action {s}{s}\x1b[0m\n", .{ INDENT_RESOURCE, self.formatCounter(&counter_buffer), resource_type, resource_name, action, suffix });
             return;
         }
 
@@ -542,16 +591,9 @@ pub const ModernProvisionDisplay = struct {
         self.skipped_count += 1;
 
         if (!self.show_progress) {
-            const total_digits = if (self.total_resources > 0) std.math.log10_int(self.total_resources) + 1 else 1;
-            const current_digits = std.math.log10_int(self.executed_count) + 1;
-            const padding = if (total_digits > current_digits) total_digits - current_digits else 0;
-            var i: usize = 0;
-            var padding_str: [16]u8 = undefined;
-            while (i < padding) : (i += 1) {
-                padding_str[i] = ' ';
-            }
             const reason = skip_reason orelse "up to date";
-            std.debug.print("{s}\x1b[90m○ [{s}{d}/{d}]  {s}[{s}] action {s} ({s})\x1b[0m\n", .{ INDENT_RESOURCE, padding_str[0..padding], self.executed_count, self.total_resources, resource_type, resource_name, action, reason });
+            var counter_buffer: [64]u8 = undefined;
+            std.debug.print("{s}\x1b[90m○ {s}  {s}[{s}] action {s} ({s})\x1b[0m\n", .{ INDENT_RESOURCE, self.formatCounter(&counter_buffer), resource_type, resource_name, action, reason });
             return;
         }
 
@@ -586,15 +628,8 @@ pub const ModernProvisionDisplay = struct {
         self.failed_count += 1;
 
         if (!self.show_progress) {
-            const total_digits = if (self.total_resources > 0) std.math.log10_int(self.total_resources) + 1 else 1;
-            const current_digits = std.math.log10_int(self.executed_count) + 1;
-            const padding = if (total_digits > current_digits) total_digits - current_digits else 0;
-            var i: usize = 0;
-            var padding_str: [16]u8 = undefined;
-            while (i < padding) : (i += 1) {
-                padding_str[i] = ' ';
-            }
-            std.debug.print("{s}\x1b[31m✗ [{s}{d}/{d}]  {s}[{s}]: {s}\x1b[0m\n", .{ INDENT_RESOURCE, padding_str[0..padding], self.executed_count, self.total_resources, resource_type, resource_name, error_msg });
+            var counter_buffer: [64]u8 = undefined;
+            std.debug.print("{s}\x1b[31m✗ {s}  {s}[{s}]: {s}\x1b[0m\n", .{ INDENT_RESOURCE, self.formatCounter(&counter_buffer), resource_type, resource_name, error_msg });
             return;
         }
 
@@ -646,12 +681,28 @@ pub const ModernProvisionDisplay = struct {
             if (self.failed_count > 0) {
                 std.debug.print("Failed: \x1b[31m{d}\x1b[0m resources\n", .{self.failed_count});
             }
-            std.debug.print("\x1b[32m✓\x1b[0m Provisioning completed successfully!\n", .{});
+            if (self.failed_count == 0) {
+                std.debug.print("\x1b[32m✓\x1b[0m Provisioning completed successfully!\n", .{});
+            } else {
+                std.debug.print("\x1b[31m✗\x1b[0m Provisioning completed with {d} failed resources.\n", .{self.failed_count});
+            }
         }
     }
 
     /// Show final summary with duration
     pub fn showSummaryWithDuration(self: *Self, duration_s: i64, duration_ms_part: i64) !void {
+        try self.showSummaryWithDurationLabel("Provisioning", duration_s, duration_ms_part);
+    }
+
+    pub fn showTaskSummaryWithDuration(self: *Self, duration_s: i64, duration_ms_part: i64) !void {
+        try self.showSummaryWithDurationLabel("Task run", duration_s, duration_ms_part);
+    }
+
+    pub fn markRunFailed(self: *Self) void {
+        self.run_failed = true;
+    }
+
+    fn showSummaryWithDurationLabel(self: *Self, label: []const u8, duration_s: i64, duration_ms_part: i64) !void {
         _ = duration_s;
         _ = duration_ms_part;
 
@@ -671,7 +722,13 @@ pub const ModernProvisionDisplay = struct {
             const elapsed_s = @divTrunc(elapsed_ms, 1000);
             const elapsed_ms_part = @rem(elapsed_ms, 1000);
             std.debug.print("Duration: \x1b[36m{d}.{d:0>3}s\x1b[0m\n", .{ elapsed_s, @abs(elapsed_ms_part) });
-            std.debug.print("\x1b[32m✓\x1b[0m Provisioning completed successfully!\n", .{});
+            if (!self.run_failed and self.failed_count == 0) {
+                std.debug.print("\x1b[32m✓\x1b[0m {s} completed successfully!\n", .{label});
+            } else if (self.failed_count > 0) {
+                std.debug.print("\x1b[31m✗\x1b[0m {s} completed with {d} failed resources.\n", .{ label, self.failed_count });
+            } else {
+                std.debug.print("\x1b[31m✗\x1b[0m {s} failed.\n", .{label});
+            }
         } else {
             // Finish the timer spinner with final message
             try self.finishTimer();
@@ -727,26 +784,9 @@ pub const ModernProvisionDisplay = struct {
     }
 
     fn buildResourceMessage(self: *Self, resource_type: []const u8, resource_name: []const u8, suffix: []const u8) ![]u8 {
-        const total_digits = if (self.total_resources > 0)
-            std.math.log10_int(self.total_resources) + 1
-        else
-            1;
-        const current_digits = std.math.log10_int(self.executed_count) + 1;
-        const padding = if (total_digits > current_digits)
-            total_digits - current_digits
-        else
-            0;
-
-        var padding_str: [16]u8 = undefined;
-        var i: usize = 0;
-        while (i < padding) : (i += 1) {
-            padding_str[i] = ' ';
-        }
-
-        return std.fmt.allocPrint(self.allocator, "[{s}{d}/{d}]  {s}[{s}]{s}", .{
-            padding_str[0..padding],
-            self.executed_count,
-            self.total_resources,
+        var counter_buffer: [64]u8 = undefined;
+        return std.fmt.allocPrint(self.allocator, "{s}  {s}[{s}]{s}", .{
+            self.formatCounter(&counter_buffer),
             resource_type,
             resource_name,
             suffix,
@@ -770,3 +810,22 @@ pub const ModernProvisionDisplay = struct {
         return result;
     }
 };
+
+test "formatCounter supports known and unknown totals" {
+    var display = try ModernProvisionDisplay.init(std.testing.allocator, false);
+    defer display.deinit();
+    var buffer: [64]u8 = undefined;
+
+    display.executed_count = 3;
+    display.setTotalResources(0);
+    try std.testing.expectEqualStrings("[3]", display.formatCounter(&buffer));
+
+    display.setTotalResources(9);
+    try std.testing.expectEqualStrings("[3/9]", display.formatCounter(&buffer));
+
+    display.setTotalResources(10);
+    try std.testing.expectEqualStrings("[ 3/10]", display.formatCounter(&buffer));
+
+    display.setTotalResources(100);
+    try std.testing.expectEqualStrings("[  3/100]", display.formatCounter(&buffer));
+}

--- a/src/modern_provision_display.zig
+++ b/src/modern_provision_display.zig
@@ -6,6 +6,7 @@ const ansi_constants = @import("ansi_constants.zig");
 const ANSI = ansi_constants.ANSI;
 const http = @import("http.zig");
 const output_channel = @import("output_channel.zig");
+const resources = @import("resources.zig");
 
 const AnsiStyle = ansi.style.Style;
 const AnsiColor = ansi.style.Color;
@@ -13,10 +14,31 @@ const STATUS_PENDING = "[DL] pending";
 const STATUS_DOWNLOADING = "[DL] downloading";
 const STATUS_DONE = "[DL] done";
 const STATUS_FAILED = "[DL] failed";
+const SECTION_MARKER = "›";
 
-// Indentation constants
-const INDENT_RESOURCE = " "; // 1 spaces for resource items
-const INDENT_NOTIFICATION = "    "; // 2 spaces for notifications (sub-items)
+// Compact command, output, and resource status markers share one left gutter.
+const INDENT_RESOURCE = "";
+
+pub const ResourceFailure = struct {
+    resource_type: []const u8,
+    resource_name: []const u8,
+    action: []const u8,
+    depth: usize,
+    error_name: []const u8,
+    message: []const u8,
+    command: ?[]const u8 = null,
+    stdout: ?[]const u8 = null,
+    stderr: ?[]const u8 = null,
+    backtrace: ?[]const u8 = null,
+};
+
+/// Normal mode is an append-only, Chef-inspired execution log intended for
+/// authoring and debugging. Compact mode is the animated spinner display for
+/// established scripts where the operator mainly needs progress and a result.
+pub const OutputMode = enum {
+    normal,
+    compact,
+};
 
 /// Modern provision display using indicatif
 pub const ModernProvisionDisplay = struct {
@@ -38,29 +60,46 @@ pub const ModernProvisionDisplay = struct {
     resource_section_spinner: ?*indicatif.ProgressBar = null, // Static section header for resources
     resource_spinner: ?*indicatif.ProgressBar = null,
     resource_message: ?[]const u8 = null, // Keep message allocated
-    show_progress: bool,
+    mode: OutputMode,
+    colorize: bool,
+    compact_at_gap: bool = false,
+    normal_at_gap: bool = false,
+    normal_resource_line_open: bool = false,
+    normal_resource_depth: usize = 0,
+    normal_display_path: []const resources.DisplayScope = &.{},
     total_resources: usize = 0,
     executed_count: usize = 0,
     updated_count: usize = 0,
     skipped_count: usize = 0,
     failed_count: usize = 0,
+    handled_failure_count: usize = 0,
     run_failed: bool = false,
     timer_spinner: ?*indicatif.ProgressBar = null,
     timer_message: ?[]u8 = null,
     start_time: i128 = 0,
 
-    pub fn init(allocator: std.mem.Allocator, show_progress: bool) !Self {
+    pub fn init(allocator: std.mem.Allocator, mode: OutputMode) !Self {
         return .{
             .allocator = allocator,
             .mp = indicatif.MultiProgress.init(allocator),
             .download_spinners = std.StringHashMap(DownloadEntry).init(allocator),
             .download_finished_messages = std.ArrayList([]const u8).empty,
             .section_messages = std.ArrayList([]const u8).empty,
-            .show_progress = show_progress,
+            .mode = mode,
+            .colorize = shouldColorizeNormal(),
         };
     }
 
+    pub fn isCompact(self: *const Self) bool {
+        return self.mode == .compact;
+    }
+
     pub fn deinit(self: *Self) void {
+        self.finishNormalResourceLine();
+        if (self.isCompact() and self.timer_spinner != null) {
+            self.addCompactGap() catch {};
+            self.mp.draw() catch {};
+        }
 
         // Clean up any remaining download spinners
         var key_iter = self.download_spinners.keyIterator();
@@ -148,7 +187,7 @@ pub const ModernProvisionDisplay = struct {
     /// Start the timer spinner
     pub fn startTimer(self: *Self, start_time: i128) !void {
         self.start_time = start_time;
-        if (!self.show_progress) return;
+        if (!self.isCompact()) return;
 
         const spinner = try self.mp.addSpinner();
         var style = try indicatif.ProgressStyle.withTemplate(self.allocator, "{spinner} {msg}");
@@ -163,7 +202,7 @@ pub const ModernProvisionDisplay = struct {
 
     /// Update the timer display
     fn updateTimer(self: *Self) !void {
-        if (!self.show_progress) return;
+        if (!self.isCompact()) return;
         if (self.timer_spinner == null) return;
 
         const io = global_io.io();
@@ -190,8 +229,8 @@ pub const ModernProvisionDisplay = struct {
     }
 
     /// Finish the timer spinner
-    pub fn finishTimer(self: *Self) !void {
-        if (!self.show_progress) return;
+    pub fn finishTimer(self: *Self, label: []const u8) !void {
+        if (!self.isCompact()) return;
         if (self.timer_spinner == null) return;
 
         const io = global_io.io();
@@ -205,25 +244,10 @@ pub const ModernProvisionDisplay = struct {
             self.allocator.free(old_msg);
         }
 
-        const succeeded = !self.run_failed and self.failed_count == 0;
-        const base_msg = if (succeeded)
-            try std.fmt.allocPrint(
-                self.allocator,
-                "✓ Completed in {d}.{d:0>3}s - {d} updated, {d} skipped",
-                .{ elapsed_s, @as(u64, @intCast(elapsed_ms_part)), self.updated_count, self.skipped_count },
-            )
-        else if (self.failed_count > 0)
-            try std.fmt.allocPrint(
-                self.allocator,
-                "✗ Completed in {d}.{d:0>3}s - {d} updated, {d} skipped, {d} failed",
-                .{ elapsed_s, @as(u64, @intCast(elapsed_ms_part)), self.updated_count, self.skipped_count, self.failed_count },
-            )
-        else
-            try std.fmt.allocPrint(
-                self.allocator,
-                "✗ Completed in {d}.{d:0>3}s - task failed",
-                .{ elapsed_s, @as(u64, @intCast(elapsed_ms_part)) },
-            );
+        const succeeded = self.didSucceed();
+        const summary = try self.formatSummaryMessage(label, elapsed_s, @intCast(elapsed_ms_part));
+        defer self.allocator.free(summary);
+        const base_msg = try std.fmt.allocPrint(self.allocator, "{s} {s}", .{ if (succeeded) "✓" else "✗", summary });
         defer self.allocator.free(base_msg);
 
         const colored_msg = try self.makeColoredMessage(if (succeeded) .Green else .Red, true, base_msg);
@@ -239,41 +263,166 @@ pub const ModernProvisionDisplay = struct {
         self.timer_message = null;
     }
 
-    /// Show section header (default level 2 = ##)
+    fn didSucceed(self: *const Self) bool {
+        return !self.run_failed and self.failed_count == 0;
+    }
+
+    fn formatSummaryMessage(self: *Self, label: []const u8, elapsed_s: i128, elapsed_ms_part: u64) ![]u8 {
+        const outcome = if (self.didSucceed()) "complete" else "failed";
+        if (self.failed_count > 0 and self.handled_failure_count > 0) {
+            return std.fmt.allocPrint(
+                self.allocator,
+                "{s} {s} in {d}.{d:0>3}s - {d} updated, {d} skipped, {d} failed, {d} handled failure{s}",
+                .{ label, outcome, elapsed_s, elapsed_ms_part, self.updated_count, self.skipped_count, self.failed_count, self.handled_failure_count, if (self.handled_failure_count == 1) "" else "s" },
+            );
+        }
+        if (self.failed_count > 0) {
+            return std.fmt.allocPrint(
+                self.allocator,
+                "{s} {s} in {d}.{d:0>3}s - {d} updated, {d} skipped, {d} failed",
+                .{ label, outcome, elapsed_s, elapsed_ms_part, self.updated_count, self.skipped_count, self.failed_count },
+            );
+        }
+        if (self.handled_failure_count > 0) {
+            return std.fmt.allocPrint(
+                self.allocator,
+                "{s} {s} in {d}.{d:0>3}s - {d} updated, {d} skipped, {d} handled failure{s}",
+                .{ label, outcome, elapsed_s, elapsed_ms_part, self.updated_count, self.skipped_count, self.handled_failure_count, if (self.handled_failure_count == 1) "" else "s" },
+            );
+        }
+        return std.fmt.allocPrint(
+            self.allocator,
+            "{s} {s} in {d}.{d:0>3}s - {d} updated, {d} skipped",
+            .{ label, outcome, elapsed_s, elapsed_ms_part, self.updated_count, self.skipped_count },
+        );
+    }
+
+    fn shouldColorizeNormal() bool {
+        if (global_io.getEnv("NO_COLOR") != null) return false;
+        if (global_io.getEnv("TERM")) |term| {
+            if (std.mem.eql(u8, term, "dumb")) return false;
+        }
+        return std.Io.File.stderr().isTty(global_io.io()) catch false;
+    }
+
+    fn normalStyle(self: *const Self, ansi_code: []const u8) []const u8 {
+        return if (self.colorize) ansi_code else "";
+    }
+
+    fn finishNormalResourceLine(self: *Self) void {
+        if (!self.normal_resource_line_open) return;
+        std.debug.print("\n", .{});
+        self.normal_resource_line_open = false;
+    }
+
+    fn ensureNormalGap(self: *Self) void {
+        if (self.normal_at_gap) return;
+        std.debug.print("\n", .{});
+        self.normal_at_gap = true;
+    }
+
+    fn printNormalIndent(units: usize) void {
+        for (0..units) |_| std.debug.print("  ", .{});
+    }
+
+    fn displayScopeEqual(a: resources.DisplayScope, b: resources.DisplayScope) bool {
+        return std.mem.eql(u8, a.type_name, b.type_name) and
+            std.mem.eql(u8, a.name, b.name) and
+            std.mem.eql(u8, a.action, b.action);
+    }
+
+    fn syncNormalDisplayPath(self: *Self, path: []const resources.DisplayScope, resource_depth: usize) void {
+        var shared: usize = 0;
+        while (shared < self.normal_display_path.len and shared < path.len and
+            displayScopeEqual(self.normal_display_path[shared], path[shared])) : (shared += 1)
+        {}
+
+        for (path[shared..], shared..) |scope, index| {
+            const scope_depth = resource_depth - (path.len - index);
+            printNormalIndent(scope_depth + 1);
+            std.debug.print("* {s}[{s}] action {s}\n", .{ scope.type_name, scope.name, scope.action });
+        }
+        self.normal_display_path = path;
+    }
+
+    fn printNormalText(depth: usize, text: []const u8) void {
+        var lines = std.mem.splitScalar(u8, text, '\n');
+        while (lines.next()) |line| {
+            if (line.len == 0) continue;
+            printNormalIndent(depth + 1);
+            std.debug.print("{s}\n", .{line});
+        }
+    }
+
+    fn isUnifiedDiff(text: []const u8) bool {
+        return std.mem.startsWith(u8, text, "diff --git ") or
+            (std.mem.startsWith(u8, text, "--- ") and std.mem.indexOf(u8, text, "\n+++ ") != null);
+    }
+
+    fn diffLineStyle(line: []const u8) []const u8 {
+        if (std.mem.startsWith(u8, line, "diff --git ") or std.mem.startsWith(u8, line, "index ")) return ANSI.DIM;
+        if (std.mem.startsWith(u8, line, "--- ") or std.mem.startsWith(u8, line, "-")) return ANSI.RED;
+        if (std.mem.startsWith(u8, line, "+++ ") or std.mem.startsWith(u8, line, "+")) return ANSI.GREEN;
+        if (std.mem.startsWith(u8, line, "@@")) return ANSI.CYAN;
+        if (std.mem.startsWith(u8, line, "\\ No newline at end of file")) return ANSI.YELLOW;
+        return "";
+    }
+
+    fn printNormalOutput(self: *Self, depth: usize, text: []const u8) void {
+        if (!isUnifiedDiff(text)) {
+            printNormalText(depth, text);
+            return;
+        }
+
+        var lines = std.mem.splitScalar(u8, text, '\n');
+        while (lines.next()) |line| {
+            if (line.len == 0) continue;
+            const ansi_code = self.normalStyle(diffLineStyle(line));
+            printNormalIndent(depth + 1);
+            std.debug.print("{s}{s}{s}\n", .{
+                ansi_code,
+                line,
+                if (ansi_code.len > 0) self.normalStyle(ANSI.RESET) else "",
+            });
+        }
+    }
+
+    /// Show a primary section header.
     pub fn showSection(self: *Self, header: []const u8) !void {
         try self.showSectionWithLevel(header, 2);
     }
 
-    /// Show section header with custom level (2 = ##, 3 = ###, 4 = ####)
+    /// Show a section header with a visual hierarchy level.
     pub fn showSectionWithLevel(self: *Self, header: []const u8, level: u8) !void {
-        try self.showSectionInternal(header, level, true);
+        try self.showSectionInternal(header, level, true, true);
+    }
+
+    /// Notification headings introduce an attached list, so unlike ordinary
+    /// section headings they must not leave a blank line before their content.
+    pub fn showNotificationSection(self: *Self, header: []const u8) !void {
+        try self.showSectionInternal(header, 3, true, false);
     }
 
     /// Show a task header without interpreting task names as provision section
     /// categories (for example, a task named "download").
     pub fn showTaskSection(self: *Self, name: []const u8) !void {
-        try self.showSectionInternal(name, 2, false);
+        try self.showSectionInternal(name, 2, false, true);
     }
 
-    fn showSectionInternal(self: *Self, header: []const u8, level: u8, deduplicate: bool) !void {
-        // Use markdown-style prefixes but optimized for terminal
-        // Level 2: ## with bold
-        // Level 3: ### without bold
-        // Level 4: #### without bold
-
-        const prefix = switch (level) {
-            2 => "##",
-            3 => "###",
-            4 => "####",
-            else => "##",
-        };
-
-        if (!self.show_progress) {
-            if (level == 2) {
-                std.debug.print("\n{s}{s} {s}{s}\n", .{ ANSI.BOLD, prefix, header, ANSI.RESET });
+    fn showSectionInternal(self: *Self, header: []const u8, level: u8, deduplicate: bool, gap_after: bool) !void {
+        if (!self.isCompact()) {
+            self.finishNormalResourceLine();
+            self.normal_display_path = &.{};
+            self.ensureNormalGap();
+            if (!deduplicate) {
+                std.debug.print("{s}{s}{s} Task: {s}{s}\n", .{ self.normalStyle(ANSI.BOLD), self.normalStyle(ANSI.MAGENTA), SECTION_MARKER, header, self.normalStyle(ANSI.RESET) });
+            } else if (level == 2) {
+                std.debug.print("{s}{s}{s} {s}{s}\n", .{ self.normalStyle(ANSI.BOLD), self.normalStyle(ANSI.MAGENTA), SECTION_MARKER, header, self.normalStyle(ANSI.RESET) });
             } else {
-                std.debug.print("{s} {s}\n", .{ prefix, header });
+                std.debug.print("{s}{s}{s} {s}:{s}\n", .{ self.normalStyle(ANSI.BOLD), self.normalStyle(ANSI.MAGENTA), SECTION_MARKER, header, self.normalStyle(ANSI.RESET) });
             }
+            if (gap_after) std.debug.print("\n", .{});
+            self.normal_at_gap = gap_after;
             return;
         }
 
@@ -290,23 +439,20 @@ pub const ModernProvisionDisplay = struct {
             return;
         }
 
-        // Add an empty line before section (except for the first section)
+        // Separate a new section from preceding output. A trailing gap from the
+        // previous section already satisfies this boundary.
         if (self.section_messages.items.len > 0) {
-            const empty_spinner = try self.mp.addSpinner();
-            const empty_msg = try self.allocator.dupe(u8, "");
-            const empty_style = try indicatif.ProgressStyle.withTemplate(self.allocator, "{msg}");
-            empty_spinner.setStyle(empty_style);
-            empty_spinner.setMessage(empty_msg);
-            empty_spinner.finish();
-            try self.section_messages.append(self.allocator, empty_msg);
+            try self.addCompactGap();
         }
 
         // Create a static section header spinner
         const spinner = try self.mp.addSpinner();
-        const msg = if (level == 2)
-            try std.fmt.allocPrint(self.allocator, "{s}{s} {s}{s}", .{ ANSI.BOLD, prefix, header, ANSI.RESET })
+        const msg = if (!deduplicate)
+            try std.fmt.allocPrint(self.allocator, "{s}{s}{s} Task: {s}{s}", .{ ANSI.BOLD, ANSI.MAGENTA, SECTION_MARKER, header, ANSI.RESET })
+        else if (level == 2)
+            try std.fmt.allocPrint(self.allocator, "{s}{s}{s} {s}{s}", .{ ANSI.BOLD, ANSI.MAGENTA, SECTION_MARKER, header, ANSI.RESET })
         else
-            try std.fmt.allocPrint(self.allocator, "{s} {s}", .{ prefix, header });
+            try std.fmt.allocPrint(self.allocator, "{s}{s}{s} {s}:{s}", .{ ANSI.BOLD, ANSI.MAGENTA, SECTION_MARKER, header, ANSI.RESET });
 
         const style = try indicatif.ProgressStyle.withTemplate(self.allocator, "{msg}");
         spinner.setStyle(style);
@@ -315,6 +461,9 @@ pub const ModernProvisionDisplay = struct {
 
         // Keep track of section message for cleanup
         try self.section_messages.append(self.allocator, msg);
+        self.compact_at_gap = false;
+
+        if (gap_after) try self.addCompactGap();
 
         // Store the section spinner based on the header text
         if (is_download_section) {
@@ -329,33 +478,141 @@ pub const ModernProvisionDisplay = struct {
         }
     }
 
+    fn addCompactGap(self: *Self) !void {
+        if (!self.isCompact() or self.compact_at_gap) return;
+
+        const spinner = try self.mp.addSpinner();
+        errdefer {
+            self.mp.remove(spinner);
+            spinner.deinit();
+        }
+        const message = try self.allocator.dupe(u8, "");
+        errdefer self.allocator.free(message);
+        const style = try indicatif.ProgressStyle.withTemplate(self.allocator, "{msg}");
+        spinner.setStyle(style);
+        spinner.setMessage(message);
+        spinner.finish();
+        try self.section_messages.append(self.allocator, message);
+        self.compact_at_gap = true;
+
+        if (self.timer_spinner) |timer| {
+            self.mp.moveToEnd(timer);
+        }
+    }
+
     /// Show info message
     pub fn showInfo(self: *Self, message: []const u8) !void {
-        if (!self.show_progress) {
-            std.debug.print("\x1b[34mℹ\x1b[0m {s}\n", .{message});
+        if (!self.isCompact()) {
+            self.finishNormalResourceLine();
+            std.debug.print("  - {s}\n", .{message});
+            self.normal_at_gap = false;
         }
     }
 
     pub fn printLine(self: *Self, text: []const u8) !void {
-        if (!self.show_progress) {
+        if (!self.isCompact()) {
+            self.finishNormalResourceLine();
             std.debug.print("{s}\n", .{text});
+            self.normal_at_gap = false;
             return;
         }
         try self.mp.println(text);
+        self.compact_at_gap = false;
     }
 
     pub fn printCommandLine(self: *Self, stream: output_channel.Stream, line: []const u8) !void {
-        const message = switch (stream) {
-            .stdout => try std.fmt.allocPrint(self.allocator, "   {s}", .{line}),
-            .stderr => try std.fmt.allocPrint(self.allocator, "{s}   {s}{s}", .{ ANSI.RED, line, ANSI.RESET }),
-        };
-        defer self.allocator.free(message);
-        try self.printLine(message);
+        // Compact mode drains live output without retaining it. On failure the
+        // captured stdout/stderr is expanded by resourceError().
+        if (self.isCompact()) return;
+
+        self.finishNormalResourceLine();
+        printNormalIndent(self.normal_resource_depth + 2);
+        const stream_color = if (stream == .stdout) ANSI.DIM else ANSI.RED;
+        std.debug.print("{s}[{s}] {s}{s}\n", .{
+            self.normalStyle(stream_color),
+            if (stream == .stdout) "stdout" else "stderr",
+            line,
+            self.normalStyle(ANSI.RESET),
+        });
+        self.normal_at_gap = false;
+    }
+
+    pub fn showCommand(self: *Self, command: []const u8) !void {
+        if (!self.isCompact() or command.len == 0) return;
+        const spinner = self.resource_spinner orelse return;
+
+        const line_end = std.mem.indexOfScalar(u8, command, '\n') orelse command.len;
+        const continuation = if (line_end < command.len) " …" else "";
+        var counter_buffer: [64]u8 = undefined;
+        const message = try std.fmt.allocPrint(
+            self.allocator,
+            "{s}  {s}$ {s}{s}{s}",
+            .{ self.formatCounter(&counter_buffer), ANSI.DIM, command[0..line_end], continuation, ANSI.RESET },
+        );
+        const old_message = self.resource_message;
+        spinner.setMessage(message);
+        self.resource_message = message;
+        if (old_message) |old_msg| self.allocator.free(old_msg);
+    }
+
+    fn addCompactOwnedLine(self: *Self, message: []u8) !void {
+        errdefer self.allocator.free(message);
+        const style = try indicatif.ProgressStyle.withTemplate(self.allocator, "{msg}");
+        const spinner = try self.mp.addSpinner();
+        errdefer {
+            self.mp.remove(spinner);
+            spinner.deinit();
+        }
+        try self.download_finished_messages.append(self.allocator, message);
+        spinner.setStyle(style);
+        spinner.setMessage(message);
+        spinner.finish();
+        self.compact_at_gap = false;
+        if (self.timer_spinner) |timer| self.mp.moveToEnd(timer);
+    }
+
+    fn addCompactCommandDetails(self: *Self, command: []const u8) !void {
+        var lines = std.mem.splitScalar(u8, command, '\n');
+        var first = true;
+        while (lines.next()) |line| {
+            if (line.len == 0) continue;
+            const message = try std.fmt.allocPrint(
+                self.allocator,
+                "{s}{s} {s}{s}",
+                .{ ANSI.DIM, if (first) "$" else ">", line, ANSI.RESET },
+            );
+            try self.addCompactOwnedLine(message);
+            first = false;
+        }
+    }
+
+    fn addCompactOutputDetails(self: *Self, stream: output_channel.Stream, output: []const u8) !void {
+        var lines = std.mem.splitScalar(u8, output, '\n');
+        while (lines.next()) |line| {
+            if (line.len == 0) continue;
+            const message = switch (stream) {
+                .stdout => try std.fmt.allocPrint(self.allocator, "{s}│{s} {s}", .{ ANSI.DIM, ANSI.RESET, line }),
+                .stderr => try std.fmt.allocPrint(self.allocator, "{s}│ {s}{s}", .{ ANSI.RED, line, ANSI.RESET }),
+            };
+            try self.addCompactOwnedLine(message);
+        }
+    }
+
+    fn addCompactBacktrace(self: *Self, backtrace: []const u8) !void {
+        const label = try std.fmt.allocPrint(self.allocator, "{s}Backtrace:{s}", .{ ANSI.DIM, ANSI.RESET });
+        try self.addCompactOwnedLine(label);
+
+        var lines = std.mem.splitScalar(u8, backtrace, '\n');
+        while (lines.next()) |line| {
+            if (line.len == 0) continue;
+            const message = try std.fmt.allocPrint(self.allocator, "{s}│ {s}{s}", .{ ANSI.DIM, line, ANSI.RESET });
+            try self.addCompactOwnedLine(message);
+        }
     }
 
     /// Pre-create download spinners so they always occupy the top rows
     pub fn reserveDownloadSlots(self: *Self, names: [][]const u8) !void {
-        if (!self.show_progress) return;
+        if (!self.isCompact()) return;
 
         for (names) |name| {
             self.download_spinners_mutex.lockUncancelable(global_io.io());
@@ -376,12 +633,13 @@ pub const ModernProvisionDisplay = struct {
             self.download_spinners_mutex.lockUncancelable(global_io.io());
             try self.download_spinners.put(name_copy, .{ .spinner = spinner, .label = label });
             self.download_spinners_mutex.unlock(global_io.io());
+            self.compact_at_gap = false;
         }
     }
 
     /// Add/update a download spinner
     pub fn addDownload(self: *Self, name: []const u8, total_bytes: u64) !void {
-        if (!self.show_progress) {
+        if (!self.isCompact()) {
             // In plain mode, don't output anything - wait for finishDownload
             return;
         }
@@ -426,7 +684,7 @@ pub const ModernProvisionDisplay = struct {
 
     /// Update download progress with percentage
     pub fn updateDownload(self: *Self, name: []const u8, bytes_downloaded: u64) !void {
-        if (!self.show_progress) return;
+        if (!self.isCompact()) return;
 
         self.download_spinners_mutex.lockUncancelable(global_io.io());
         defer self.download_spinners_mutex.unlock(global_io.io());
@@ -474,7 +732,7 @@ pub const ModernProvisionDisplay = struct {
 
     /// Finish a download
     pub fn finishDownload(self: *Self, name: []const u8, success: bool) !void {
-        if (!self.show_progress) {
+        if (!self.isCompact()) {
             // In plain mode, downloads are silent - no output
             return;
         }
@@ -509,11 +767,24 @@ pub const ModernProvisionDisplay = struct {
     }
 
     /// Start a resource execution
-    pub fn startResource(self: *Self, resource_type: []const u8, resource_name: []const u8) !void {
+    pub fn startResource(
+        self: *Self,
+        resource_type: []const u8,
+        resource_name: []const u8,
+        action: []const u8,
+        depth: usize,
+        display_path: []const resources.DisplayScope,
+    ) !void {
         self.executed_count += 1;
 
-        if (!self.show_progress) {
-            // In plain mode, don't output "Processing..." - just wait for the final status
+        if (!self.isCompact()) {
+            self.finishNormalResourceLine();
+            self.syncNormalDisplayPath(display_path, depth);
+            self.normal_resource_depth = depth;
+            printNormalIndent(depth + 1);
+            std.debug.print("* {s}[{s}] action {s}", .{ resource_type, resource_name, action });
+            self.normal_resource_line_open = true;
+            self.normal_at_gap = false;
             return;
         }
 
@@ -536,6 +807,7 @@ pub const ModernProvisionDisplay = struct {
 
         self.resource_spinner = spinner;
         self.resource_message = msg; // Keep message allocated
+        self.compact_at_gap = false;
 
         // Move timer spinner to the end if it exists
         if (self.timer_spinner) |timer| {
@@ -546,7 +818,14 @@ pub const ModernProvisionDisplay = struct {
     /// Mark resource as updated. When skip_reason is set (e.g. "up to date"),
     /// the action ran but did not change state; otherwise the resource was
     /// actually modified.
-    pub fn resourceUpdated(self: *Self, resource_type: []const u8, resource_name: []const u8, action: []const u8, skip_reason: ?[]const u8) !void {
+    pub fn resourceUpdated(
+        self: *Self,
+        resource_type: []const u8,
+        resource_name: []const u8,
+        action: []const u8,
+        skip_reason: ?[]const u8,
+        output: ?[]const u8,
+    ) !void {
         self.updated_count += 1;
 
         const suffix: []const u8 = if (skip_reason) |reason|
@@ -555,9 +834,17 @@ pub const ModernProvisionDisplay = struct {
             "";
         defer if (skip_reason != null) self.allocator.free(suffix);
 
-        if (!self.show_progress) {
-            var counter_buffer: [64]u8 = undefined;
-            std.debug.print("{s}\x1b[32m✓ {s}  {s}[{s}] action {s}{s}\x1b[0m\n", .{ INDENT_RESOURCE, self.formatCounter(&counter_buffer), resource_type, resource_name, action, suffix });
+        if (!self.isCompact()) {
+            if (self.normal_resource_line_open) {
+                const status = skip_reason orelse "updated";
+                std.debug.print(" {s}({s}){s}\n", .{ self.normalStyle(ANSI.GREEN), status, self.normalStyle(ANSI.RESET) });
+                self.normal_resource_line_open = false;
+            }
+            if (output) |detail| {
+                if (!std.mem.eql(u8, resource_type, "execute")) {
+                    self.printNormalOutput(self.normal_resource_depth + 1, detail);
+                }
+            }
             return;
         }
 
@@ -590,10 +877,12 @@ pub const ModernProvisionDisplay = struct {
     pub fn resourceSkipped(self: *Self, resource_type: []const u8, resource_name: []const u8, action: []const u8, skip_reason: ?[]const u8) !void {
         self.skipped_count += 1;
 
-        if (!self.show_progress) {
+        if (!self.isCompact()) {
             const reason = skip_reason orelse "up to date";
-            var counter_buffer: [64]u8 = undefined;
-            std.debug.print("{s}\x1b[90m○ {s}  {s}[{s}] action {s} ({s})\x1b[0m\n", .{ INDENT_RESOURCE, self.formatCounter(&counter_buffer), resource_type, resource_name, action, reason });
+            if (self.normal_resource_line_open) {
+                std.debug.print(" {s}({s}){s}\n", .{ self.normalStyle(ANSI.CYAN), reason, self.normalStyle(ANSI.RESET) });
+                self.normal_resource_line_open = false;
+            }
             return;
         }
 
@@ -624,12 +913,51 @@ pub const ModernProvisionDisplay = struct {
     }
 
     /// Mark resource as failed
-    pub fn resourceError(self: *Self, resource_type: []const u8, resource_name: []const u8, error_msg: []const u8) !void {
+    pub fn resourceError(self: *Self, failure: ResourceFailure) !void {
         self.failed_count += 1;
 
-        if (!self.show_progress) {
-            var counter_buffer: [64]u8 = undefined;
-            std.debug.print("{s}\x1b[31m✗ {s}  {s}[{s}]: {s}\x1b[0m\n", .{ INDENT_RESOURCE, self.formatCounter(&counter_buffer), resource_type, resource_name, error_msg });
+        if (!self.isCompact()) {
+            self.finishNormalResourceLine();
+            const detail_indent = failure.depth + 2;
+            const message = if (failure.stderr != null)
+                failure.message[0 .. std.mem.indexOf(u8, failure.message, "; stderr:") orelse failure.message.len]
+            else
+                failure.message;
+            const message_includes_title = std.mem.indexOf(u8, message, failure.error_name) != null;
+            printNormalIndent(detail_indent);
+            std.debug.print("{s}{s}Error: {s}{s}\n", .{
+                self.normalStyle(ANSI.BOLD),
+                self.normalStyle(ANSI.RED),
+                if (message_includes_title) message else failure.error_name,
+                self.normalStyle(ANSI.RESET),
+            });
+            if (!message_includes_title) printNormalText(failure.depth + 2, message);
+
+            if (failure.command) |command| {
+                printNormalIndent(detail_indent);
+                std.debug.print("{s}Command:{s}\n", .{ self.normalStyle(ANSI.BOLD), self.normalStyle(ANSI.RESET) });
+                printNormalText(failure.depth + 2, command);
+            }
+
+            if (failure.stdout != null or failure.stderr != null) {
+                printNormalIndent(detail_indent);
+                std.debug.print("{s}Output:{s}\n", .{ self.normalStyle(ANSI.BOLD), self.normalStyle(ANSI.RESET) });
+                if (failure.stdout) |stdout| {
+                    printNormalIndent(detail_indent + 1);
+                    std.debug.print("{s}stdout:{s}\n", .{ self.normalStyle(ANSI.DIM), self.normalStyle(ANSI.RESET) });
+                    printNormalText(failure.depth + 3, stdout);
+                }
+                if (failure.stderr) |stderr| {
+                    printNormalIndent(detail_indent + 1);
+                    std.debug.print("{s}stderr:{s}\n", .{ self.normalStyle(ANSI.RED), self.normalStyle(ANSI.RESET) });
+                    printNormalText(failure.depth + 3, stderr);
+                }
+            }
+            if (failure.backtrace) |backtrace| {
+                printNormalIndent(detail_indent);
+                std.debug.print("{s}Backtrace:{s}\n", .{ self.normalStyle(ANSI.BOLD), self.normalStyle(ANSI.RESET) });
+                printNormalText(failure.depth + 2, backtrace);
+            }
             return;
         }
 
@@ -638,9 +966,13 @@ pub const ModernProvisionDisplay = struct {
                 self.allocator.free(old_msg);
             }
 
-            const suffix = try std.fmt.allocPrint(self.allocator, ": {s}", .{error_msg});
+            const detail = if (failure.stderr != null)
+                failure.message[0 .. std.mem.indexOf(u8, failure.message, "; stderr:") orelse failure.message.len]
+            else
+                failure.message;
+            const suffix = try std.fmt.allocPrint(self.allocator, ": {s}", .{detail});
             defer self.allocator.free(suffix);
-            const base = try self.buildResourceMessage(resource_type, resource_name, suffix);
+            const base = try self.buildResourceMessage(failure.resource_type, failure.resource_name, suffix);
             defer self.allocator.free(base);
             // Add indentation and error icon before the message
             const base_with_icon = try std.fmt.allocPrint(self.allocator, "{s}✗ {s}", .{ INDENT_RESOURCE, base });
@@ -656,36 +988,51 @@ pub const ModernProvisionDisplay = struct {
 
             self.resource_spinner = null;
             self.resource_message = null;
+
+            if (failure.command) |command| try self.addCompactCommandDetails(command);
+            if (failure.stdout) |stdout| try self.addCompactOutputDetails(.stdout, stdout);
+            if (failure.stderr) |stderr| try self.addCompactOutputDetails(.stderr, stderr);
+            if (failure.backtrace) |backtrace| try self.addCompactBacktrace(backtrace);
         }
     }
 
     /// Show notification
     pub fn showNotification(self: *Self, source_id: []const u8, target: []const u8, action: []const u8) !void {
-        if (!self.show_progress) {
-            std.debug.print("{s}\x1b[36m🔔 {s} -> {s} ({s})\x1b[0m\n", .{ INDENT_NOTIFICATION, source_id, target, action });
+        if (!self.isCompact()) {
+            self.finishNormalResourceLine();
+            printNormalIndent(1);
+            std.debug.print("{s}- notify {s} -> {s} ({s}){s}\n", .{ self.normalStyle(ANSI.CYAN), source_id, target, action, self.normalStyle(ANSI.RESET) });
+            self.normal_at_gap = false;
+            return;
         }
+
+        const message = try std.fmt.allocPrint(
+            self.allocator,
+            "{s}  - notify {s} -> {s} ({s}){s}",
+            .{ ANSI.CYAN, source_id, target, action, ANSI.RESET },
+        );
+        try self.addCompactOwnedLine(message);
     }
 
     /// Show final summary
     pub fn showSummary(self: *Self) !void {
         // Don't clear - we want to keep the finished resource list visible
-        // if (self.show_progress) {
+        // if (self.isCompact()) {
         //     try self.mp.clear();
         // }
 
-        if (!self.show_progress) {
-            std.debug.print("\n\x1b[1m\x1b[36m--- Execution Summary ---\x1b[0m\n", .{});
-            std.debug.print("Executed: {d} resources\n", .{self.executed_count});
-            std.debug.print("Updated: \x1b[32m{d}\x1b[0m resources\n", .{self.updated_count});
-            std.debug.print("Skipped: \x1b[2m{d}\x1b[0m resources\n", .{self.skipped_count});
-            if (self.failed_count > 0) {
-                std.debug.print("Failed: \x1b[31m{d}\x1b[0m resources\n", .{self.failed_count});
-            }
-            if (self.failed_count == 0) {
-                std.debug.print("\x1b[32m✓\x1b[0m Provisioning completed successfully!\n", .{});
-            } else {
-                std.debug.print("\x1b[31m✗\x1b[0m Provisioning completed with {d} failed resources.\n", .{self.failed_count});
-            }
+        if (!self.isCompact()) {
+            self.finishNormalResourceLine();
+            const succeeded = !self.run_failed and self.failed_count == 0;
+            std.debug.print("\n{s}Provisioning {s}, {d}/{d} resources updated", .{
+                self.normalStyle(if (succeeded) ANSI.GREEN else ANSI.RED),
+                if (succeeded) "complete" else "failed",
+                self.updated_count,
+                self.executed_count,
+            });
+            if (self.failed_count > 0) std.debug.print(", {d} failed", .{self.failed_count});
+            if (self.handled_failure_count > 0) std.debug.print(", {d} handled failure{s}", .{ self.handled_failure_count, if (self.handled_failure_count == 1) "" else "s" });
+            std.debug.print("{s}\n", .{self.normalStyle(ANSI.RESET)});
         }
     }
 
@@ -702,36 +1049,43 @@ pub const ModernProvisionDisplay = struct {
         self.run_failed = true;
     }
 
+    pub fn failureCheckpoint(self: *const Self) usize {
+        return self.failed_count;
+    }
+
+    /// Reclassify failures raised and handled inside a successful task action.
+    /// The resource row remains visible as a failure, but it no longer makes the
+    /// overall task run fail.
+    pub fn handleFailuresSince(self: *Self, checkpoint: usize) void {
+        if (self.failed_count <= checkpoint) return;
+        self.handled_failure_count += self.failed_count - checkpoint;
+        self.failed_count = checkpoint;
+    }
+
     fn showSummaryWithDurationLabel(self: *Self, label: []const u8, duration_s: i64, duration_ms_part: i64) !void {
         _ = duration_s;
         _ = duration_ms_part;
 
-        if (!self.show_progress) {
-            std.debug.print("\n\x1b[1m\x1b[36m--- Execution Summary ---\x1b[0m\n", .{});
-            std.debug.print("Executed: {d} resources\n", .{self.executed_count});
-            std.debug.print("Updated: \x1b[32m{d}\x1b[0m resources\n", .{self.updated_count});
-            std.debug.print("Skipped: \x1b[2m{d}\x1b[0m resources\n", .{self.skipped_count});
-            if (self.failed_count > 0) {
-                std.debug.print("Failed: \x1b[31m{d}\x1b[0m resources\n", .{self.failed_count});
-            }
-
+        if (!self.isCompact()) {
+            self.finishNormalResourceLine();
             const io = global_io.io();
             const current_time: i128 = std.Io.Timestamp.now(io, .real).toNanoseconds();
             const elapsed_ns = current_time - self.start_time;
             const elapsed_ms = @divTrunc(elapsed_ns, std.time.ns_per_ms);
             const elapsed_s = @divTrunc(elapsed_ms, 1000);
             const elapsed_ms_part = @rem(elapsed_ms, 1000);
-            std.debug.print("Duration: \x1b[36m{d}.{d:0>3}s\x1b[0m\n", .{ elapsed_s, @abs(elapsed_ms_part) });
-            if (!self.run_failed and self.failed_count == 0) {
-                std.debug.print("\x1b[32m✓\x1b[0m {s} completed successfully!\n", .{label});
-            } else if (self.failed_count > 0) {
-                std.debug.print("\x1b[31m✗\x1b[0m {s} completed with {d} failed resources.\n", .{ label, self.failed_count });
-            } else {
-                std.debug.print("\x1b[31m✗\x1b[0m {s} failed.\n", .{label});
-            }
+            const summary = try self.formatSummaryMessage(label, elapsed_s, @intCast(@abs(elapsed_ms_part)));
+            defer self.allocator.free(summary);
+            std.debug.print("\n{s}{s}{s}\n", .{
+                self.normalStyle(if (self.didSucceed()) ANSI.GREEN else ANSI.RED),
+                summary,
+                self.normalStyle(ANSI.RESET),
+            });
         } else {
+            try self.addCompactGap();
+
             // Finish the timer spinner with final message
-            try self.finishTimer();
+            try self.finishTimer(label);
 
             // Draw the final state
             try self.mp.draw();
@@ -740,7 +1094,7 @@ pub const ModernProvisionDisplay = struct {
 
     /// Update display (for continuous rendering)
     pub fn update(self: *Self) !void {
-        if (!self.show_progress) return;
+        if (!self.isCompact()) return;
 
         // Update timer message
         try self.updateTimer();
@@ -812,7 +1166,7 @@ pub const ModernProvisionDisplay = struct {
 };
 
 test "formatCounter supports known and unknown totals" {
-    var display = try ModernProvisionDisplay.init(std.testing.allocator, false);
+    var display = try ModernProvisionDisplay.init(std.testing.allocator, .normal);
     defer display.deinit();
     var buffer: [64]u8 = undefined;
 
@@ -828,4 +1182,105 @@ test "formatCounter supports known and unknown totals" {
 
     display.setTotalResources(100);
     try std.testing.expectEqualStrings("[  3/100]", display.formatCounter(&buffer));
+}
+
+test "unified diff lines use semantic terminal colors" {
+    const diff =
+        \\diff --git a/config b/config
+        \\index 1111111..2222222 100644
+        \\--- a/config
+        \\+++ b/config
+        \\@@ -1 +1 @@
+        \\-old
+        \\+new
+    ;
+    try std.testing.expect(ModernProvisionDisplay.isUnifiedDiff(diff));
+    try std.testing.expectEqualStrings(ANSI.DIM, ModernProvisionDisplay.diffLineStyle("diff --git a/config b/config"));
+    try std.testing.expectEqualStrings(ANSI.DIM, ModernProvisionDisplay.diffLineStyle("index 1111111..2222222 100644"));
+    try std.testing.expectEqualStrings(ANSI.RED, ModernProvisionDisplay.diffLineStyle("--- a/config"));
+    try std.testing.expectEqualStrings(ANSI.RED, ModernProvisionDisplay.diffLineStyle("-old"));
+    try std.testing.expectEqualStrings(ANSI.GREEN, ModernProvisionDisplay.diffLineStyle("+++ b/config"));
+    try std.testing.expectEqualStrings(ANSI.GREEN, ModernProvisionDisplay.diffLineStyle("+new"));
+    try std.testing.expectEqualStrings(ANSI.CYAN, ModernProvisionDisplay.diffLineStyle("@@ -1 +1 @@"));
+    try std.testing.expectEqualStrings("", ModernProvisionDisplay.diffLineStyle(" unchanged"));
+}
+
+test "notification heading stays attached to its compact list" {
+    const allocator = std.testing.allocator;
+    var display = try ModernProvisionDisplay.init(allocator, .compact);
+    defer display.deinit();
+
+    try display.showNotificationSection("Immediate notifications");
+    try std.testing.expect(!display.compact_at_gap);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        display.section_messages.items[0],
+        ANSI.MAGENTA ++ SECTION_MARKER ++ " Immediate notifications:",
+    ) != null);
+
+    try display.showNotification("file[/tmp/config]", "execute[reload]", "run");
+    try std.testing.expectEqual(@as(usize, 1), display.download_finished_messages.items.len);
+    try std.testing.expect(std.mem.indexOf(
+        u8,
+        display.download_finished_messages.items[0],
+        "  - notify file[/tmp/config] -> execute[reload] (run)",
+    ) != null);
+
+    try display.showNotificationSection("Delayed notifications");
+    try std.testing.expectEqual(@as(usize, 3), display.section_messages.items.len);
+    try std.testing.expectEqualStrings("", display.section_messages.items[1]);
+    try std.testing.expect(!display.compact_at_gap);
+}
+
+test "compact output collapses successful command details" {
+    const allocator = std.testing.allocator;
+    var display = try ModernProvisionDisplay.init(allocator, .compact);
+    defer display.deinit();
+
+    try display.startResource("execute", "build step", "run", 0, &.{});
+    try display.showCommand("printf 'successful output\\n'");
+    try std.testing.expect(std.mem.indexOf(u8, display.resource_message.?, "$ printf") != null);
+
+    try display.printCommandLine(.stdout, "successful output");
+    try display.resourceUpdated("execute", "build step", "run", null, "successful output\n");
+
+    try std.testing.expectEqual(@as(usize, 1), display.download_finished_messages.items.len);
+    const final_line = display.download_finished_messages.items[0];
+    try std.testing.expect(std.mem.indexOf(u8, final_line, "execute[build step] action run") != null);
+    try std.testing.expect(std.mem.indexOf(u8, final_line, "printf") == null);
+    try std.testing.expect(std.mem.indexOf(u8, final_line, "successful output") == null);
+}
+
+test "compact output expands failed command diagnostics" {
+    const allocator = std.testing.allocator;
+    var display = try ModernProvisionDisplay.init(allocator, .compact);
+    defer display.deinit();
+
+    try display.startResource("execute", "compile", "run", 0, &.{});
+    try display.showCommand("cc main.c");
+    try display.resourceError(.{
+        .resource_type = "execute",
+        .resource_name = "compile",
+        .action = "run",
+        .depth = 0,
+        .error_name = "Command failed",
+        .message = "command exited with status 1; stderr: compile failed",
+        .command = "cc main.c",
+        .stdout = "compiling main.c\n",
+        .stderr = "compile failed\n",
+        .backtrace = "Holafile:12",
+    });
+
+    try std.testing.expectEqual(@as(usize, 6), display.download_finished_messages.items.len);
+    const expected = [_][]const u8{
+        "command exited with status 1",
+        "$ cc main.c",
+        "compiling main.c",
+        "compile failed",
+        "Backtrace:",
+        "Holafile:12",
+    };
+    for (expected, display.download_finished_messages.items) |needle, line| {
+        try std.testing.expect(std.mem.indexOf(u8, line, needle) != null);
+    }
 }

--- a/src/modern_provision_display.zig
+++ b/src/modern_provision_display.zig
@@ -247,16 +247,19 @@ pub const ModernProvisionDisplay = struct {
         const succeeded = self.didSucceed();
         const summary = try self.formatSummaryMessage(label, elapsed_s, @intCast(elapsed_ms_part));
         defer self.allocator.free(summary);
-        const base_msg = try std.fmt.allocPrint(self.allocator, "{s} {s}", .{ if (succeeded) "✓" else "✗", summary });
-        defer self.allocator.free(base_msg);
-
-        const colored_msg = try self.makeColoredMessage(if (succeeded) .Green else .Red, true, base_msg);
-        try self.download_finished_messages.append(self.allocator, colored_msg);
+        const status_color = if (succeeded) ANSI.BRIGHT_GREEN else ANSI.RED;
+        const message = try std.fmt.allocPrint(self.allocator, "{s}{s}{s} {s}", .{
+            status_color,
+            if (succeeded) "✓" else "✗",
+            ANSI.RESET,
+            summary,
+        });
+        try self.download_finished_messages.append(self.allocator, message);
 
         if (self.timer_spinner) |spinner| {
             const finished_style = try indicatif.ProgressStyle.withTemplate(self.allocator, "{msg}");
             spinner.setStyle(finished_style);
-            spinner.setMessage(colored_msg);
+            spinner.setMessage(message);
             spinner.state.finish();
         }
 
@@ -363,7 +366,7 @@ pub const ModernProvisionDisplay = struct {
         if (std.mem.startsWith(u8, line, "diff --git ") or std.mem.startsWith(u8, line, "index ")) return ANSI.DIM;
         if (std.mem.startsWith(u8, line, "--- ") or std.mem.startsWith(u8, line, "-")) return ANSI.RED;
         if (std.mem.startsWith(u8, line, "+++ ") or std.mem.startsWith(u8, line, "+")) return ANSI.GREEN;
-        if (std.mem.startsWith(u8, line, "@@")) return ANSI.CYAN;
+        if (std.mem.startsWith(u8, line, "@@")) return ANSI.MAGENTA;
         if (std.mem.startsWith(u8, line, "\\ No newline at end of file")) return ANSI.YELLOW;
         return "";
     }
@@ -828,16 +831,10 @@ pub const ModernProvisionDisplay = struct {
     ) !void {
         self.updated_count += 1;
 
-        const suffix: []const u8 = if (skip_reason) |reason|
-            try std.fmt.allocPrint(self.allocator, " ({s})", .{reason})
-        else
-            "";
-        defer if (skip_reason != null) self.allocator.free(suffix);
-
         if (!self.isCompact()) {
             if (self.normal_resource_line_open) {
                 const status = skip_reason orelse "updated";
-                std.debug.print(" {s}({s}){s}\n", .{ self.normalStyle(ANSI.GREEN), status, self.normalStyle(ANSI.RESET) });
+                std.debug.print(" {s}({s}){s}\n", .{ self.normalStyle(ANSI.BRIGHT_GREEN), status, self.normalStyle(ANSI.RESET) });
                 self.normal_resource_line_open = false;
             }
             if (output) |detail| {
@@ -855,12 +852,18 @@ pub const ModernProvisionDisplay = struct {
 
             const base = try self.buildResourceMessage(resource_type, resource_name, "");
             defer self.allocator.free(base);
-            const message = try std.fmt.allocPrint(self.allocator, "{s} action {s}{s}", .{ base, action, suffix });
-            defer self.allocator.free(message);
-            // Add indentation and checkmark icon before the message
-            const base_with_checkmark = try std.fmt.allocPrint(self.allocator, "{s}✓ {s}", .{ INDENT_RESOURCE, message });
-            defer self.allocator.free(base_with_checkmark);
-            const msg = try self.makeColoredMessage(.Green, true, base_with_checkmark);
+            const msg = if (skip_reason) |reason|
+                try std.fmt.allocPrint(
+                    self.allocator,
+                    "{s}{s}✓{s} {s} {s}action {s} ({s}){s}",
+                    .{ INDENT_RESOURCE, ANSI.BRIGHT_GREEN, ANSI.RESET, base, ANSI.BRIGHT_GREEN, action, reason, ANSI.RESET },
+                )
+            else
+                try std.fmt.allocPrint(
+                    self.allocator,
+                    "{s}{s}✓{s} {s} {s}action {s}{s}",
+                    .{ INDENT_RESOURCE, ANSI.BRIGHT_GREEN, ANSI.RESET, base, ANSI.BRIGHT_GREEN, action, ANSI.RESET },
+                );
             try self.download_finished_messages.append(self.allocator, msg);
 
             const finished_style = try indicatif.ProgressStyle.withTemplate(self.allocator, "{msg}");
@@ -880,7 +883,7 @@ pub const ModernProvisionDisplay = struct {
         if (!self.isCompact()) {
             const reason = skip_reason orelse "up to date";
             if (self.normal_resource_line_open) {
-                std.debug.print(" {s}({s}){s}\n", .{ self.normalStyle(ANSI.CYAN), reason, self.normalStyle(ANSI.RESET) });
+                std.debug.print(" {s}({s}){s}\n", .{ self.normalStyle(ANSI.DIM), reason, self.normalStyle(ANSI.RESET) });
                 self.normal_resource_line_open = false;
             }
             return;
@@ -894,17 +897,16 @@ pub const ModernProvisionDisplay = struct {
             const base = try self.buildResourceMessage(resource_type, resource_name, "");
             defer self.allocator.free(base);
             const reason = skip_reason orelse "up to date";
-            const message = try std.fmt.allocPrint(self.allocator, "{s} action {s} ({s})", .{ base, action, reason });
-            defer self.allocator.free(message);
-            // Add indentation and skip icon (hollow circle) before the message
-            // Use gray color (ANSI Bright Black, code 90) for modern terminals
-            const base_with_icon = try std.fmt.allocPrint(self.allocator, "{s}\x1b[90m○ {s}\x1b[0m", .{ INDENT_RESOURCE, message });
-            // Don't free base_with_icon here - it's stored in download_finished_messages
-            try self.download_finished_messages.append(self.allocator, base_with_icon);
+            const message = try std.fmt.allocPrint(
+                self.allocator,
+                "{s}{s}○{s} {s} action {s} {s}({s}){s}",
+                .{ INDENT_RESOURCE, ANSI.DIM, ANSI.RESET, base, action, ANSI.DIM, reason, ANSI.RESET },
+            );
+            try self.download_finished_messages.append(self.allocator, message);
 
             const finished_style = try indicatif.ProgressStyle.withTemplate(self.allocator, "{msg}");
             spinner.setStyle(finished_style);
-            spinner.setMessage(base_with_icon);
+            spinner.setMessage(message);
             spinner.state.finish();
 
             self.resource_spinner = null;
@@ -1001,15 +1003,15 @@ pub const ModernProvisionDisplay = struct {
         if (!self.isCompact()) {
             self.finishNormalResourceLine();
             printNormalIndent(1);
-            std.debug.print("{s}- notify {s} -> {s} ({s}){s}\n", .{ self.normalStyle(ANSI.CYAN), source_id, target, action, self.normalStyle(ANSI.RESET) });
+            std.debug.print("- notify {s} -> {s} ({s})\n", .{ source_id, target, action });
             self.normal_at_gap = false;
             return;
         }
 
         const message = try std.fmt.allocPrint(
             self.allocator,
-            "{s}  - notify {s} -> {s} ({s}){s}",
-            .{ ANSI.CYAN, source_id, target, action, ANSI.RESET },
+            "  - notify {s} -> {s} ({s})",
+            .{ source_id, target, action },
         );
         try self.addCompactOwnedLine(message);
     }
@@ -1024,15 +1026,17 @@ pub const ModernProvisionDisplay = struct {
         if (!self.isCompact()) {
             self.finishNormalResourceLine();
             const succeeded = !self.run_failed and self.failed_count == 0;
-            std.debug.print("\n{s}Provisioning {s}, {d}/{d} resources updated", .{
-                self.normalStyle(if (succeeded) ANSI.GREEN else ANSI.RED),
+            std.debug.print("\n{s}{s}{s} Provisioning {s}, {d}/{d} resources updated", .{
+                self.normalStyle(if (succeeded) ANSI.BRIGHT_GREEN else ANSI.RED),
+                if (succeeded) "✓" else "✗",
+                self.normalStyle(ANSI.RESET),
                 if (succeeded) "complete" else "failed",
                 self.updated_count,
                 self.executed_count,
             });
             if (self.failed_count > 0) std.debug.print(", {d} failed", .{self.failed_count});
             if (self.handled_failure_count > 0) std.debug.print(", {d} handled failure{s}", .{ self.handled_failure_count, if (self.handled_failure_count == 1) "" else "s" });
-            std.debug.print("{s}\n", .{self.normalStyle(ANSI.RESET)});
+            std.debug.print("\n", .{});
         }
     }
 
@@ -1076,10 +1080,11 @@ pub const ModernProvisionDisplay = struct {
             const elapsed_ms_part = @rem(elapsed_ms, 1000);
             const summary = try self.formatSummaryMessage(label, elapsed_s, @intCast(@abs(elapsed_ms_part)));
             defer self.allocator.free(summary);
-            std.debug.print("\n{s}{s}{s}\n", .{
-                self.normalStyle(if (self.didSucceed()) ANSI.GREEN else ANSI.RED),
-                summary,
+            std.debug.print("\n{s}{s}{s} {s}\n", .{
+                self.normalStyle(if (self.didSucceed()) ANSI.BRIGHT_GREEN else ANSI.RED),
+                if (self.didSucceed()) "✓" else "✗",
                 self.normalStyle(ANSI.RESET),
+                summary,
             });
         } else {
             try self.addCompactGap();
@@ -1201,7 +1206,7 @@ test "unified diff lines use semantic terminal colors" {
     try std.testing.expectEqualStrings(ANSI.RED, ModernProvisionDisplay.diffLineStyle("-old"));
     try std.testing.expectEqualStrings(ANSI.GREEN, ModernProvisionDisplay.diffLineStyle("+++ b/config"));
     try std.testing.expectEqualStrings(ANSI.GREEN, ModernProvisionDisplay.diffLineStyle("+new"));
-    try std.testing.expectEqualStrings(ANSI.CYAN, ModernProvisionDisplay.diffLineStyle("@@ -1 +1 @@"));
+    try std.testing.expectEqualStrings(ANSI.MAGENTA, ModernProvisionDisplay.diffLineStyle("@@ -1 +1 @@"));
     try std.testing.expectEqualStrings("", ModernProvisionDisplay.diffLineStyle(" unchanged"));
 }
 
@@ -1225,6 +1230,7 @@ test "notification heading stays attached to its compact list" {
         display.download_finished_messages.items[0],
         "  - notify file[/tmp/config] -> execute[reload] (run)",
     ) != null);
+    try std.testing.expect(std.mem.indexOf(u8, display.download_finished_messages.items[0], ANSI.CYAN) == null);
 
     try display.showNotificationSection("Delayed notifications");
     try std.testing.expectEqual(@as(usize, 3), display.section_messages.items.len);
@@ -1237,6 +1243,7 @@ test "compact output collapses successful command details" {
     var display = try ModernProvisionDisplay.init(allocator, .compact);
     defer display.deinit();
 
+    display.setTotalResources(1);
     try display.startResource("execute", "build step", "run", 0, &.{});
     try display.showCommand("printf 'successful output\\n'");
     try std.testing.expect(std.mem.indexOf(u8, display.resource_message.?, "$ printf") != null);
@@ -1246,9 +1253,28 @@ test "compact output collapses successful command details" {
 
     try std.testing.expectEqual(@as(usize, 1), display.download_finished_messages.items.len);
     const final_line = display.download_finished_messages.items[0];
-    try std.testing.expect(std.mem.indexOf(u8, final_line, "execute[build step] action run") != null);
+    try std.testing.expectEqualStrings(
+        ANSI.BRIGHT_GREEN ++ "✓" ++ ANSI.RESET ++ " [1/1]  execute[build step] " ++ ANSI.BRIGHT_GREEN ++ "action run" ++ ANSI.RESET,
+        final_line,
+    );
     try std.testing.expect(std.mem.indexOf(u8, final_line, "printf") == null);
     try std.testing.expect(std.mem.indexOf(u8, final_line, "successful output") == null);
+}
+
+test "compact skipped resource colors only its status markers" {
+    const allocator = std.testing.allocator;
+    var display = try ModernProvisionDisplay.init(allocator, .compact);
+    defer display.deinit();
+
+    display.setTotalResources(1);
+    try display.startResource("file", "/tmp/unchanged", "create", 0, &.{});
+    try display.resourceSkipped("file", "/tmp/unchanged", "create", "up to date");
+
+    try std.testing.expectEqual(@as(usize, 1), display.download_finished_messages.items.len);
+    try std.testing.expectEqualStrings(
+        ANSI.DIM ++ "○" ++ ANSI.RESET ++ " [1/1]  file[/tmp/unchanged] action create " ++ ANSI.DIM ++ "(up to date)" ++ ANSI.RESET,
+        display.download_finished_messages.items[0],
+    );
 }
 
 test "compact output expands failed command diagnostics" {

--- a/src/mruby.zig
+++ b/src/mruby.zig
@@ -98,6 +98,7 @@ pub extern fn mrb_intern_cstr(mrb: *mrb_state, str: [*c]const u8) mrb_sym;
 pub extern fn zig_mrb_type(val: mrb_value) u32;
 pub const mrb_type = zig_mrb_type;
 pub extern fn zig_mrb_string_p(val: mrb_value) c_int;
+pub extern fn zig_mrb_array_p(val: mrb_value) c_int;
 
 // Array handling (using C helpers)
 pub extern fn zig_mrb_ary_len(mrb: *mrb_state, arr: mrb_value) mrb_int;

--- a/src/mruby.zig
+++ b/src/mruby.zig
@@ -58,11 +58,36 @@ pub extern fn mrb_yield_argv(mrb: *mrb_state, b: mrb_value, argc: mrb_int, argv:
 
 // Function call
 pub extern fn mrb_funcall_argv(mrb: *mrb_state, val: mrb_value, name: mrb_sym, argc: mrb_int, argv: [*c]const mrb_value) mrb_value;
+extern fn zig_mrb_funcall_protected(mrb: *mrb_state, val: mrb_value, name: mrb_sym, argc: mrb_int, argv: [*c]const mrb_value, raised: *mrb_bool) mrb_value;
+extern fn zig_mrb_load_nstring_protected(mrb: *mrb_state, source: [*c]const u8, length: usize, filename: [*c]const u8, raised: *mrb_bool) mrb_value;
+
+pub const CallResult = union(enum) {
+    ok: mrb_value,
+    raised: mrb_value,
+};
+
+pub fn callProtected(mrb: *mrb_state, receiver: mrb_value, method: [*:0]const u8, args: []const mrb_value) CallResult {
+    const method_sym = mrb_intern_cstr(mrb, method);
+    var raised: mrb_bool = 0;
+    const argv: [*c]const mrb_value = if (args.len == 0) null else args.ptr;
+    const result = zig_mrb_funcall_protected(mrb, receiver, method_sym, @intCast(args.len), argv, &raised);
+    return if (raised != 0) .{ .raised = result } else .{ .ok = result };
+}
+
+pub fn loadStringProtected(mrb: *mrb_state, source: []const u8, filename: [*:0]const u8) CallResult {
+    var raised: mrb_bool = 0;
+    const result = zig_mrb_load_nstring_protected(mrb, source.ptr, source.len, filename, &raised);
+    return if (raised != 0) .{ .raised = result } else .{ .ok = result };
+}
 
 // GC protection
 pub extern fn mrb_gc_register(mrb: *mrb_state, obj: mrb_value) void;
 pub extern fn mrb_gc_unregister(mrb: *mrb_state, obj: mrb_value) void;
 pub extern fn mrb_gc_protect(mrb: *mrb_state, obj: mrb_value) void;
+pub extern fn zig_mrb_gc_arena_save(mrb: *mrb_state) c_int;
+pub extern fn zig_mrb_gc_arena_restore(mrb: *mrb_state, arena_index: c_int) void;
+pub extern fn zig_mrb_print_exc(mrb: *mrb_state, exc: mrb_value) void;
+pub extern fn zig_mrb_has_exception(mrb: *mrb_state) c_int;
 
 // Global variables
 pub extern fn mrb_gv_get(mrb: *mrb_state, sym: mrb_sym) mrb_value;
@@ -82,6 +107,8 @@ pub extern fn zig_mrb_float(mrb: *mrb_state, val: mrb_value) f64;
 
 // Value constructors
 pub extern fn zig_mrb_int_value(mrb: *mrb_state, i: mrb_int) mrb_value;
+pub extern fn zig_mrb_true_value() mrb_value;
+pub extern fn zig_mrb_false_value() mrb_value;
 
 // Array creation and manipulation
 pub extern fn mrb_ary_new_capa(mrb: *mrb_state, capa: mrb_int) mrb_value;
@@ -207,5 +234,15 @@ pub const State = struct {
             mrb_print_error(mrb);
             return error.MRubyException;
         }
+    }
+
+    pub fn setGlobal(self: *State, name: [*:0]const u8, value: mrb_value) void {
+        const state = self.mrb orelse return;
+        mrb_gv_set(state, mrb_intern_cstr(state, name), value);
+    }
+
+    pub fn getGlobal(self: *State, name: [*:0]const u8) mrb_value {
+        const state = self.mrb orelse return mrb_nil_value();
+        return mrb_gv_get(state, mrb_intern_cstr(state, name));
     }
 };

--- a/src/mruby_helpers.c
+++ b/src/mruby_helpers.c
@@ -6,6 +6,7 @@
 #include <mruby/variable.h>
 #include <mruby/class.h>
 #include <mruby/error.h>
+#include <mruby/compile.h>
 #include <stdio.h>
 
 #ifdef __linux__
@@ -182,4 +183,78 @@ void zig_mrb_exc_summary(mrb_state *mrb, mrb_value exc, char *buf, size_t buflen
     } else {
         snprintf(buf, buflen, "%s", class_name);
     }
+}
+
+struct zig_mrb_funcall_context {
+    mrb_value receiver;
+    mrb_sym method;
+    mrb_int argc;
+    const mrb_value *argv;
+};
+
+static mrb_value zig_mrb_funcall_body(mrb_state *mrb, void *userdata) {
+    struct zig_mrb_funcall_context *context = userdata;
+    return mrb_funcall_argv(mrb, context->receiver, context->method,
+                            context->argc, context->argv);
+}
+
+// Call Ruby with a catch frame even when invoked reentrantly from the VM. This
+// prevents a Ruby raise from longjmping across Zig stack frames and skipping
+// their cleanup.
+mrb_value zig_mrb_funcall_protected(mrb_state *mrb, mrb_value receiver,
+                                    mrb_sym method, mrb_int argc,
+                                    const mrb_value *argv, mrb_bool *raised) {
+    struct zig_mrb_funcall_context context = {
+        .receiver = receiver,
+        .method = method,
+        .argc = argc,
+        .argv = argv,
+    };
+    return mrb_protect_error(mrb, zig_mrb_funcall_body, &context, raised);
+}
+
+int zig_mrb_gc_arena_save(mrb_state *mrb) {
+    return mrb_gc_arena_save(mrb);
+}
+
+void zig_mrb_gc_arena_restore(mrb_state *mrb, int arena_index) {
+    mrb_gc_arena_restore(mrb, arena_index);
+}
+
+void zig_mrb_print_exc(mrb_state *mrb, mrb_value exc) {
+    struct RObject *previous = mrb->exc;
+    mrb->exc = mrb_exc_ptr(exc);
+    mrb_print_error(mrb);
+    mrb->exc = previous;
+}
+
+struct zig_mrb_load_context {
+    const char *source;
+    size_t length;
+    mrbc_context *context;
+};
+
+static mrb_value zig_mrb_load_body(mrb_state *mrb, void *userdata) {
+    struct zig_mrb_load_context *context = userdata;
+    return mrb_load_nstring_cxt(mrb, context->source, context->length,
+                                context->context);
+}
+
+mrb_value zig_mrb_load_nstring_protected(mrb_state *mrb, const char *source,
+                                         size_t length, const char *filename,
+                                         mrb_bool *raised) {
+    mrbc_context *compiler_context = mrbc_context_new(mrb);
+    if (compiler_context == NULL) {
+        if (raised) *raised = TRUE;
+        return mrb_nil_value();
+    }
+    mrbc_filename(mrb, compiler_context, filename);
+    struct zig_mrb_load_context context = {
+        .source = source,
+        .length = length,
+        .context = compiler_context,
+    };
+    mrb_value result = mrb_protect_error(mrb, zig_mrb_load_body, &context, raised);
+    mrbc_context_free(mrb, compiler_context);
+    return result;
 }

--- a/src/output_channel.zig
+++ b/src/output_channel.zig
@@ -1,0 +1,100 @@
+const std = @import("std");
+const global_io = @import("global_io.zig");
+
+pub const Stream = enum(u8) {
+    stdout = 1,
+    stderr = 2,
+};
+
+pub const Batch = struct {
+    bytes: []u8,
+    dropped: usize,
+};
+
+/// Bounded worker-to-main line queue used by live command output. Records are
+/// encoded as one stream tag byte, the line bytes, and a trailing newline.
+pub const LineChannel = struct {
+    pub const MAX_PENDING_BYTES: usize = 1024 * 1024;
+
+    allocator: std.mem.Allocator,
+    mutex: std.Io.Mutex = .init,
+    pending: std.ArrayList(u8) = .empty,
+    dropped: usize = 0,
+
+    pub fn init(allocator: std.mem.Allocator) LineChannel {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *LineChannel) void {
+        self.pending.deinit(self.allocator);
+        self.pending = .empty;
+    }
+
+    pub fn push(self: *LineChannel, stream: Stream, line: []const u8) void {
+        self.mutex.lockUncancelable(global_io.io());
+        defer self.mutex.unlock(global_io.io());
+
+        const record_len = 1 + line.len + 1;
+        if (record_len > MAX_PENDING_BYTES or self.pending.items.len + record_len > MAX_PENDING_BYTES) {
+            self.dropped += 1;
+            return;
+        }
+        self.pending.append(self.allocator, @intFromEnum(stream)) catch {
+            self.dropped += 1;
+            return;
+        };
+        self.pending.appendSlice(self.allocator, line) catch {
+            _ = self.pending.pop();
+            self.dropped += 1;
+            return;
+        };
+        self.pending.append(self.allocator, '\n') catch {
+            self.pending.shrinkRetainingCapacity(self.pending.items.len - line.len - 1);
+            self.dropped += 1;
+        };
+    }
+
+    pub fn take(self: *LineChannel) !Batch {
+        self.mutex.lockUncancelable(global_io.io());
+        var pending = self.pending;
+        self.pending = .empty;
+        const dropped = self.dropped;
+        self.dropped = 0;
+        self.mutex.unlock(global_io.io());
+        errdefer pending.deinit(self.allocator);
+
+        return .{
+            .bytes = try pending.toOwnedSlice(self.allocator),
+            .dropped = dropped,
+        };
+    }
+};
+
+threadlocal var current: ?*LineChannel = null;
+
+pub fn setCurrent(channel: ?*LineChannel) void {
+    current = channel;
+}
+
+pub fn getCurrent() ?*LineChannel {
+    return current;
+}
+
+test "LineChannel transfers tagged records and reports drops" {
+    var channel = LineChannel.init(std.testing.allocator);
+    defer channel.deinit();
+
+    channel.push(.stdout, "hello");
+    channel.push(.stderr, "oops");
+    const batch = try channel.take();
+    defer std.testing.allocator.free(batch.bytes);
+    try std.testing.expectEqual(@as(usize, 0), batch.dropped);
+    try std.testing.expectEqualSlices(u8, &.{ 1, 'h', 'e', 'l', 'l', 'o', '\n', 2, 'o', 'o', 'p', 's', '\n' }, batch.bytes);
+
+    const oversized = try std.testing.allocator.alloc(u8, LineChannel.MAX_PENDING_BYTES);
+    defer std.testing.allocator.free(oversized);
+    channel.push(.stdout, oversized);
+    const dropped_batch = try channel.take();
+    defer std.testing.allocator.free(dropped_batch.bytes);
+    try std.testing.expectEqual(@as(usize, 1), dropped_batch.dropped);
+}

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -487,7 +487,7 @@ pub const Session = struct {
         // `file` and `directory` are standard Rake task constructors. Keep the
         // provision resource classes available for the explicit
         // Hola::Resources namespace, but remove their top-level methods before
-        // a Rakefile is evaluated.
+        // a task file is evaluated.
         if (opts.mode == .task) {
             try self.mrb.evalString(
                 \\Object.send(:remove_method, :file)

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -24,6 +24,7 @@ const glob = @import("glob.zig");
 pub const Options = struct {
     script_path: []const u8,
     output_mode: modern_display.OutputMode = .normal,
+    phase: ?[]const u8 = null,
     params_json: ?[]const u8 = null, // JSON string for data_bag injection
     secrets_json: ?[]const u8 = null, // JSON string for secrets_bag injection
 };
@@ -31,6 +32,7 @@ pub const Options = struct {
 pub const ResourceResult = struct {
     type_name: []const u8,
     name: []const u8,
+    phase: ?[]const u8 = null,
     action: []const u8,
     was_updated: bool,
     skipped: bool,
@@ -57,6 +59,7 @@ fn freeResourceResults(allocator: std.mem.Allocator, results: *std.ArrayList(Res
     for (results.items) |rr| {
         allocator.free(rr.type_name);
         allocator.free(rr.name);
+        if (rr.phase) |phase| allocator.free(phase);
         allocator.free(rr.action);
         if (rr.skip_reason) |sr| allocator.free(sr);
         if (rr.error_name) |en| allocator.free(en);
@@ -78,6 +81,20 @@ pub const SessionMode = enum {
     task,
 };
 
+pub const ResourceSelection = union(enum) {
+    all,
+    unphased,
+    phase: []const u8,
+
+    fn matches(self: ResourceSelection, resource_phase: ?[]const u8) bool {
+        return switch (self) {
+            .all => true,
+            .unphased => resource_phase == null,
+            .phase => |selected| if (resource_phase) |declared| std.mem.eql(u8, selected, declared) else false,
+        };
+    }
+};
+
 pub const ProvisionRunner = struct {
     allocator: std.mem.Allocator,
     resources: std.ArrayList(resources.ResourceWithMetadata),
@@ -89,6 +106,8 @@ pub const ProvisionRunner = struct {
     converging: bool = false,
     last_failed_index: ?usize = null,
     current_resource_index: ?usize = null,
+    current_declaration_phase: ?[]const u8 = null,
+    phase_names: std.ArrayList([]const u8) = .empty,
     declaration_display_path: std.ArrayList(resources.DisplayScope) = .empty,
     start_time: i128 = 0,
     output: output_channel.LineChannel,
@@ -109,6 +128,9 @@ pub const ProvisionRunner = struct {
         self.delayed_notifications.deinit(self.allocator);
         for (self.declaration_display_path.items) |scope| scope.deinit(self.allocator);
         self.declaration_display_path.deinit(self.allocator);
+        if (self.current_declaration_phase) |phase| self.allocator.free(phase);
+        for (self.phase_names.items) |phase| self.allocator.free(phase);
+        self.phase_names.deinit(self.allocator);
         self.output.deinit();
         for (self.resources.items) |*res| {
             res.deinit(self.allocator);
@@ -134,6 +156,37 @@ pub const ProvisionRunner = struct {
         return results;
     }
 
+    pub fn setDeclarationPhase(self: *ProvisionRunner, phase: ?[]const u8) !void {
+        const next = if (phase) |name| try self.allocator.dupe(u8, name) else null;
+        errdefer if (next) |name| self.allocator.free(name);
+
+        if (phase) |name| {
+            if (!self.hasPhase(name)) {
+                const registered = try self.allocator.dupe(u8, name);
+                errdefer self.allocator.free(registered);
+                try self.phase_names.append(self.allocator, registered);
+            }
+        }
+
+        if (self.current_declaration_phase) |current| self.allocator.free(current);
+        self.current_declaration_phase = next;
+    }
+
+    pub fn hasPhase(self: *const ProvisionRunner, name: []const u8) bool {
+        for (self.phase_names.items) |phase| {
+            if (std.mem.eql(u8, phase, name)) return true;
+        }
+        return false;
+    }
+
+    pub fn countResources(self: *const ProvisionRunner, selection: ResourceSelection) usize {
+        var count: usize = 0;
+        for (self.resources.items) |resource| {
+            if (selection.matches(resource.phase)) count += 1;
+        }
+        return count;
+    }
+
     const ResultFields = struct {
         action: []const u8 = "",
         was_updated: bool = false,
@@ -144,11 +197,13 @@ pub const ProvisionRunner = struct {
         output: ?[]const u8 = null,
     };
 
-    fn recordResult(self: *ProvisionRunner, id: resources.ResourceId, fields: ResultFields) !void {
+    fn recordResult(self: *ProvisionRunner, id: resources.ResourceId, phase_value: ?[]const u8, fields: ResultFields) !void {
         const type_name = try self.allocator.dupe(u8, id.type_name);
         errdefer self.allocator.free(type_name);
         const name = try self.allocator.dupe(u8, id.name);
         errdefer self.allocator.free(name);
+        const phase = if (phase_value) |value| try self.allocator.dupe(u8, value) else null;
+        errdefer if (phase) |value| self.allocator.free(value);
         const action = try self.allocator.dupe(u8, fields.action);
         errdefer self.allocator.free(action);
         const skip_reason = if (fields.skip_reason) |value| try self.allocator.dupe(u8, value) else null;
@@ -163,6 +218,7 @@ pub const ProvisionRunner = struct {
         try self.resource_results.append(self.allocator, .{
             .type_name = type_name,
             .name = name,
+            .phase = phase,
             .action = action,
             .was_updated = fields.was_updated,
             .skipped = fields.skipped,
@@ -243,7 +299,7 @@ pub const ProvisionRunner = struct {
                 .backtrace = base.getProvisionErrorTrace(),
             });
             try display.update();
-            try self.recordResult(res.id, .{
+            try self.recordResult(res.id, res.phase, .{
                 .error_name = @errorName(err),
                 .error_message = detail_msg,
             });
@@ -254,6 +310,11 @@ pub const ProvisionRunner = struct {
             self.last_failed_index = index;
             return err;
         };
+
+        const previous_phase = if (self.current_declaration_phase) |phase| try self.allocator.dupe(u8, phase) else null;
+        defer if (previous_phase) |phase| self.allocator.free(phase);
+        try self.setDeclarationPhase(starting_resource.phase);
+        defer self.setDeclarationPhase(previous_phase) catch {};
 
         self.current_resource_index = index;
         defer self.current_resource_index = null;
@@ -276,7 +337,7 @@ pub const ProvisionRunner = struct {
                 .backtrace = base.getProvisionErrorTrace(),
             });
             try display.update();
-            try self.recordResult(res.id, .{
+            try self.recordResult(res.id, res.phase, .{
                 .error_name = @errorName(err),
                 .error_message = detail_msg,
             });
@@ -298,7 +359,7 @@ pub const ProvisionRunner = struct {
         if (result.was_updated) {
             try display.resourceUpdated(res.id.type_name, res.id.name, result.action, result.skip_reason, result.output);
             try display.update();
-            try self.recordResult(res.id, .{
+            try self.recordResult(res.id, res.phase, .{
                 .action = result.action,
                 .was_updated = true,
                 .skip_reason = result.skip_reason,
@@ -330,24 +391,19 @@ pub const ProvisionRunner = struct {
 
         try display.resourceSkipped(res.id.type_name, res.id.name, result.action, result.skip_reason);
         try display.update();
-        try self.recordResult(res.id, .{
+        try self.recordResult(res.id, res.phase, .{
             .action = result.action,
             .skipped = true,
             .skip_reason = result.skip_reason,
         });
     }
 
-    pub fn convergeFrom(self: *ProvisionRunner, from_index: usize) !void {
-        const display = self.display orelse return error.DisplayNotAttached;
-        const start_index = @max(from_index, self.converged_index);
-        if (start_index >= self.resources.items.len) return;
-
-        self.converging = true;
-        defer self.converging = false;
-
-        // Convert subscriptions on newly declared resources to reverse notifications.
-        var subscriber_index = start_index;
+    fn resolveSubscriptions(self: *ProvisionRunner) !void {
+        var subscriber_index: usize = 0;
         while (subscriber_index < self.resources.items.len) : (subscriber_index += 1) {
+            if (self.resources.items[subscriber_index].subscriptions_resolved) continue;
+            self.resources.items[subscriber_index].subscriptions_resolved = true;
+
             const common = self.resources.items[subscriber_index].resource.getCommonProps();
             for (common.subscriptions.items) |subscription| {
                 const source_id = base.notification.ResourceId.parse(self.allocator, subscription.target_resource_id) catch continue;
@@ -375,6 +431,15 @@ pub const ProvisionRunner = struct {
                 }
             }
         }
+    }
+
+    fn convergeSelection(self: *ProvisionRunner, from_index: usize, selection: ResourceSelection, advance_watermark: bool) !void {
+        const display = self.display orelse return error.DisplayNotAttached;
+        if (from_index >= self.resources.items.len) return;
+
+        self.converging = true;
+        defer self.converging = false;
+        try self.resolveSubscriptions();
 
         var immediate_notifications = std.ArrayList(PendingNotification).empty;
         defer {
@@ -382,11 +447,14 @@ pub const ProvisionRunner = struct {
             immediate_notifications.deinit(self.allocator);
         }
 
-        var index = start_index;
+        var index = from_index;
         while (index < self.resources.items.len) : (index += 1) {
-            // Advance before apply so a failed resource is never retried by a
-            // later incremental converge call.
-            self.converged_index = index + 1;
+            if (advance_watermark) self.converged_index = index + 1;
+            if (self.resources.items[index].converged or !selection.matches(self.resources.items[index].phase)) continue;
+
+            // Mark before apply so a failed resource is never retried by a
+            // later incremental or phase-specific converge call.
+            self.resources.items[index].converged = true;
             try self.applyOne(index, &immediate_notifications);
         }
 
@@ -396,6 +464,19 @@ pub const ProvisionRunner = struct {
                 try processNotification(self.allocator, pending, display);
             }
         }
+    }
+
+    pub fn convergeFrom(self: *ProvisionRunner, from_index: usize) !void {
+        try self.convergeSelection(@max(from_index, self.converged_index), .all, true);
+    }
+
+    pub fn convergeUnphasedFrom(self: *ProvisionRunner, from_index: usize) !void {
+        try self.convergeSelection(@max(from_index, self.converged_index), .unphased, true);
+    }
+
+    pub fn convergePhase(self: *ProvisionRunner, name: []const u8) !void {
+        if (!self.hasPhase(name)) return error.UnknownPhase;
+        try self.convergeSelection(0, .{ .phase = name }, false);
     }
 
     pub fn flushDelayed(self: *ProvisionRunner) !void {
@@ -726,7 +807,18 @@ fn addResourceWithMetadata(
             return mruby.mrb_nil_value();
         };
 
+        const phase = if (runner.current_declaration_phase) |name|
+            allocator.dupe(u8, name) catch {
+                deinitNotifications(allocator, &notifications);
+                id.deinit(allocator);
+                wrapped.deinit(allocator);
+                return mruby.mrb_nil_value();
+            }
+        else
+            null;
+
         const display_path = cloneCurrentDisplayPath(runner) catch {
+            if (phase) |name| allocator.free(name);
             deinitNotifications(allocator, &notifications);
             id.deinit(allocator);
             wrapped.deinit(allocator);
@@ -738,6 +830,7 @@ fn addResourceWithMetadata(
             .resource = wrapped,
             .id = id,
             .notifications = notifications,
+            .phase = phase,
             .display_depth = currentDisplayDepth(runner),
             .display_path = display_path,
         };
@@ -1307,6 +1400,21 @@ fn statusPair(mrb: *mruby.mrb_state, ok: bool, message: ?[]const u8) mruby.mrb_v
     return pair;
 }
 
+fn convergeErrorStatus(mrb: *mruby.mrb_state, runner: *ProvisionRunner, err: anyerror) mruby.mrb_value {
+    const detail = base.getProvisionErrorDetail() orelse base.userFacingError(err);
+    if (runner.last_failed_index) |index| {
+        if (index < runner.resources.items.len) {
+            const id = runner.resources.items[index].id;
+            const message = std.fmt.allocPrint(runner.allocator, "{s}[{s}]: {s}", .{ id.type_name, id.name, detail }) catch {
+                return statusPair(mrb, false, detail);
+            };
+            defer runner.allocator.free(message);
+            return statusPair(mrb, false, message);
+        }
+    }
+    return statusPair(mrb, false, detail);
+}
+
 export fn zig_converge(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
     _ = self_value;
     const runner = currentRunnerOrNilValue() orelse return statusPair(mrb, false, "provision runner is not initialized");
@@ -1317,26 +1425,64 @@ export fn zig_converge(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callc
 
     const arena_index = mruby.zig_mrb_gc_arena_save(mrb);
     const converge_error: ?anyerror = blk: {
-        runner.convergeFrom(runner.converged_index) catch |err| break :blk err;
+        runner.convergeUnphasedFrom(runner.converged_index) catch |err| break :blk err;
         break :blk null;
     };
     mruby.zig_mrb_gc_arena_restore(mrb, arena_index);
 
-    if (converge_error) |err| {
-        const detail = base.getProvisionErrorDetail() orelse base.userFacingError(err);
-        if (runner.last_failed_index) |index| {
-            if (index < runner.resources.items.len) {
-                const id = runner.resources.items[index].id;
-                const message = std.fmt.allocPrint(runner.allocator, "{s}[{s}]: {s}", .{ id.type_name, id.name, detail }) catch {
-                    return statusPair(mrb, false, detail);
-                };
-                defer runner.allocator.free(message);
-                return statusPair(mrb, false, message);
-            }
-        }
-        return statusPair(mrb, false, detail);
-    }
+    if (converge_error) |err| return convergeErrorStatus(mrb, runner, err);
     return statusPair(mrb, true, null);
+}
+
+export fn zig_converge_phase(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    var name_value: mruby.mrb_value = undefined;
+    if (mruby.mrb_get_args(mrb, "S", &name_value) != 1) return statusPair(mrb, false, "converge_phase expects one phase name");
+    const runner = currentRunnerOrNilValue() orelse return statusPair(mrb, false, "provision runner is not initialized");
+    if (runner.display == null) return statusPair(mrb, false, "provision display is not attached");
+    if (runner.converging) return statusPair(mrb, true, null);
+
+    const name = std.mem.span(mruby.mrb_str_to_cstr(mrb, name_value));
+    if (!runner.hasPhase(name)) {
+        const message = std.fmt.allocPrint(runner.allocator, "unknown phase '{s}'", .{name}) catch return statusPair(mrb, false, "unknown phase");
+        defer runner.allocator.free(message);
+        return statusPair(mrb, false, message);
+    }
+
+    const arena_index = mruby.zig_mrb_gc_arena_save(mrb);
+    const converge_error: ?anyerror = blk: {
+        runner.convergePhase(name) catch |err| break :blk err;
+        break :blk null;
+    };
+    mruby.zig_mrb_gc_arena_restore(mrb, arena_index);
+
+    if (converge_error) |err| return convergeErrorStatus(mrb, runner, err);
+    return statusPair(mrb, true, null);
+}
+
+export fn zig_select_phase(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    var name_value: mruby.mrb_value = undefined;
+    if (mruby.mrb_get_args(mrb, "S", &name_value) != 1) return statusPair(mrb, false, "phase expects one name");
+    const runner = currentRunnerOrNilValue() orelse return statusPair(mrb, false, "provision runner is not initialized");
+    const name = std.mem.span(mruby.mrb_str_to_cstr(mrb, name_value));
+    if (name.len == 0) return statusPair(mrb, false, "phase name cannot be empty");
+    runner.setDeclarationPhase(name) catch return statusPair(mrb, false, "out of memory selecting phase");
+    return statusPair(mrb, true, null);
+}
+
+export fn zig_clear_phase(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    const runner = currentRunnerOrNilValue() orelse return statusPair(mrb, false, "provision runner is not initialized");
+    runner.setDeclarationPhase(null) catch return statusPair(mrb, false, "out of memory clearing phase");
+    return statusPair(mrb, true, null);
+}
+
+export fn zig_current_phase(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    const runner = currentRunnerOrNilValue() orelse return mruby.mrb_nil_value();
+    const phase = runner.current_declaration_phase orelse return mruby.mrb_nil_value();
+    return mruby.mrb_str_new(mrb, phase.ptr, @intCast(phase.len));
 }
 
 export fn zig_flush_delayed(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
@@ -1477,7 +1623,11 @@ export fn zig_load_file(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) call
 fn registerResourceBindings(mrb_ptr: *mruby.mrb_state, zig_module: *mruby.RClass) void {
     const bindings = [_]ResourceBinding{
         .{ .name = "converge", .handler = zig_converge, .args_spec = mruby.MRB_ARGS_NONE() },
+        .{ .name = "converge_phase", .handler = zig_converge_phase, .args_spec = mruby.MRB_ARGS_REQ(1) },
         .{ .name = "flush_delayed", .handler = zig_flush_delayed, .args_spec = mruby.MRB_ARGS_NONE() },
+        .{ .name = "select_phase", .handler = zig_select_phase, .args_spec = mruby.MRB_ARGS_REQ(1) },
+        .{ .name = "clear_phase", .handler = zig_clear_phase, .args_spec = mruby.MRB_ARGS_NONE() },
+        .{ .name = "current_phase", .handler = zig_current_phase, .args_spec = mruby.MRB_ARGS_NONE() },
         .{ .name = "failure_checkpoint", .handler = zig_failure_checkpoint, .args_spec = mruby.MRB_ARGS_NONE() },
         .{ .name = "handle_failures_since", .handler = zig_handle_failures_since, .args_spec = mruby.MRB_ARGS_REQ(1) },
         .{ .name = "display_section", .handler = zig_display_section, .args_spec = mruby.MRB_ARGS_REQ(1) },
@@ -1583,6 +1733,18 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     try session.evalScript(opts.script_path);
 
     const runner = &session.runner;
+    const selection: ResourceSelection = if (opts.phase) |phase| blk: {
+        if (!runner.hasPhase(phase)) {
+            std.debug.print("Unknown phase '{s}'.", .{phase});
+            if (runner.phase_names.items.len > 0) {
+                std.debug.print(" Available phases:", .{});
+                for (runner.phase_names.items) |name| std.debug.print(" {s}", .{name});
+            }
+            std.debug.print("\n", .{});
+            return error.UnknownPhase;
+        }
+        break :blk .{ .phase = phase };
+    } else .all;
     runner.start_time = std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds();
 
     // Initialize modern display with the specified output mode
@@ -1593,10 +1755,16 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     defer runner.detachDisplay();
 
     // Show section header
-    try display.showSection("Applying configuration");
+    if (opts.phase) |phase| {
+        const heading = try std.fmt.allocPrint(allocator, "Applying phase: {s}", .{phase});
+        defer allocator.free(heading);
+        try display.showSection(heading);
+    } else {
+        try display.showSection("Applying configuration");
+    }
 
     // Set total number of resources for progress display
-    display.setTotalResources(runner.resources.items.len);
+    display.setTotalResources(runner.countResources(selection));
 
     // Phase 0: Start parallel downloads for remote files
     // Initialize download manager with the specified output mode
@@ -1667,6 +1835,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     // Collect all remote_file resources for parallel download
     // Only pre-download simple files (no conditions like only_if/not_if, and action is :create)
     for (runner.resources.items) |*res| {
+        if (!selection.matches(res.phase)) continue;
         if (res.resource == .remote_file) {
             const remote_res = &res.resource.remote_file;
 
@@ -1781,7 +1950,11 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
 
     // Start the real-time timer spinner (after all download spinners are created)
     try display.startTimer(runner.start_time);
-    try runner.convergeFrom(0);
+    if (opts.phase) |phase| {
+        try runner.convergePhase(phase);
+    } else {
+        try runner.convergeFrom(0);
+    }
     try runner.flushDelayed();
 
     // Wait for download thread to complete
@@ -1888,6 +2061,193 @@ test "composite resource display scope unwinds after a Ruby exception" {
     const sibling = session.runner.resources.items[0];
     try std.testing.expectEqual(@as(usize, 0), sibling.display_depth);
     try std.testing.expectEqual(@as(usize, 0), sibling.display_path.len);
+}
+
+test "phase marker tags following resources and block form restores declaration state" {
+    const allocator = std.testing.allocator;
+    json.setAllocator(allocator);
+    const session = try Session.open(allocator, .{});
+    defer session.close();
+
+    try session.evalString(
+        \\execute('unphased') { action :nothing }
+        \\phase :prepare
+        \\execute('prepare-one') { action :nothing }
+        \\phase :deploy do
+        \\  execute('deploy-one') { action :nothing }
+        \\end
+        \\execute('prepare-two') { action :nothing }
+    );
+
+    try std.testing.expectEqual(@as(usize, 4), session.runner.resources.items.len);
+    try std.testing.expect(session.runner.resources.items[0].phase == null);
+    try std.testing.expectEqualStrings("prepare", session.runner.resources.items[1].phase.?);
+    try std.testing.expectEqualStrings("deploy", session.runner.resources.items[2].phase.?);
+    try std.testing.expectEqualStrings("prepare", session.runner.resources.items[3].phase.?);
+    try std.testing.expectEqual(@as(usize, 2), session.runner.phase_names.items.len);
+    try std.testing.expectEqualStrings("prepare", session.runner.phase_names.items[0]);
+    try std.testing.expectEqualStrings("deploy", session.runner.phase_names.items[1]);
+}
+
+test "dynamic resources inherit the executing phase and nested phase blocks restore it" {
+    const allocator = std.testing.allocator;
+    json.setAllocator(allocator);
+    const session = try Session.open(allocator, .{});
+    defer session.close();
+
+    try session.evalString(
+        \\phase :prepare
+        \\ruby_block 'declare phase children' do
+        \\  block do
+        \\    execute('prepare-before') { action :nothing }
+        \\    phase :nested do
+        \\      execute('nested-child') { action :nothing }
+        \\    end
+        \\    execute('prepare-after') { action :nothing }
+        \\  end
+        \\end
+        \\phase :deploy
+        \\execute('deploy-resource') { action :nothing }
+    );
+
+    var display = try modern_display.ModernProvisionDisplay.init(allocator, .normal);
+    defer display.deinit();
+    session.runner.attachDisplay(&display);
+    defer session.runner.detachDisplay();
+    try session.runner.convergePhase("prepare");
+
+    try std.testing.expectEqual(@as(usize, 5), session.runner.resources.items.len);
+    try std.testing.expectEqualStrings("prepare", session.runner.resources.items[2].phase.?);
+    try std.testing.expectEqualStrings("nested", session.runner.resources.items[3].phase.?);
+    try std.testing.expectEqualStrings("prepare", session.runner.resources.items[4].phase.?);
+    try std.testing.expect(session.runner.resources.items[2].converged);
+    try std.testing.expect(!session.runner.resources.items[3].converged);
+    try std.testing.expect(session.runner.resources.items[4].converged);
+}
+
+test "unphased and named phase resources converge independently" {
+    const allocator = std.testing.allocator;
+    const io = global_io.io();
+    json.setAllocator(allocator);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realPathFileAlloc(io, ".", allocator);
+    defer allocator.free(root);
+    const shared_path = try std.fs.path.join(allocator, &.{ root, "shared.txt" });
+    defer allocator.free(shared_path);
+    const prepare_path = try std.fs.path.join(allocator, &.{ root, "prepare.txt" });
+    defer allocator.free(prepare_path);
+    const deploy_path = try std.fs.path.join(allocator, &.{ root, "deploy.txt" });
+    defer allocator.free(deploy_path);
+
+    const session = try Session.open(allocator, .{});
+    defer session.close();
+    const script = try std.fmt.allocPrint(allocator,
+        \\file '{s}' do
+        \\  content 'shared'
+        \\end
+        \\phase :prepare
+        \\file '{s}' do
+        \\  content 'prepare'
+        \\end
+        \\phase :deploy
+        \\file '{s}' do
+        \\  content 'deploy'
+        \\end
+    , .{ shared_path, prepare_path, deploy_path });
+    defer allocator.free(script);
+    try session.evalString(script);
+
+    var display = try modern_display.ModernProvisionDisplay.init(allocator, .normal);
+    defer display.deinit();
+    session.runner.attachDisplay(&display);
+    defer session.runner.detachDisplay();
+    display.setTotalResources(3);
+
+    try session.runner.convergeUnphasedFrom(0);
+    try std.Io.Dir.cwd().access(io, shared_path, .{});
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, prepare_path, .{}));
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, deploy_path, .{}));
+    try std.testing.expectEqual(@as(usize, 1), session.runner.resource_results.items.len);
+
+    try session.runner.convergePhase("prepare");
+    try std.Io.Dir.cwd().access(io, prepare_path, .{});
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, deploy_path, .{}));
+    try std.testing.expectEqual(@as(usize, 2), session.runner.resource_results.items.len);
+    try std.testing.expectEqualStrings("prepare", session.runner.resource_results.items[1].phase.?);
+
+    try session.runner.convergePhase("prepare");
+    try std.testing.expectEqual(@as(usize, 2), session.runner.resource_results.items.len);
+    try session.runner.convergePhase("deploy");
+    try std.Io.Dir.cwd().access(io, deploy_path, .{});
+    try std.testing.expectEqual(@as(usize, 3), session.runner.resource_results.items.len);
+    try std.testing.expectError(error.UnknownPhase, session.runner.convergePhase("missing"));
+}
+
+test "Holafile imports phases as tasks without leaking the resource DSL" {
+    const allocator = std.testing.allocator;
+    const io = global_io.io();
+    json.setAllocator(allocator);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realPathFileAlloc(io, ".", allocator);
+    defer allocator.free(root);
+    const recipe_path = try std.fs.path.join(allocator, &.{ root, "deploy.rb" });
+    defer allocator.free(recipe_path);
+    const prepare_path = try std.fs.path.join(allocator, &.{ root, "prepared.txt" });
+    defer allocator.free(prepare_path);
+    const deploy_path = try std.fs.path.join(allocator, &.{ root, "deployed.txt" });
+    defer allocator.free(deploy_path);
+
+    const recipe = try std.fmt.allocPrint(allocator,
+        \\phase :prepare
+        \\file '{s}' do
+        \\  content 'prepared'
+        \\end
+        \\phase :deploy
+        \\file '{s}' do
+        \\  content 'deployed'
+        \\end
+    , .{ prepare_path, deploy_path });
+    defer allocator.free(recipe);
+    try tmp.dir.writeFile(io, .{ .sub_path = "deploy.rb", .data = recipe });
+
+    const session = try Session.open(allocator, .{ .mode = .task });
+    defer session.close();
+    var display = try modern_display.ModernProvisionDisplay.init(allocator, .normal);
+    defer display.deinit();
+    session.runner.attachDisplay(&display);
+    defer session.runner.detachDisplay();
+    session.runner.start_time = std.Io.Timestamp.now(io, .real).toNanoseconds();
+    try display.startTimer(session.runner.start_time);
+    try session.loadTaskPrelude();
+
+    const holafile = try std.fmt.allocPrint(allocator,
+        \\$imported_phases = import_phases('{s}', :as => :app)
+        \\file 'still-a-rake-file-task'
+        \\task :workflow => 'app:prepare'
+        \\$hola_run_argv = ['workflow']
+        \\Hola::Rake.main
+        \\$phase_import_ok = $imported_phases == ['app:prepare', 'app:deploy'] &&
+        \\  Rake::Task.task_defined?('app:prepare') &&
+        \\  Rake::Task.task_defined?('app:deploy') &&
+        \\  Rake::Task[:'still-a-rake-file-task'].is_a?(Rake::FileTask)
+    , .{recipe_path});
+    defer allocator.free(holafile);
+    try session.evalString(holafile);
+
+    try std.testing.expect(mruby.mrb_test(session.mrb.getGlobal("$phase_import_ok")));
+    try std.testing.expect(session.runner.current_declaration_phase == null);
+    try std.testing.expectEqual(@as(usize, 2), session.runner.resources.items.len);
+    try std.testing.expectEqualStrings("app:prepare", session.runner.resources.items[0].phase.?);
+    try std.testing.expectEqualStrings("app:deploy", session.runner.resources.items[1].phase.?);
+    try std.Io.Dir.cwd().access(io, prepare_path, .{});
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, deploy_path, .{}));
+
+    try session.evalString("Rake::Task['app:deploy'].invoke");
+    try std.Io.Dir.cwd().access(io, deploy_path, .{});
 }
 
 test "resources declared while applying inherit the parent display depth" {

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -18,6 +18,8 @@ const builtin = @import("builtin");
 const is_macos = builtin.os.tag == .macos;
 const is_linux = builtin.os.tag == .linux;
 const AsyncExecutor = @import("async_executor.zig").AsyncExecutor;
+const output_channel = @import("output_channel.zig");
+const glob = @import("glob.zig");
 
 pub const Options = struct {
     script_path: []const u8,
@@ -47,36 +49,317 @@ pub const ProvisionResult = struct {
     resource_results: std.ArrayList(ResourceResult),
 
     pub fn deinit(self: *ProvisionResult, allocator: std.mem.Allocator) void {
-        for (self.resource_results.items) |rr| {
-            allocator.free(rr.type_name);
-            allocator.free(rr.name);
-            allocator.free(rr.action);
-            if (rr.skip_reason) |sr| allocator.free(sr);
-            if (rr.error_name) |en| allocator.free(en);
-            if (rr.error_message) |em| allocator.free(em);
-            if (rr.output) |o| allocator.free(o);
-        }
-        self.resource_results.deinit(allocator);
+        freeResourceResults(allocator, &self.resource_results);
     }
 };
 
-const ProvisionRunner = struct {
+fn freeResourceResults(allocator: std.mem.Allocator, results: *std.ArrayList(ResourceResult)) void {
+    for (results.items) |rr| {
+        allocator.free(rr.type_name);
+        allocator.free(rr.name);
+        allocator.free(rr.action);
+        if (rr.skip_reason) |sr| allocator.free(sr);
+        if (rr.error_name) |en| allocator.free(en);
+        if (rr.error_message) |em| allocator.free(em);
+        if (rr.output) |o| allocator.free(o);
+    }
+    results.deinit(allocator);
+    results.* = .empty;
+}
+
+pub const SessionOptions = struct {
+    params_json: ?[]const u8 = null,
+    secrets_json: ?[]const u8 = null,
+    mode: SessionMode = .provision,
+};
+
+pub const SessionMode = enum {
+    provision,
+    task,
+};
+
+pub const ProvisionRunner = struct {
     allocator: std.mem.Allocator,
     resources: std.ArrayList(resources.ResourceWithMetadata),
     display: ?*modern_display.ModernProvisionDisplay = null,
+    download_mgr: ?*http.download.Manager = null,
+    resource_results: std.ArrayList(ResourceResult) = .empty,
+    delayed_notifications: std.ArrayList(PendingNotification) = .empty,
+    converged_index: usize = 0,
+    converging: bool = false,
+    last_failed_index: ?usize = null,
+    start_time: i128 = 0,
+    output: output_channel.LineChannel,
 
     fn init(allocator: std.mem.Allocator) ProvisionRunner {
         return .{
             .allocator = allocator,
             .resources = std.ArrayList(resources.ResourceWithMetadata).empty,
+            .output = output_channel.LineChannel.init(allocator),
         };
     }
 
     fn deinit(self: *ProvisionRunner) void {
+        freeResourceResults(self.allocator, &self.resource_results);
+        for (self.delayed_notifications.items) |pending| {
+            self.allocator.free(pending.source_id);
+        }
+        self.delayed_notifications.deinit(self.allocator);
+        self.output.deinit();
         for (self.resources.items) |*res| {
             res.deinit(self.allocator);
         }
         self.resources.deinit(self.allocator);
+    }
+
+    pub fn attachDisplay(self: *ProvisionRunner, display: *modern_display.ModernProvisionDisplay) void {
+        self.display = display;
+        output_channel.setCurrent(&self.output);
+        AsyncExecutor.setPollCallback(pollDisplayUpdate);
+    }
+
+    pub fn detachDisplay(self: *ProvisionRunner) void {
+        AsyncExecutor.setPollCallback(null);
+        output_channel.setCurrent(null);
+        self.display = null;
+    }
+
+    pub fn takeResults(self: *ProvisionRunner) std.ArrayList(ResourceResult) {
+        const results = self.resource_results;
+        self.resource_results = .empty;
+        return results;
+    }
+
+    const ResultFields = struct {
+        action: []const u8 = "",
+        was_updated: bool = false,
+        skipped: bool = false,
+        skip_reason: ?[]const u8 = null,
+        error_name: ?[]const u8 = null,
+        error_message: ?[]const u8 = null,
+        output: ?[]const u8 = null,
+    };
+
+    fn recordResult(self: *ProvisionRunner, id: resources.ResourceId, fields: ResultFields) !void {
+        const type_name = try self.allocator.dupe(u8, id.type_name);
+        errdefer self.allocator.free(type_name);
+        const name = try self.allocator.dupe(u8, id.name);
+        errdefer self.allocator.free(name);
+        const action = try self.allocator.dupe(u8, fields.action);
+        errdefer self.allocator.free(action);
+        const skip_reason = if (fields.skip_reason) |value| try self.allocator.dupe(u8, value) else null;
+        errdefer if (skip_reason) |value| self.allocator.free(value);
+        const error_name = if (fields.error_name) |value| try self.allocator.dupe(u8, value) else null;
+        errdefer if (error_name) |value| self.allocator.free(value);
+        const error_message = if (fields.error_message) |value| try self.allocator.dupe(u8, value) else null;
+        errdefer if (error_message) |value| self.allocator.free(value);
+        const output = if (fields.output) |value| try self.allocator.dupe(u8, value) else null;
+        errdefer if (output) |value| self.allocator.free(value);
+
+        try self.resource_results.append(self.allocator, .{
+            .type_name = type_name,
+            .name = name,
+            .action = action,
+            .was_updated = fields.was_updated,
+            .skipped = fields.skipped,
+            .skip_reason = skip_reason,
+            .error_name = error_name,
+            .error_message = error_message,
+            .output = output,
+        });
+    }
+
+    fn waitForDownload(self: *ProvisionRunner, index: usize) !void {
+        const download_mgr = self.download_mgr orelse return;
+        const display = self.display orelse return error.DisplayNotAttached;
+        const res = &self.resources.items[index];
+        if (res.resource != .remote_file) return;
+
+        const resource_id = try std.fmt.allocPrint(self.allocator, "{s}[{s}]", .{ res.id.type_name, res.id.name });
+        defer self.allocator.free(resource_id);
+
+        const task = download_mgr.getTask(resource_id) orelse return;
+        const initial_status = task.status.load(.acquire);
+        if (initial_status == .queued or initial_status == .downloading) {
+            var max_wait_iterations: usize = 3000;
+            while (max_wait_iterations > 0) : (max_wait_iterations -= 1) {
+                const status = task.status.load(.acquire);
+                if (status != .queued and status != .downloading) break;
+
+                try display.update();
+                std.Thread.yield() catch {};
+                global_io.io().sleep(.fromNanoseconds(10 * std.time.ns_per_ms), .awake) catch {};
+            }
+        }
+
+        if (task.status.load(.acquire) == .failed) {
+            const err_msg_owned = task.getError(self.allocator);
+            defer if (err_msg_owned) |msg| self.allocator.free(msg);
+            const err_msg = err_msg_owned orelse "Unknown error";
+            const msg = try std.fmt.allocPrint(self.allocator, "Download failed for {s}: {s}", .{ resource_id, err_msg });
+            defer self.allocator.free(msg);
+            base.recordProvisionErrorDetailSlice(msg);
+            return error.DownloadFailed;
+        }
+    }
+
+    fn applyOne(self: *ProvisionRunner, index: usize, immediate: *std.ArrayList(PendingNotification)) !void {
+        const display = self.display orelse return error.DisplayNotAttached;
+        base.clearProvisionErrorDetail();
+        self.last_failed_index = null;
+
+        try display.startResource(self.resources.items[index].id.type_name, self.resources.items[index].id.name);
+        try display.update();
+        self.waitForDownload(index) catch |err| {
+            const res = &self.resources.items[index];
+            const detail_msg = base.getProvisionErrorDetail();
+            const error_display = detail_msg orelse @errorName(err);
+            try display.resourceError(res.id.type_name, res.id.name, error_display);
+            try display.update();
+            try self.recordResult(res.id, .{
+                .error_name = @errorName(err),
+                .error_message = detail_msg,
+            });
+            self.last_failed_index = index;
+            return err;
+        };
+
+        const result = self.resources.items[index].resource.apply() catch |err| {
+            const res = &self.resources.items[index];
+            const detail_msg = base.getProvisionErrorDetail();
+            const error_display = detail_msg orelse @errorName(err);
+            try display.resourceError(res.id.type_name, res.id.name, error_display);
+            try display.update();
+            try self.recordResult(res.id, .{
+                .error_name = @errorName(err),
+                .error_message = detail_msg,
+            });
+
+            if (res.resource.shouldIgnoreFailure()) return;
+            self.last_failed_index = index;
+            return err;
+        };
+        defer if (result.output) |output| std.heap.c_allocator.free(output);
+
+        // Applying a ruby_block may append resources and reallocate the list.
+        // Always reacquire the pointer after apply() before reading metadata.
+        const res = &self.resources.items[index];
+        res.was_updated = result.was_updated;
+
+        if (result.was_updated) {
+            try display.resourceUpdated(res.id.type_name, res.id.name, result.action, result.skip_reason);
+            try display.update();
+            try self.recordResult(res.id, .{
+                .action = result.action,
+                .was_updated = true,
+                .skip_reason = result.skip_reason,
+                .output = result.output,
+            });
+
+            if (result.skip_reason == null or !std.mem.eql(u8, result.skip_reason.?, "up to date")) {
+                for (res.notifications.items) |notification| {
+                    const source_id = try res.id.toString(self.allocator);
+                    const pending = PendingNotification{
+                        .notification = notification,
+                        .source_id = source_id,
+                    };
+                    if (notification.timing == .immediate) {
+                        immediate.append(self.allocator, pending) catch |err| {
+                            self.allocator.free(source_id);
+                            return err;
+                        };
+                    } else {
+                        self.delayed_notifications.append(self.allocator, pending) catch |err| {
+                            self.allocator.free(source_id);
+                            return err;
+                        };
+                    }
+                }
+            }
+            return;
+        }
+
+        try display.resourceSkipped(res.id.type_name, res.id.name, result.action, result.skip_reason);
+        try display.update();
+        try self.recordResult(res.id, .{
+            .action = result.action,
+            .skipped = true,
+            .skip_reason = result.skip_reason,
+        });
+    }
+
+    pub fn convergeFrom(self: *ProvisionRunner, from_index: usize) !void {
+        const display = self.display orelse return error.DisplayNotAttached;
+        const start_index = @max(from_index, self.converged_index);
+        if (start_index >= self.resources.items.len) return;
+
+        self.converging = true;
+        defer self.converging = false;
+
+        // Convert subscriptions on newly declared resources to reverse notifications.
+        var subscriber_index = start_index;
+        while (subscriber_index < self.resources.items.len) : (subscriber_index += 1) {
+            const common = self.resources.items[subscriber_index].resource.getCommonProps();
+            for (common.subscriptions.items) |subscription| {
+                const source_id = base.notification.ResourceId.parse(self.allocator, subscription.target_resource_id) catch continue;
+                defer source_id.deinit(self.allocator);
+
+                for (self.resources.items) |*source_res| {
+                    if (!std.mem.eql(u8, source_res.id.type_name, source_id.type_name) or
+                        !std.mem.eql(u8, source_res.id.name, source_id.name)) continue;
+
+                    const subscriber_id = try self.resources.items[subscriber_index].id.toString(self.allocator);
+                    const action_name = self.allocator.dupe(u8, subscription.action.action_name) catch |err| {
+                        self.allocator.free(subscriber_id);
+                        return err;
+                    };
+                    source_res.resource.getCommonProps().notifications.append(self.allocator, .{
+                        .target_resource_id = subscriber_id,
+                        .action = .{ .action_name = action_name },
+                        .timing = subscription.timing,
+                    }) catch |err| {
+                        self.allocator.free(subscriber_id);
+                        self.allocator.free(action_name);
+                        return err;
+                    };
+                    break;
+                }
+            }
+        }
+
+        var immediate_notifications = std.ArrayList(PendingNotification).empty;
+        defer {
+            for (immediate_notifications.items) |pending| self.allocator.free(pending.source_id);
+            immediate_notifications.deinit(self.allocator);
+        }
+
+        var index = start_index;
+        while (index < self.resources.items.len) : (index += 1) {
+            // Advance before apply so a failed resource is never retried by a
+            // later incremental converge call.
+            self.converged_index = index + 1;
+            try self.applyOne(index, &immediate_notifications);
+        }
+
+        if (immediate_notifications.items.len > 0) {
+            try display.showSectionWithLevel("Processing Immediate Notifications", 3);
+            for (immediate_notifications.items) |pending| {
+                try processNotification(self.allocator, pending, display);
+            }
+        }
+    }
+
+    pub fn flushDelayed(self: *ProvisionRunner) !void {
+        if (self.delayed_notifications.items.len == 0) return;
+        const display = self.display orelse return error.DisplayNotAttached;
+        try display.showSectionWithLevel("Processing Delayed Notifications", 3);
+        for (self.delayed_notifications.items) |pending| {
+            try processNotification(self.allocator, pending, display);
+        }
+        for (self.delayed_notifications.items) |pending| {
+            self.allocator.free(pending.source_id);
+        }
+        self.delayed_notifications.clearRetainingCapacity();
     }
 };
 
@@ -90,6 +373,26 @@ fn requireRunner() *ProvisionRunner {
 fn pollDisplayUpdate() !void {
     if (current_runner) |runner| {
         if (runner.display) |display| {
+            var batch = try runner.output.take();
+            defer runner.allocator.free(batch.bytes);
+            var index: usize = 0;
+            while (index < batch.bytes.len) {
+                const stream: output_channel.Stream = switch (batch.bytes[index]) {
+                    @intFromEnum(output_channel.Stream.stdout) => .stdout,
+                    @intFromEnum(output_channel.Stream.stderr) => .stderr,
+                    else => break,
+                };
+                const line_start = index + 1;
+                const relative_end = std.mem.indexOfScalar(u8, batch.bytes[line_start..], '\n') orelse break;
+                const line_end = line_start + relative_end;
+                try display.printCommandLine(stream, batch.bytes[line_start..line_end]);
+                index = line_end + 1;
+            }
+            if (batch.dropped > 0) {
+                var message_buf: [128]u8 = undefined;
+                const message = try std.fmt.bufPrint(&message_buf, "   [hola] dropped {d} live output lines", .{batch.dropped});
+                try display.printLine(message);
+            }
             try display.update();
         }
     }
@@ -103,6 +406,137 @@ fn currentRunnerOrNilValue() ?*ProvisionRunner {
 const PendingNotification = struct {
     notification: resources.Notification,
     source_id: []const u8,
+};
+
+/// A reusable mruby provisioning session. The value is heap allocated so the
+/// threadlocal runner pointer remains stable while resource callbacks execute.
+pub const Session = struct {
+    allocator: std.mem.Allocator,
+    mrb: mruby.State,
+    runner: ProvisionRunner,
+
+    pub fn open(allocator: std.mem.Allocator, opts: SessionOptions) !*Session {
+        base.clearProvisionErrorDetail();
+
+        var mrb_state = try mruby.State.init();
+        const self = allocator.create(Session) catch |err| {
+            mrb_state.deinit();
+            return err;
+        };
+        self.* = .{
+            .allocator = allocator,
+            .mrb = mrb_state,
+            .runner = ProvisionRunner.init(allocator),
+        };
+        current_runner = &self.runner;
+
+        self.initialize(opts) catch |err| {
+            self.close();
+            return err;
+        };
+        return self;
+    }
+
+    fn initialize(self: *Session, opts: SessionOptions) !void {
+        const mrb_ptr = self.mrb.mrb orelse return error.MRubyNotInitialized;
+        const zig_module = mruby.mrb_define_module(mrb_ptr, "ZigBackend");
+        registerResourceBindings(mrb_ptr, zig_module);
+
+        const api_modules = [_]mruby_module.MRubyModule{
+            file_ext.mruby_module_def,
+            json.mruby_module_def,
+            http.mruby_module_def,
+            base64.mruby_module_def,
+            hola_logger.mruby_module_def,
+            node_info.mruby_module_def,
+            env_access.mruby_module_def,
+            resolv.mruby_module_def,
+        };
+        for (api_modules) |module| {
+            try mruby_module.registerModule(mrb_ptr, zig_module, self.allocator, module, &self.mrb);
+        }
+
+        file_ext.setupFileExtensions(mrb_ptr);
+        try self.mrb.evalString(@embedFile("ruby_prelude/open_struct.rb"));
+        try self.mrb.evalString(@embedFile("ruby_prelude/time_parse.rb"));
+
+        try self.mrb.evalString(resources.file.ruby_prelude);
+        try self.mrb.evalString(resources.execute.ruby_prelude);
+        try self.mrb.evalString(resources.remote_file.ruby_prelude);
+        try self.mrb.evalString(resources.template.ruby_prelude);
+        try self.mrb.evalString(resources.macos_dock.ruby_prelude);
+        try self.mrb.evalString(resources.macos_defaults.ruby_prelude);
+        try self.mrb.evalString(resources.directory.ruby_prelude);
+        try self.mrb.evalString(resources.link.ruby_prelude);
+        try self.mrb.evalString(resources.route.ruby_prelude);
+        try self.mrb.evalString(resources.apt_repository.ruby_prelude);
+        try self.mrb.evalString(resources.systemd_unit.ruby_prelude);
+        try self.mrb.evalString(resources.mount_res.ruby_prelude);
+        try self.mrb.evalString(resources.package.ruby_prelude);
+        try self.mrb.evalString(resources.homebrew_package.ruby_prelude);
+        try self.mrb.evalString(resources.apt_package.ruby_prelude);
+        try self.mrb.evalString(resources.ruby_block.ruby_prelude);
+        try self.mrb.evalString(resources.git.ruby_prelude);
+        try self.mrb.evalString(resources.user.ruby_prelude);
+        try self.mrb.evalString(resources.group.ruby_prelude);
+        try self.mrb.evalString(resources.aws_kms.ruby_prelude);
+        try self.mrb.evalString(resources.file_edit.ruby_prelude);
+        try self.mrb.evalString(resources.extract.ruby_prelude);
+        try self.mrb.evalString(@embedFile("resources/apt_update_resource.rb"));
+
+        // `file` and `directory` are standard Rake task constructors. Keep the
+        // provision resource classes available for the explicit
+        // Hola::Resources namespace, but remove their top-level methods before
+        // a Rakefile is evaluated.
+        if (opts.mode == .task) {
+            try self.mrb.evalString(
+                \\Object.send(:remove_method, :file)
+                \\Object.send(:remove_method, :directory)
+            );
+        }
+
+        try self.mrb.evalString(@embedFile("ruby_prelude/data_bag.rb"));
+        try self.mrb.evalString(@embedFile("ruby_prelude/secrets_bag.rb"));
+
+        if (opts.params_json) |params_json| try injectParams(mrb_ptr, params_json);
+        if (opts.secrets_json) |secrets_json| try injectSecrets(mrb_ptr, secrets_json);
+        if (builtin.mode == .Debug) {
+            try self.mrb.evalString(@embedFile("ruby_prelude/test_helper.rb"));
+        }
+    }
+
+    pub fn close(self: *Session) void {
+        if (self.runner.display != null) self.runner.detachDisplay();
+        if (current_runner) |runner| {
+            if (runner == &self.runner) current_runner = null;
+        }
+        // Resource teardown unregisters mruby guard values, so it must happen
+        // before the interpreter is closed.
+        self.runner.deinit();
+        self.mrb.deinit();
+        self.allocator.destroy(self);
+    }
+
+    pub fn evalScript(self: *Session, path: []const u8) !void {
+        self.mrb.evalFile(path) catch |err| {
+            if (err == error.MRubyException) {
+                const mrb_ptr = self.mrb.mrb orelse return error.MRubyNotInitialized;
+                const exc = mruby.mrb_get_exception(mrb_ptr);
+                if (mruby.mrb_test(exc)) {
+                    base.recordProvisionException(mrb_ptr, exc, "script raised");
+                }
+            }
+            return err;
+        };
+    }
+
+    pub fn evalString(self: *Session, code: []const u8) !void {
+        try self.mrb.evalString(code);
+    }
+
+    pub fn loadTaskPrelude(self: *Session) !void {
+        try self.mrb.evalString(@embedFile("ruby_prelude/tasks.rb"));
+    }
 };
 
 fn cloneNotificationsFromCommon(
@@ -724,8 +1158,134 @@ const ResourceBinding = struct {
     platform: ResourcePlatform = .all,
 };
 
+fn statusPair(mrb: *mruby.mrb_state, ok: bool, message: ?[]const u8) mruby.mrb_value {
+    const pair = mruby.mrb_ary_new_capa(mrb, 2);
+    mruby.mrb_ary_push(mrb, pair, if (ok) mruby.zig_mrb_true_value() else mruby.zig_mrb_false_value());
+    if (message) |text| {
+        mruby.mrb_ary_push(mrb, pair, mruby.mrb_str_new(mrb, text.ptr, @intCast(text.len)));
+    } else {
+        mruby.mrb_ary_push(mrb, pair, mruby.mrb_nil_value());
+    }
+    return pair;
+}
+
+export fn zig_converge(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    const runner = currentRunnerOrNilValue() orelse return statusPair(mrb, false, "provision runner is not initialized");
+    if (runner.display == null) return statusPair(mrb, false, "provision display is not attached");
+    if (runner.converging or runner.converged_index >= runner.resources.items.len) {
+        return statusPair(mrb, true, null);
+    }
+
+    const arena_index = mruby.zig_mrb_gc_arena_save(mrb);
+    const converge_error: ?anyerror = blk: {
+        runner.convergeFrom(runner.converged_index) catch |err| break :blk err;
+        break :blk null;
+    };
+    mruby.zig_mrb_gc_arena_restore(mrb, arena_index);
+
+    if (converge_error) |err| {
+        const detail = base.getProvisionErrorDetail() orelse @errorName(err);
+        if (runner.last_failed_index) |index| {
+            if (index < runner.resources.items.len) {
+                const id = runner.resources.items[index].id;
+                const message = std.fmt.allocPrint(runner.allocator, "{s}[{s}]: {s}", .{ id.type_name, id.name, detail }) catch {
+                    return statusPair(mrb, false, detail);
+                };
+                defer runner.allocator.free(message);
+                return statusPair(mrb, false, message);
+            }
+        }
+        return statusPair(mrb, false, detail);
+    }
+    return statusPair(mrb, true, null);
+}
+
+export fn zig_flush_delayed(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    const runner = currentRunnerOrNilValue() orelse return statusPair(mrb, false, "provision runner is not initialized");
+    if (runner.display == null) return statusPair(mrb, false, "provision display is not attached");
+    runner.flushDelayed() catch |err| {
+        return statusPair(mrb, false, base.getProvisionErrorDetail() orelse @errorName(err));
+    };
+    return statusPair(mrb, true, null);
+}
+
+export fn zig_display_section(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    var name_value: mruby.mrb_value = undefined;
+    if (mruby.mrb_get_args(mrb, "S", &name_value) != 1) {
+        return statusPair(mrb, false, "display_section expects one task name");
+    }
+    const runner = currentRunnerOrNilValue() orelse return statusPair(mrb, false, "provision runner is not initialized");
+    const display = runner.display orelse return statusPair(mrb, false, "provision display is not attached");
+    const name = std.mem.span(mruby.mrb_str_to_cstr(mrb, name_value));
+    display.showTaskSection(name) catch |err| return statusPair(mrb, false, @errorName(err));
+    return statusPair(mrb, true, null);
+}
+
+export fn zig_print_line(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    var text_value: mruby.mrb_value = undefined;
+    if (mruby.mrb_get_args(mrb, "S", &text_value) != 1) {
+        return statusPair(mrb, false, "print_line expects one string");
+    }
+    const runner = currentRunnerOrNilValue() orelse return statusPair(mrb, false, "provision runner is not initialized");
+    const display = runner.display orelse return statusPair(mrb, false, "provision display is not attached");
+    const line = std.mem.span(mruby.mrb_str_to_cstr(mrb, text_value));
+    display.printLine(line) catch |err| return statusPair(mrb, false, @errorName(err));
+    return statusPair(mrb, true, null);
+}
+
+export fn zig_glob(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    var pattern_value: mruby.mrb_value = undefined;
+    if (mruby.mrb_get_args(mrb, "S", &pattern_value) != 1) return mruby.mrb_ary_new_capa(mrb, 0);
+    const runner = currentRunnerOrNilValue() orelse return mruby.mrb_ary_new_capa(mrb, 0);
+    const pattern = std.mem.span(mruby.mrb_str_to_cstr(mrb, pattern_value));
+    var matches = glob.expand(runner.allocator, global_io.io(), pattern) catch return mruby.mrb_ary_new_capa(mrb, 0);
+    defer glob.freeMatches(runner.allocator, &matches);
+
+    const result = mruby.mrb_ary_new_capa(mrb, @intCast(matches.items.len));
+    for (matches.items) |path| {
+        mruby.mrb_ary_push(mrb, result, mruby.mrb_str_new(mrb, path.ptr, @intCast(path.len)));
+    }
+    return result;
+}
+
+export fn zig_load_file(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    var path_value: mruby.mrb_value = undefined;
+    if (mruby.mrb_get_args(mrb, "S", &path_value) != 1) return statusPair(mrb, false, "load_file expects one path");
+    const runner = currentRunnerOrNilValue() orelse return statusPair(mrb, false, "provision runner is not initialized");
+    const path = std.mem.span(mruby.mrb_str_to_cstr(mrb, path_value));
+    const source = std.Io.Dir.cwd().readFileAlloc(global_io.io(), path, runner.allocator, .unlimited) catch |err| {
+        const message = std.fmt.allocPrint(runner.allocator, "cannot load {s}: {s}", .{ path, @errorName(err) }) catch return statusPair(mrb, false, @errorName(err));
+        defer runner.allocator.free(message);
+        return statusPair(mrb, false, message);
+    };
+    defer runner.allocator.free(source);
+    const path_z = runner.allocator.dupeZ(u8, path) catch return statusPair(mrb, false, "out of memory loading Ruby file");
+    defer runner.allocator.free(path_z);
+
+    return switch (mruby.loadStringProtected(mrb, source, path_z)) {
+        .ok => statusPair(mrb, true, null),
+        .raised => |exc| blk: {
+            var summary: [1024]u8 = undefined;
+            mruby.zig_mrb_exc_summary(mrb, exc, &summary, summary.len);
+            break :blk statusPair(mrb, false, std.mem.sliceTo(&summary, 0));
+        },
+    };
+}
+
 fn registerResourceBindings(mrb_ptr: *mruby.mrb_state, zig_module: *mruby.RClass) void {
     const bindings = [_]ResourceBinding{
+        .{ .name = "converge", .handler = zig_converge, .args_spec = mruby.MRB_ARGS_NONE() },
+        .{ .name = "flush_delayed", .handler = zig_flush_delayed, .args_spec = mruby.MRB_ARGS_NONE() },
+        .{ .name = "display_section", .handler = zig_display_section, .args_spec = mruby.MRB_ARGS_REQ(1) },
+        .{ .name = "print_line", .handler = zig_print_line, .args_spec = mruby.MRB_ARGS_REQ(1) },
+        .{ .name = "glob", .handler = zig_glob, .args_spec = mruby.MRB_ARGS_REQ(1) },
+        .{ .name = "load_file", .handler = zig_load_file, .args_spec = mruby.MRB_ARGS_REQ(1) },
         .{ .name = "add_file", .handler = zig_add_file_resource, .args_spec = mruby.MRB_ARGS_REQ(6) | mruby.MRB_ARGS_OPT(5) },
         .{ .name = "add_execute", .handler = zig_add_execute_resource, .args_spec = mruby.MRB_ARGS_REQ(10) | mruby.MRB_ARGS_OPT(5) },
         .{ .name = "add_remote_file", .handler = zig_add_remote_file_resource, .args_spec = mruby.MRB_ARGS_REQ(12) | mruby.MRB_ARGS_OPT(15) },
@@ -815,162 +1375,22 @@ fn injectSecrets(mrb: *mruby.mrb_state, secrets_json: []const u8) !void {
 }
 
 pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
-    // Provision error detail buffer is threadlocal; clear at entry so a prior
-    // invocation on this thread can't leak into this run.
-    base.clearProvisionErrorDetail();
+    const session = try Session.open(allocator, .{
+        .params_json = opts.params_json,
+        .secrets_json = opts.secrets_json,
+    });
+    defer session.close();
+    try session.evalScript(opts.script_path);
 
-    // Initialize the mruby interpreter before the runner so it outlives the
-    // resources. Resource teardown (CommonProps.deinit) calls
-    // mrb_gc_unregister on the mrb state for only_if/not_if guard blocks, so
-    // the state must still be alive when runner.deinit() runs. Defers execute
-    // LIFO: registering mrb.deinit() first makes runner.deinit() (and resource
-    // teardown) run before the mruby state is closed.
-    var mrb = try mruby.State.init();
-    defer mrb.deinit();
-
-    var runner = ProvisionRunner.init(allocator);
-    defer runner.deinit();
-
-    current_runner = &runner;
-    defer current_runner = null;
-
-    // Register Zig functions in mruby
-    const mrb_ptr = mrb.mrb orelse return error.MRubyNotInitialized;
-    const zig_module = mruby.mrb_define_module(mrb_ptr, "ZigBackend");
-    registerResourceBindings(mrb_ptr, zig_module);
-
-    // Register all API modules using the unified interface
-    // Register modules in dependency order: JSON must be registered before http_client
-    // because http_client's Ruby prelude calls JSON.parse in Response#json method
-    const api_modules = [_]mruby_module.MRubyModule{
-        file_ext.mruby_module_def, // File.stat and File.mtime extensions
-        json.mruby_module_def,
-        http.mruby_module_def,
-        base64.mruby_module_def,
-        hola_logger.mruby_module_def,
-        node_info.mruby_module_def,
-        env_access.mruby_module_def,
-        resolv.mruby_module_def,
-    };
-
-    for (api_modules) |module| {
-        try mruby_module.registerModule(mrb_ptr, zig_module, allocator, module, &mrb);
-    }
-
-    // Setup File class methods (must be done after registerModule loads the prelude)
-    // This registers File.stat and File.mtime as class methods
-    file_ext.setupFileExtensions(mrb_ptr);
-
-    // Load OpenStruct utility class (used by node object and other resources)
-    try mrb.evalString(@embedFile("ruby_prelude/open_struct.rb"));
-
-    // Load Time.parse polyfill (mruby ships no Regexp, no Time.parse)
-    try mrb.evalString(@embedFile("ruby_prelude/time_parse.rb"));
-
-    // Load Ruby DSL preludes for resource types
-    try mrb.evalString(resources.file.ruby_prelude);
-    try mrb.evalString(resources.execute.ruby_prelude);
-    try mrb.evalString(resources.remote_file.ruby_prelude);
-    try mrb.evalString(resources.template.ruby_prelude);
-    // Always load macOS-specific Ruby DSLs so the methods exist cross-platform.
-    // On non-macOS, the Ruby preludes themselves detect the absence of ZigBackend
-    // entrypoints and act as no-op helpers.
-    try mrb.evalString(resources.macos_dock.ruby_prelude);
-    try mrb.evalString(resources.macos_defaults.ruby_prelude);
-    try mrb.evalString(resources.directory.ruby_prelude);
-    try mrb.evalString(resources.link.ruby_prelude);
-    try mrb.evalString(resources.route.ruby_prelude);
-    // Load Linux-specific Ruby DSLs (apt_repository, systemd_unit, etc.)
-    // On non-Linux, the Ruby preludes detect absence of ZigBackend entrypoints
-    try mrb.evalString(resources.apt_repository.ruby_prelude);
-    try mrb.evalString(resources.systemd_unit.ruby_prelude);
-    try mrb.evalString(resources.mount_res.ruby_prelude);
-    // Load package resources (delegator and platform-specific)
-    try mrb.evalString(resources.package.ruby_prelude);
-    try mrb.evalString(resources.homebrew_package.ruby_prelude);
-    try mrb.evalString(resources.apt_package.ruby_prelude);
-    // Load ruby_block resource
-    try mrb.evalString(resources.ruby_block.ruby_prelude);
-    // Load git resource
-    try mrb.evalString(resources.git.ruby_prelude);
-    // Load user and group resources
-    try mrb.evalString(resources.user.ruby_prelude);
-    try mrb.evalString(resources.group.ruby_prelude);
-    // Load aws_kms resource
-    try mrb.evalString(resources.aws_kms.ruby_prelude);
-    // Load file_edit resource
-    try mrb.evalString(resources.file_edit.ruby_prelude);
-    // Load extract resource
-    try mrb.evalString(resources.extract.ruby_prelude);
-    // Load Ruby-only custom resources
-    try mrb.evalString(@embedFile("resources/apt_update_resource.rb"));
-
-    // Load data_bag support
-    try mrb.evalString(@embedFile("ruby_prelude/data_bag.rb"));
-
-    // Load secrets_bag support
-    try mrb.evalString(@embedFile("ruby_prelude/secrets_bag.rb"));
-
-    // Inject params as $_hola_params if provided (agent mode)
-    if (opts.params_json) |params_json| {
-        try injectParams(mrb_ptr, params_json);
-    }
-
-    // Inject secrets as $_hola_secrets if provided
-    if (opts.secrets_json) |secrets_json| {
-        try injectSecrets(mrb_ptr, secrets_json);
-    }
-
-    // Load test helper only in debug builds
-    if (builtin.mode == .Debug) {
-        try mrb.evalString(@embedFile("ruby_prelude/test_helper.rb"));
-    }
-
-    // Load and execute user's recipe
-    // Use evalFile instead of evalString to preserve file path and line numbers in error messages.
-    // On failure, capture the mruby exception summary (ClassName + message) so
-    // the agent callback / top-level caller can surface something friendlier
-    // than the bare "MRubyException" Zig error name. mrb_print_error() inside
-    // evalFile doesn't clear mrb->exc, so we can still read it here.
-    mrb.evalFile(opts.script_path) catch |err| {
-        if (err == error.MRubyException) {
-            const exc = mruby.mrb_get_exception(mrb_ptr);
-            if (mruby.mrb_test(exc)) {
-                base.recordProvisionException(mrb_ptr, exc, "script raised");
-            }
-        }
-        return err;
-    };
-
-    // Record start time for timer
-    const start_time: i128 = std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds();
-
-    // Initialize resource results collection
-    var resource_results = std.ArrayList(ResourceResult).empty;
-    errdefer {
-        for (resource_results.items) |rr| {
-            allocator.free(rr.type_name);
-            allocator.free(rr.name);
-            allocator.free(rr.action);
-            if (rr.skip_reason) |sr| allocator.free(sr);
-            if (rr.error_name) |en| allocator.free(en);
-            if (rr.error_message) |em| allocator.free(em);
-            if (rr.output) |o| allocator.free(o);
-        }
-        resource_results.deinit(allocator);
-    }
+    const runner = &session.runner;
+    runner.start_time = std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds();
 
     // Initialize modern display with the specified output mode
     var display = try modern_display.ModernProvisionDisplay.init(allocator, opts.use_pretty_output);
     defer display.deinit();
 
-    // Set global display for async executor callback
-    runner.display = &display;
-    defer runner.display = null;
-
-    // Set poll callback for async executor
-    AsyncExecutor.setPollCallback(pollDisplayUpdate);
-    defer AsyncExecutor.setPollCallback(null);
+    runner.attachDisplay(&display);
+    defer runner.detachDisplay();
 
     // Show section header
     try display.showSection("Applying Configuration");
@@ -1139,6 +1559,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
 
     // Start background download processing if we have tasks
     var download_thread: ?std.Thread = null;
+    defer if (download_thread) |thread| thread.join();
     if (download_mgr.tasks.items.len > 0) {
         const DownloadThread = struct {
             fn run(mgr: *http.download.Manager) void {
@@ -1149,200 +1570,22 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
         };
         download_thread = try std.Thread.spawn(.{}, DownloadThread.run, .{&download_mgr});
     }
+    runner.download_mgr = &download_mgr;
+    defer runner.download_mgr = null;
 
     // Start resource execution phase
     try display.showSectionWithLevel("Executing Resources", 3);
 
     // Start the real-time timer spinner (after all download spinners are created)
-    try display.startTimer(start_time);
-
-    // Track immediate and delayed notifications
-    var immediate_notifications = std.ArrayList(PendingNotification).empty;
-    defer immediate_notifications.deinit(allocator);
-    var delayed_notifications = std.ArrayList(PendingNotification).empty;
-    defer delayed_notifications.deinit(allocator);
-
-    // Phase 0: Convert subscriptions to reverse notifications
-    // When resource A subscribes to resource B, we add a notification from B to A
-    for (runner.resources.items) |*subscriber_res| {
-        const common = subscriber_res.resource.getCommonProps();
-        for (common.subscriptions.items) |sub| {
-            // Find the source resource that this resource is subscribing to
-            const source_id_parsed = base.notification.ResourceId.parse(allocator, sub.target_resource_id) catch continue;
-            defer source_id_parsed.deinit(allocator);
-
-            // Find the source resource in our list
-            for (runner.resources.items) |*source_res| {
-                if (std.mem.eql(u8, source_res.id.type_name, source_id_parsed.type_name) and
-                    std.mem.eql(u8, source_res.id.name, source_id_parsed.name))
-                {
-                    // Add a notification from source to subscriber
-                    const subscriber_id = try subscriber_res.id.toString(allocator);
-                    const notif = base.notification.Notification{
-                        .target_resource_id = subscriber_id,
-                        .action = .{ .action_name = try allocator.dupe(u8, sub.action.action_name) },
-                        .timing = sub.timing,
-                    };
-
-                    const source_common = source_res.resource.getCommonProps();
-                    try source_common.notifications.append(allocator, notif);
-                    break;
-                }
-            }
-        }
-    }
-
-    // Phase 1: Execute resources and collect notifications
-    for (runner.resources.items) |*res| {
-        base.clearProvisionErrorDetail();
-        try display.startResource(res.id.type_name, res.id.name);
-        try display.update();
-
-        // Wait for download task if this is a remote_file resource
-        if (res.resource == .remote_file and download_thread != null) {
-            // Find the download task for this specific remote_file resource
-            const resource_id = try std.fmt.allocPrint(allocator, "{s}[{s}]", .{ res.id.type_name, res.id.name });
-            defer allocator.free(resource_id);
-
-            if (download_mgr.getTask(resource_id)) |task| {
-                // Check current status first
-                const initial_status = task.status.load(.acquire);
-
-                // Only wait if the task is still in progress
-                if (initial_status == .queued or initial_status == .downloading) {
-                    // Wait for this specific download task to complete
-                    var max_wait_iterations: usize = 3000; // 30 seconds max wait (10ms * 3000)
-                    while (max_wait_iterations > 0) {
-                        const status = task.status.load(.acquire);
-                        if (status != .queued and status != .downloading) {
-                            break;
-                        }
-
-                        try display.update();
-                        std.Thread.yield() catch {};
-                        global_io.io().sleep(.fromNanoseconds(10 * std.time.ns_per_ms), .awake) catch {};
-                        max_wait_iterations -= 1;
-                    }
-                }
-
-                // Check if the download failed
-                const final_status = task.status.load(.acquire);
-                if (final_status == .failed) {
-                    const err_msg_owned = task.getError(allocator);
-                    defer if (err_msg_owned) |msg| allocator.free(msg);
-                    const err_msg = err_msg_owned orelse "Unknown error";
-
-                    const msg = try std.fmt.allocPrint(allocator, "Download failed for {s}: {s}", .{ resource_id, err_msg });
-                    defer allocator.free(msg);
-                    base.recordProvisionErrorDetailSlice(msg);
-                    try display.showInfo(msg);
-                    return error.DownloadFailed;
-                }
-            }
-        }
-
-        const result = res.resource.apply() catch |err| {
-            const detail_msg = base.getProvisionErrorDetail();
-            const error_display = detail_msg orelse @errorName(err);
-            try display.resourceError(res.id.type_name, res.id.name, error_display);
-            try display.update();
-
-            try resource_results.append(allocator, .{
-                .type_name = try allocator.dupe(u8, res.id.type_name),
-                .name = try allocator.dupe(u8, res.id.name),
-                .action = try allocator.dupe(u8, ""),
-                .was_updated = false,
-                .skipped = false,
-                .skip_reason = null,
-                .error_name = try allocator.dupe(u8, @errorName(err)),
-                .error_message = if (detail_msg) |m| try allocator.dupe(u8, m) else null,
-                .output = null,
-            });
-
-            // Check if this resource has ignore_failure set
-            if (res.resource.shouldIgnoreFailure()) {
-                // Continue to next resource if ignore_failure is true
-                continue;
-            } else {
-                // Stop execution and return error
-                return err;
-            }
-        };
-        // Free resource-allocated output after duping into resource_results
-        defer if (result.output) |o| std.heap.c_allocator.free(o);
-        res.was_updated = result.was_updated;
-
-        // Update resource status with action and skip reason
-        // If skip_reason is "up to date", show it even if was_updated is false
-        if (result.was_updated) {
-            // Pass skip_reason to resourceUpdated so it can handle "up to date" case
-            try display.resourceUpdated(res.id.type_name, res.id.name, result.action, result.skip_reason);
-            try display.update();
-
-            try resource_results.append(allocator, .{
-                .type_name = try allocator.dupe(u8, res.id.type_name),
-                .name = try allocator.dupe(u8, res.id.name),
-                .action = try allocator.dupe(u8, result.action),
-                .was_updated = true,
-                .skipped = false,
-                .skip_reason = if (result.skip_reason) |sr| try allocator.dupe(u8, sr) else null,
-                .error_name = null,
-                .output = if (result.output) |o| try allocator.dupe(u8, o) else null,
-            });
-
-            // Collect notifications from updated resources (only if actually updated, not "up to date")
-            if (result.skip_reason == null or !std.mem.eql(u8, result.skip_reason.?, "up to date")) {
-                for (res.notifications.items) |notif| {
-                    const pending = PendingNotification{
-                        .notification = notif,
-                        .source_id = try res.id.toString(allocator),
-                    };
-
-                    if (notif.timing == .immediate) {
-                        try immediate_notifications.append(allocator, pending);
-                    } else {
-                        try delayed_notifications.append(allocator, pending);
-                    }
-                }
-            }
-        } else {
-            // Resource was not updated - show skip reason (including "up to date")
-            try display.resourceSkipped(res.id.type_name, res.id.name, result.action, result.skip_reason);
-            try display.update();
-
-            try resource_results.append(allocator, .{
-                .type_name = try allocator.dupe(u8, res.id.type_name),
-                .name = try allocator.dupe(u8, res.id.name),
-                .action = try allocator.dupe(u8, result.action),
-                .was_updated = false,
-                .skipped = true,
-                .skip_reason = if (result.skip_reason) |sr| try allocator.dupe(u8, sr) else null,
-                .error_name = null,
-                .output = null,
-            });
-        }
-    }
-
-    // Phase 2: Process immediate notifications
-    if (immediate_notifications.items.len > 0) {
-        try display.showSectionWithLevel("Processing Immediate Notifications", 3);
-        for (immediate_notifications.items) |pending| {
-            try processNotification(allocator, pending, &display);
-        }
-    }
-
-    // Phase 3: Process delayed notifications at end
-    if (delayed_notifications.items.len > 0) {
-        try display.showSectionWithLevel("Processing Delayed Notifications", 3);
-        for (delayed_notifications.items) |pending| {
-            try processNotification(allocator, pending, &display);
-        }
-    }
+    try display.startTimer(runner.start_time);
+    try runner.convergeFrom(0);
+    try runner.flushDelayed();
 
     // Wait for download thread to complete
     if (download_thread) |thread| {
         try display.showInfo("Waiting for remaining downloads to complete...");
         thread.join();
+        download_thread = null;
 
         // Show final stats
         const stats = download_mgr.getStats();
@@ -1353,20 +1596,12 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
         }
     }
 
-    // Cleanup pending notifications
-    for (immediate_notifications.items) |pending| {
-        allocator.free(pending.source_id);
-    }
-    for (delayed_notifications.items) |pending| {
-        allocator.free(pending.source_id);
-    }
-
     // Show execution summary with duration
     try display.showSummaryWithDuration(0, 0);
 
     // Compute duration
     const end_time: i128 = std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds();
-    const elapsed_ms = @divTrunc(end_time - start_time, std.time.ns_per_ms);
+    const elapsed_ms = @divTrunc(end_time - runner.start_time, std.time.ns_per_ms);
 
     return ProvisionResult{
         .executed_count = display.executed_count,
@@ -1374,8 +1609,228 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
         .skipped_count = display.skipped_count,
         .failed_count = display.failed_count,
         .duration_ms = @intCast(elapsed_ms),
-        .resource_results = resource_results,
+        .resource_results = runner.takeResults(),
     };
+}
+
+test "Session.open collects resources without applying" {
+    const allocator = std.testing.allocator;
+    json.setAllocator(allocator);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realPathFileAlloc(global_io.io(), ".", allocator);
+    defer allocator.free(root);
+    const target = try std.fs.path.join(allocator, &.{ root, "not-applied.txt" });
+    defer allocator.free(target);
+
+    const session = try Session.open(allocator, .{});
+    defer session.close();
+    const script = try std.fmt.allocPrint(allocator, "file '{s}' do\n  content 'x'\nend", .{target});
+    defer allocator.free(script);
+    try session.evalString(script);
+
+    try std.testing.expectEqual(@as(usize, 1), session.runner.resources.items.len);
+    try std.testing.expectEqual(@as(usize, 0), session.runner.converged_index);
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(global_io.io(), target, .{}));
+}
+
+test "convergeFrom applies and records results once" {
+    const allocator = std.testing.allocator;
+    json.setAllocator(allocator);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realPathFileAlloc(global_io.io(), ".", allocator);
+    defer allocator.free(root);
+    const target = try std.fs.path.join(allocator, &.{ root, "applied.txt" });
+    defer allocator.free(target);
+
+    const session = try Session.open(allocator, .{});
+    defer session.close();
+    const script = try std.fmt.allocPrint(allocator, "file '{s}' do\n  content 'x'\nend", .{target});
+    defer allocator.free(script);
+    try session.evalString(script);
+
+    var display = try modern_display.ModernProvisionDisplay.init(allocator, false);
+    defer display.deinit();
+    session.runner.attachDisplay(&display);
+    defer session.runner.detachDisplay();
+    display.setTotalResources(1);
+
+    try session.runner.convergeFrom(0);
+    try std.testing.expectEqual(@as(usize, 1), session.runner.resource_results.items.len);
+    try std.testing.expectEqual(@as(usize, 1), session.runner.converged_index);
+    try std.Io.Dir.cwd().access(global_io.io(), target, .{});
+
+    try session.runner.convergeFrom(1);
+    try std.testing.expectEqual(@as(usize, 1), session.runner.resource_results.items.len);
+}
+
+test "task prelude supports common Rake task semantics" {
+    var mrb_state = try mruby.State.init();
+    defer mrb_state.deinit();
+    const mrb_ptr = mrb_state.mrb orelse return error.MRubyNotInitialized;
+
+    try mrb_state.evalString(
+        \\module ZigBackend
+        \\  def self.converge; [true, nil]; end
+        \\  def self.flush_delayed; [true, nil]; end
+        \\  def self.display_section(name); ($sections ||= []) << name; [true, nil]; end
+        \\end
+        \\module ENV
+        \\  @values = {}
+        \\  def self.[](key); @values[key]; end
+        \\  def self.[]=(key, value); @values[key] = value; end
+        \\end
+    );
+    try mrb_state.evalString(@embedFile("ruby_prelude/tasks.rb"));
+    try mrb_state.evalString(
+        \\$events = []
+        \\task(:a) { $events << :a }
+        \\task(:b => :a) { $events << :b }
+        \\task(:c => [:a, :b]) { $events << :c }
+        \\task :greet, [:name] do |task, args|
+        \\  args.with_defaults(:name => 'world')
+        \\  $events << args.name
+        \\end
+        \\namespace :db do
+        \\  task :prepare do
+        \\    $events << :db_prepare
+        \\  end
+        \\  namespace :admin do
+        \\    task :reset => 'prepare' do
+        \\      $events << :admin_reset
+        \\    end
+        \\  end
+        \\  task :reset do
+        \\    $events << :reset
+        \\  end
+        \\end
+        \\task(:merged) { $events << :first }
+        \\task(:merged) { $events << :second }
+        \\file 'standard-file-task'
+        \\file_task 'legacy-file-task'
+        \\directory 'standard-directory-task'
+        \\task :cycle_a => :cycle_b
+        \\task :cycle_b => :cycle_a
+        \\class ExampleTaskLib < Rake::TaskLib
+        \\  def initialize
+        \\    task(:from_tasklib) { $events << :tasklib }
+        \\  end
+        \\end
+        \\ExampleTaskLib.new
+        \\require 'rake/clean'
+        \\Hola::Rake.application.run(['HOLA_TASK_ENV=present', 'c', 'greet[bob]', 'db:reset', 'db:admin:reset', 'from_tasklib'])
+        \\$dependency_result = ($events == [:a, :b, :c, 'bob', :reset, :db_prepare, :admin_reset, :tasklib])
+        \\$dependency_result = $dependency_result && (ENV['HOLA_TASK_ENV'] == 'present')
+        \\Rake::Task[:merged].invoke
+        \\Rake::Task[:merged].invoke
+        \\Rake::Task[:merged].reenable
+        \\Rake::Task[:merged].invoke
+        \\$enhance_result = ($events[-4, 4] == [:first, :second, :first, :second])
+        \\begin
+        \\  Rake::Task[:cycle_a].invoke
+        \\rescue => error
+        \\  $cycle_result = error.message.include?('Circular dependency detected: cycle_a => cycle_b => cycle_a')
+        \\end
+        \\begin
+        \\  Rake::Task[:missing]
+        \\rescue => error
+        \\  $missing_result = (error.message == "Don't know how to build task 'missing'")
+        \\end
+        \\$parse_result = [
+        \\  Hola::Rake.application.parse_task_string('a'),
+        \\  Hola::Rake.application.parse_task_string('a[]'),
+        \\  Hola::Rake.application.parse_task_string('a[1, 2]'),
+        \\  Hola::Rake.application.parse_task_string('ns:a[x]'),
+        \\]
+        \\$parse_test_result = ($parse_result == [['a', []], ['a', []], ['a', ['1', '2']], ['ns:a', ['x']]])
+        \\$tasklib_result = Rake::Task.task_defined?(:from_tasklib) && Rake::Task.task_defined?(:clean) && Rake::Task.task_defined?(:clobber)
+        \\$file_dsl_result = Rake::Task[:'standard-file-task'].is_a?(Rake::FileTask) && Rake::Task[:'legacy-file-task'].is_a?(Rake::FileTask) && Rake::Task[:'standard-directory-task'].is_a?(Rake::FileTask)
+    );
+
+    const result_names = [_][*:0]const u8{
+        "$dependency_result",
+        "$enhance_result",
+        "$cycle_result",
+        "$missing_result",
+        "$parse_test_result",
+        "$tasklib_result",
+        "$file_dsl_result",
+    };
+    for (result_names) |name| {
+        const result = mruby.mrb_gv_get(mrb_ptr, mruby.mrb_intern_cstr(mrb_ptr, name));
+        try std.testing.expect(mruby.mrb_test(result));
+    }
+}
+
+test "task prelude immediate wrapper converges resource declarations" {
+    var mrb_state = try mruby.State.init();
+    defer mrb_state.deinit();
+    const mrb_ptr = mrb_state.mrb orelse return error.MRubyNotInitialized;
+
+    try mrb_state.evalString(
+        \\$converge_calls = 0
+        \\module ZigBackend
+        \\  def self.converge; $converge_calls += 1; [true, nil]; end
+        \\  def self.flush_delayed; [true, nil]; end
+        \\  def self.display_section(name); [true, nil]; end
+        \\end
+        \\def execute(name, &block); name; end
+    );
+    try mrb_state.evalString(@embedFile("ruby_prelude/tasks.rb"));
+    try mrb_state.evalString("$hola_run_immediate = true; execute('command'); $immediate_result = ($converge_calls == 1)");
+    const result = mruby.mrb_gv_get(mrb_ptr, mruby.mrb_intern_cstr(mrb_ptr, "$immediate_result"));
+    try std.testing.expect(mruby.mrb_test(result));
+}
+
+test "task command-line assignments use the environment bridge" {
+    const allocator = std.testing.allocator;
+    json.setAllocator(allocator);
+    const session = try Session.open(allocator, .{ .mode = .task });
+    defer session.close();
+    defer session.evalString("ENV.delete('HOLA_TASK_TEST_ENV')") catch {};
+
+    var display = try modern_display.ModernProvisionDisplay.init(allocator, false);
+    defer display.deinit();
+    session.runner.attachDisplay(&display);
+    defer session.runner.detachDisplay();
+    session.runner.start_time = std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds();
+    try display.startTimer(session.runner.start_time);
+
+    try session.loadTaskPrelude();
+    try session.evalString(
+        \\file 'standard-task-file'
+        \\task(:check_env) { $env_seen = ENV['HOLA_TASK_TEST_ENV'] }
+        \\$hola_run_argv = ['HOLA_TASK_TEST_ENV=present', 'check_env']
+        \\Hola::Rake.main
+        \\$env_bridge_result = ($hola_run_status == 0 && $env_seen == 'present')
+    );
+    const result = session.mrb.getGlobal("$env_bridge_result");
+    try std.testing.expect(mruby.mrb_test(result));
+    try std.testing.expectEqual(@as(usize, 0), session.runner.resources.items.len);
+}
+
+test "protected ruby_block failure returns a converge status and session remains usable" {
+    const allocator = std.testing.allocator;
+    json.setAllocator(allocator);
+    const session = try Session.open(allocator, .{});
+    defer session.close();
+
+    var display = try modern_display.ModernProvisionDisplay.init(allocator, false);
+    defer display.deinit();
+    session.runner.attachDisplay(&display);
+    defer session.runner.detachDisplay();
+
+    try session.evalString("ruby_block('boom') { block { raise 'kaboom' } }; $r = ZigBackend.converge");
+    try session.evalString("$protected_failure = (!$r[0] && $r[1].include?('ruby_block[boom]') && $r[1].include?('kaboom'))");
+    const failure_result = mruby.mrb_gv_get(session.mrb.mrb.?, mruby.mrb_intern_cstr(session.mrb.mrb.?, "$protected_failure"));
+    try std.testing.expect(mruby.mrb_test(failure_result));
+
+    try session.evalString("ruby_block('ok') { block { true } }; $r2 = ZigBackend.converge; $protected_recovery = ($r2 == [true, nil])");
+    const recovery_result = mruby.mrb_gv_get(session.mrb.mrb.?, mruby.mrb_intern_cstr(session.mrb.mrb.?, "$protected_recovery"));
+    try std.testing.expect(mruby.mrb_test(recovery_result));
 }
 
 test "injectSecrets and secrets_bag reads values correctly" {

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -23,7 +23,7 @@ const glob = @import("glob.zig");
 
 pub const Options = struct {
     script_path: []const u8,
-    use_pretty_output: bool = true, // Default to pretty output
+    output_mode: modern_display.OutputMode = .normal,
     params_json: ?[]const u8 = null, // JSON string for data_bag injection
     secrets_json: ?[]const u8 = null, // JSON string for secrets_bag injection
 };
@@ -88,6 +88,8 @@ pub const ProvisionRunner = struct {
     converged_index: usize = 0,
     converging: bool = false,
     last_failed_index: ?usize = null,
+    current_resource_index: ?usize = null,
+    declaration_display_path: std.ArrayList(resources.DisplayScope) = .empty,
     start_time: i128 = 0,
     output: output_channel.LineChannel,
 
@@ -105,6 +107,8 @@ pub const ProvisionRunner = struct {
             self.allocator.free(pending.source_id);
         }
         self.delayed_notifications.deinit(self.allocator);
+        for (self.declaration_display_path.items) |scope| scope.deinit(self.allocator);
+        self.declaration_display_path.deinit(self.allocator);
         self.output.deinit();
         for (self.resources.items) |*res| {
             res.deinit(self.allocator);
@@ -208,34 +212,79 @@ pub const ProvisionRunner = struct {
         base.clearProvisionErrorDetail();
         self.last_failed_index = null;
 
-        try display.startResource(self.resources.items[index].id.type_name, self.resources.items[index].id.name);
+        const starting_resource = &self.resources.items[index];
+        try display.startResource(
+            starting_resource.id.type_name,
+            starting_resource.id.name,
+            starting_resource.resource.getActionName(),
+            starting_resource.display_depth,
+            starting_resource.display_path,
+        );
+        if (starting_resource.resource.getCommand()) |command| {
+            try display.showCommand(command);
+        }
         try display.update();
         self.waitForDownload(index) catch |err| {
             const res = &self.resources.items[index];
             const detail_msg = base.getProvisionErrorDetail();
-            const error_display = detail_msg orelse @errorName(err);
-            try display.resourceError(res.id.type_name, res.id.name, error_display);
+            const error_display = detail_msg orelse base.userFacingError(err);
+            const diagnostic = base.getCommandDiagnostic();
+            const failure_checkpoint = display.failureCheckpoint();
+            try display.resourceError(.{
+                .resource_type = res.id.type_name,
+                .resource_name = res.id.name,
+                .action = res.resource.getActionName(),
+                .depth = res.display_depth,
+                .error_name = base.userFacingError(err),
+                .message = error_display,
+                .command = res.resource.getCommand(),
+                .stdout = if (diagnostic) |value| value.stdout else null,
+                .stderr = if (diagnostic) |value| value.stderr else null,
+                .backtrace = base.getProvisionErrorTrace(),
+            });
             try display.update();
             try self.recordResult(res.id, .{
                 .error_name = @errorName(err),
                 .error_message = detail_msg,
             });
+            if (res.resource.shouldIgnoreFailure()) {
+                display.handleFailuresSince(failure_checkpoint);
+                return;
+            }
             self.last_failed_index = index;
             return err;
         };
 
+        self.current_resource_index = index;
+        defer self.current_resource_index = null;
         const result = self.resources.items[index].resource.apply() catch |err| {
             const res = &self.resources.items[index];
             const detail_msg = base.getProvisionErrorDetail();
-            const error_display = detail_msg orelse @errorName(err);
-            try display.resourceError(res.id.type_name, res.id.name, error_display);
+            const error_display = detail_msg orelse base.userFacingError(err);
+            const diagnostic = base.getCommandDiagnostic();
+            const failure_checkpoint = display.failureCheckpoint();
+            try display.resourceError(.{
+                .resource_type = res.id.type_name,
+                .resource_name = res.id.name,
+                .action = res.resource.getActionName(),
+                .depth = res.display_depth,
+                .error_name = base.userFacingError(err),
+                .message = error_display,
+                .command = res.resource.getCommand(),
+                .stdout = if (diagnostic) |value| value.stdout else null,
+                .stderr = if (diagnostic) |value| value.stderr else null,
+                .backtrace = base.getProvisionErrorTrace(),
+            });
             try display.update();
             try self.recordResult(res.id, .{
                 .error_name = @errorName(err),
                 .error_message = detail_msg,
             });
 
-            if (res.resource.shouldIgnoreFailure()) return;
+            if (res.resource.shouldIgnoreFailure()) {
+                display.handleFailuresSince(failure_checkpoint);
+                return;
+            }
             self.last_failed_index = index;
             return err;
         };
@@ -247,7 +296,7 @@ pub const ProvisionRunner = struct {
         res.was_updated = result.was_updated;
 
         if (result.was_updated) {
-            try display.resourceUpdated(res.id.type_name, res.id.name, result.action, result.skip_reason);
+            try display.resourceUpdated(res.id.type_name, res.id.name, result.action, result.skip_reason, result.output);
             try display.update();
             try self.recordResult(res.id, .{
                 .action = result.action,
@@ -342,7 +391,7 @@ pub const ProvisionRunner = struct {
         }
 
         if (immediate_notifications.items.len > 0) {
-            try display.showSectionWithLevel("Processing Immediate Notifications", 3);
+            try display.showNotificationSection("Immediate notifications");
             for (immediate_notifications.items) |pending| {
                 try processNotification(self.allocator, pending, display);
             }
@@ -352,7 +401,7 @@ pub const ProvisionRunner = struct {
     pub fn flushDelayed(self: *ProvisionRunner) !void {
         if (self.delayed_notifications.items.len == 0) return;
         const display = self.display orelse return error.DisplayNotAttached;
-        try display.showSectionWithLevel("Processing Delayed Notifications", 3);
+        try display.showNotificationSection("Delayed notifications");
         for (self.delayed_notifications.items) |pending| {
             try processNotification(self.allocator, pending, display);
         }
@@ -388,7 +437,7 @@ fn pollDisplayUpdate() !void {
                 try display.printCommandLine(stream, batch.bytes[line_start..line_end]);
                 index = line_end + 1;
             }
-            if (batch.dropped > 0) {
+            if (batch.dropped > 0 and !display.isCompact()) {
                 var message_buf: [128]u8 = undefined;
                 const message = try std.fmt.bufPrint(&message_buf, "   [hola] dropped {d} live output lines", .{batch.dropped});
                 try display.printLine(message);
@@ -547,18 +596,33 @@ fn cloneNotificationsFromCommon(
     common: *const base.CommonProps,
 ) !std.ArrayList(resources.Notification) {
     var notifications = std.ArrayList(resources.Notification).empty;
+    errdefer {
+        for (notifications.items) |notif| notif.deinit(allocator);
+        notifications.deinit(allocator);
+    }
     for (common.notifications.items) |notif| {
         const target_id = try allocator.dupe(u8, notif.target_resource_id);
-        const action_name = try allocator.dupe(u8, notif.action.action_name);
+        const action_name = allocator.dupe(u8, notif.action.action_name) catch |err| {
+            allocator.free(target_id);
+            return err;
+        };
 
         const notif_copy = resources.Notification{
             .target_resource_id = target_id,
             .action = .{ .action_name = action_name },
             .timing = notif.timing,
         };
-        try notifications.append(allocator, notif_copy);
+        notifications.append(allocator, notif_copy) catch |err| {
+            notif_copy.deinit(allocator);
+            return err;
+        };
     }
     return notifications;
+}
+
+fn deinitNotifications(allocator: std.mem.Allocator, notifications: *std.ArrayList(resources.Notification)) void {
+    for (notifications.items) |notif| notif.deinit(allocator);
+    notifications.deinit(allocator);
 }
 
 fn makeResourceId(
@@ -566,10 +630,58 @@ fn makeResourceId(
     type_name: []const u8,
     name: []const u8,
 ) !resources.ResourceId {
-    return resources.ResourceId{
-        .type_name = try allocator.dupe(u8, type_name),
+    const owned_type_name = try allocator.dupe(u8, type_name);
+    errdefer allocator.free(owned_type_name);
+    return .{
+        .type_name = owned_type_name,
         .name = try allocator.dupe(u8, name),
     };
+}
+
+fn cloneDisplayScope(allocator: std.mem.Allocator, scope: resources.DisplayScope) !resources.DisplayScope {
+    const type_name = try allocator.dupe(u8, scope.type_name);
+    errdefer allocator.free(type_name);
+    const name = try allocator.dupe(u8, scope.name);
+    errdefer allocator.free(name);
+    return .{
+        .type_name = type_name,
+        .name = name,
+        .action = try allocator.dupe(u8, scope.action),
+    };
+}
+
+fn currentDisplayDepth(runner: *const ProvisionRunner) usize {
+    const parent_depth = if (runner.current_resource_index) |index|
+        runner.resources.items[index].display_depth + 1
+    else
+        0;
+    return parent_depth + runner.declaration_display_path.items.len;
+}
+
+fn cloneCurrentDisplayPath(runner: *const ProvisionRunner) ![]resources.DisplayScope {
+    const allocator = runner.allocator;
+    const inherited = if (runner.current_resource_index) |index|
+        runner.resources.items[index].display_path
+    else
+        &.{};
+    const total = inherited.len + runner.declaration_display_path.items.len;
+    if (total == 0) return &.{};
+
+    const result = try allocator.alloc(resources.DisplayScope, total);
+    var initialized: usize = 0;
+    errdefer {
+        for (result[0..initialized]) |scope| scope.deinit(allocator);
+        allocator.free(result);
+    }
+    for (inherited) |scope| {
+        result[initialized] = try cloneDisplayScope(allocator, scope);
+        initialized += 1;
+    }
+    for (runner.declaration_display_path.items) |scope| {
+        result[initialized] = try cloneDisplayScope(allocator, scope);
+        initialized += 1;
+    }
+    return result;
 }
 
 fn addResourceWithMetadata(
@@ -596,21 +708,44 @@ fn addResourceWithMetadata(
 
     // Process all resources in tmp_resources (some resources like systemd_unit create multiple)
     for (tmp_resources.items) |res| {
+        // Ownership of each temporary resource is transferred either to the
+        // runner or to this error path; the temporary list only owns its buffer.
+        const wrapped = wrap(res);
+
         // Build ResourceId
-        const id = build_id(allocator, &res) catch return mruby.mrb_nil_value();
+        const id = build_id(allocator, &res) catch {
+            wrapped.deinit(allocator);
+            return mruby.mrb_nil_value();
+        };
 
         // Copy notifications from common props into metadata
         const common_ref = get_common_props(&res);
-        const notifications = cloneNotificationsFromCommon(allocator, common_ref) catch return mruby.mrb_nil_value();
-
-        // Wrap into unified Resource enum
-        const res_with_meta = resources.ResourceWithMetadata{
-            .resource = wrap(res),
-            .id = id,
-            .notifications = notifications,
+        var notifications = cloneNotificationsFromCommon(allocator, common_ref) catch {
+            id.deinit(allocator);
+            wrapped.deinit(allocator);
+            return mruby.mrb_nil_value();
         };
 
-        runner.resources.append(allocator, res_with_meta) catch return mruby.mrb_nil_value();
+        const display_path = cloneCurrentDisplayPath(runner) catch {
+            deinitNotifications(allocator, &notifications);
+            id.deinit(allocator);
+            wrapped.deinit(allocator);
+            return mruby.mrb_nil_value();
+        };
+
+        // Wrap into unified Resource enum
+        var res_with_meta = resources.ResourceWithMetadata{
+            .resource = wrapped,
+            .id = id,
+            .notifications = notifications,
+            .display_depth = currentDisplayDepth(runner),
+            .display_path = display_path,
+        };
+
+        runner.resources.append(allocator, res_with_meta) catch {
+            res_with_meta.deinit(allocator);
+            return mruby.mrb_nil_value();
+        };
     }
 
     return result;
@@ -1188,7 +1323,7 @@ export fn zig_converge(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callc
     mruby.zig_mrb_gc_arena_restore(mrb, arena_index);
 
     if (converge_error) |err| {
-        const detail = base.getProvisionErrorDetail() orelse @errorName(err);
+        const detail = base.getProvisionErrorDetail() orelse base.userFacingError(err);
         if (runner.last_failed_index) |index| {
             if (index < runner.resources.items.len) {
                 const id = runner.resources.items[index].id;
@@ -1209,9 +1344,26 @@ export fn zig_flush_delayed(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) 
     const runner = currentRunnerOrNilValue() orelse return statusPair(mrb, false, "provision runner is not initialized");
     if (runner.display == null) return statusPair(mrb, false, "provision display is not attached");
     runner.flushDelayed() catch |err| {
-        return statusPair(mrb, false, base.getProvisionErrorDetail() orelse @errorName(err));
+        return statusPair(mrb, false, base.getProvisionErrorDetail() orelse base.userFacingError(err));
     };
     return statusPair(mrb, true, null);
+}
+
+export fn zig_failure_checkpoint(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    const runner = currentRunnerOrNilValue() orelse return mruby.mrb_int_value(mrb, 0);
+    const display = runner.display orelse return mruby.mrb_int_value(mrb, 0);
+    return mruby.mrb_int_value(mrb, @intCast(display.failureCheckpoint()));
+}
+
+export fn zig_handle_failures_since(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    var checkpoint: mruby.mrb_int = 0;
+    if (mruby.mrb_get_args(mrb, "i", &checkpoint) != 1) return mruby.mrb_nil_value();
+    const runner = currentRunnerOrNilValue() orelse return mruby.mrb_nil_value();
+    const display = runner.display orelse return mruby.mrb_nil_value();
+    display.handleFailuresSince(@intCast(@max(checkpoint, 0)));
+    return mruby.mrb_nil_value();
 }
 
 export fn zig_display_section(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
@@ -1237,6 +1389,47 @@ export fn zig_print_line(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) cal
     const display = runner.display orelse return statusPair(mrb, false, "provision display is not attached");
     const line = std.mem.span(mruby.mrb_str_to_cstr(mrb, text_value));
     display.printLine(line) catch |err| return statusPair(mrb, false, @errorName(err));
+    return statusPair(mrb, true, null);
+}
+
+export fn zig_begin_resource_scope(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    var type_value: mruby.mrb_value = undefined;
+    var name_value: mruby.mrb_value = undefined;
+    var action_value: mruby.mrb_value = undefined;
+    if (mruby.mrb_get_args(mrb, "SSS", &type_value, &name_value, &action_value) != 3) {
+        return statusPair(mrb, false, "begin_resource_scope expects type, name, and action");
+    }
+    const runner = currentRunnerOrNilValue() orelse return statusPair(mrb, false, "provision runner is not initialized");
+    const allocator = runner.allocator;
+    const type_name = allocator.dupe(u8, std.mem.span(mruby.mrb_str_to_cstr(mrb, type_value))) catch return statusPair(mrb, false, "out of memory");
+    const name = allocator.dupe(u8, std.mem.span(mruby.mrb_str_to_cstr(mrb, name_value))) catch {
+        allocator.free(type_name);
+        return statusPair(mrb, false, "out of memory");
+    };
+    const action = allocator.dupe(u8, std.mem.span(mruby.mrb_str_to_cstr(mrb, action_value))) catch {
+        allocator.free(type_name);
+        allocator.free(name);
+        return statusPair(mrb, false, "out of memory");
+    };
+    runner.declaration_display_path.append(allocator, .{
+        .type_name = type_name,
+        .name = name,
+        .action = action,
+    }) catch {
+        allocator.free(type_name);
+        allocator.free(name);
+        allocator.free(action);
+        return statusPair(mrb, false, "out of memory");
+    };
+    return statusPair(mrb, true, null);
+}
+
+export fn zig_end_resource_scope(mrb: *mruby.mrb_state, self_value: mruby.mrb_value) callconv(.c) mruby.mrb_value {
+    _ = self_value;
+    const runner = currentRunnerOrNilValue() orelse return statusPair(mrb, false, "provision runner is not initialized");
+    if (runner.declaration_display_path.items.len == 0) return statusPair(mrb, false, "resource scope stack is empty");
+    if (runner.declaration_display_path.pop()) |scope| scope.deinit(runner.allocator);
     return statusPair(mrb, true, null);
 }
 
@@ -1285,8 +1478,12 @@ fn registerResourceBindings(mrb_ptr: *mruby.mrb_state, zig_module: *mruby.RClass
     const bindings = [_]ResourceBinding{
         .{ .name = "converge", .handler = zig_converge, .args_spec = mruby.MRB_ARGS_NONE() },
         .{ .name = "flush_delayed", .handler = zig_flush_delayed, .args_spec = mruby.MRB_ARGS_NONE() },
+        .{ .name = "failure_checkpoint", .handler = zig_failure_checkpoint, .args_spec = mruby.MRB_ARGS_NONE() },
+        .{ .name = "handle_failures_since", .handler = zig_handle_failures_since, .args_spec = mruby.MRB_ARGS_REQ(1) },
         .{ .name = "display_section", .handler = zig_display_section, .args_spec = mruby.MRB_ARGS_REQ(1) },
         .{ .name = "print_line", .handler = zig_print_line, .args_spec = mruby.MRB_ARGS_REQ(1) },
+        .{ .name = "begin_resource_scope", .handler = zig_begin_resource_scope, .args_spec = mruby.MRB_ARGS_REQ(3) },
+        .{ .name = "end_resource_scope", .handler = zig_end_resource_scope, .args_spec = mruby.MRB_ARGS_NONE() },
         .{ .name = "glob", .handler = zig_glob, .args_spec = mruby.MRB_ARGS_REQ(1) },
         .{ .name = "load_file", .handler = zig_load_file, .args_spec = mruby.MRB_ARGS_REQ(1) },
         .{ .name = "add_file", .handler = zig_add_file_resource, .args_spec = mruby.MRB_ARGS_REQ(6) | mruby.MRB_ARGS_OPT(5) },
@@ -1389,14 +1586,14 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     runner.start_time = std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds();
 
     // Initialize modern display with the specified output mode
-    var display = try modern_display.ModernProvisionDisplay.init(allocator, opts.use_pretty_output);
+    var display = try modern_display.ModernProvisionDisplay.init(allocator, opts.output_mode);
     defer display.deinit();
 
     runner.attachDisplay(&display);
     defer runner.detachDisplay();
 
     // Show section header
-    try display.showSection("Applying Configuration");
+    try display.showSection("Applying configuration");
 
     // Set total number of resources for progress display
     display.setTotalResources(runner.resources.items.len);
@@ -1548,9 +1745,9 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
         }
     }
 
-    if (download_mgr.tasks.items.len > 0) {
-        // Show download section header
-        try display.showSectionWithLevel("Downloading Remote Files", 3);
+    const has_downloads = download_mgr.tasks.items.len > 0;
+    if (has_downloads) {
+        try display.showSectionWithLevel("Downloads", 3);
 
         const download_names = try allocator.alloc([]const u8, download_mgr.tasks.items.len);
         defer allocator.free(download_names);
@@ -1563,7 +1760,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     // Start background download processing if we have tasks
     var download_thread: ?std.Thread = null;
     defer if (download_thread) |thread| thread.join();
-    if (download_mgr.tasks.items.len > 0) {
+    if (has_downloads) {
         const DownloadThread = struct {
             fn run(mgr: *http.download.Manager) void {
                 mgr.processAll() catch |err| {
@@ -1576,8 +1773,11 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     runner.download_mgr = &download_mgr;
     defer runner.download_mgr = null;
 
-    // Start resource execution phase
-    try display.showSectionWithLevel("Executing Resources", 3);
+    // With downloads present, name both phases. For the common resources-only
+    // path, the primary heading already provides enough context.
+    if (has_downloads) {
+        try display.showSectionWithLevel("Resources", 3);
+    }
 
     // Start the real-time timer spinner (after all download spinners are created)
     try display.startTimer(runner.start_time);
@@ -1653,6 +1853,70 @@ test "Session.open exposes every resource through Hola::Resources" {
     try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(global_io.io(), target, .{}));
 }
 
+test "composite resources preserve their virtual parent display path" {
+    const allocator = std.testing.allocator;
+    json.setAllocator(allocator);
+    const session = try Session.open(allocator, .{});
+    defer session.close();
+
+    try session.evalString("apt_update('package metadata') { action :update }");
+    try std.testing.expectEqual(@as(usize, 1), session.runner.resources.items.len);
+    const child = session.runner.resources.items[0];
+    try std.testing.expectEqual(@as(usize, 1), child.display_depth);
+    try std.testing.expectEqual(@as(usize, 1), child.display_path.len);
+    try std.testing.expectEqualStrings("apt_update", child.display_path[0].type_name);
+    try std.testing.expectEqualStrings("package metadata", child.display_path[0].name);
+    try std.testing.expectEqualStrings("update", child.display_path[0].action);
+}
+
+test "composite resource display scope unwinds after a Ruby exception" {
+    const allocator = std.testing.allocator;
+    json.setAllocator(allocator);
+    const session = try Session.open(allocator, .{});
+    defer session.close();
+
+    try session.evalString(
+        \\begin
+        \\  Hola::Resources.with_resource_scope('outer', 'failing') { raise 'boom' }
+        \\rescue RuntimeError
+        \\end
+        \\Hola::Resources.execute('sibling') { action :nothing }
+    );
+
+    try std.testing.expectEqual(@as(usize, 0), session.runner.declaration_display_path.items.len);
+    try std.testing.expectEqual(@as(usize, 1), session.runner.resources.items.len);
+    const sibling = session.runner.resources.items[0];
+    try std.testing.expectEqual(@as(usize, 0), sibling.display_depth);
+    try std.testing.expectEqual(@as(usize, 0), sibling.display_path.len);
+}
+
+test "resources declared while applying inherit the parent display depth" {
+    const allocator = std.testing.allocator;
+    json.setAllocator(allocator);
+    const session = try Session.open(allocator, .{});
+    defer session.close();
+    try session.evalString(
+        \\ruby_block 'parent' do
+        \\  block do
+        \\    Hola::Resources.execute 'child' do
+        \\      command 'exit 99'
+        \\      action :nothing
+        \\    end
+        \\  end
+        \\end
+    );
+
+    var display = try modern_display.ModernProvisionDisplay.init(allocator, .normal);
+    defer display.deinit();
+    session.runner.attachDisplay(&display);
+    defer session.runner.detachDisplay();
+    try session.runner.convergeFrom(0);
+
+    try std.testing.expectEqual(@as(usize, 2), session.runner.resources.items.len);
+    try std.testing.expectEqual(@as(usize, 0), session.runner.resources.items[0].display_depth);
+    try std.testing.expectEqual(@as(usize, 1), session.runner.resources.items[1].display_depth);
+}
+
 test "convergeFrom applies and records results once" {
     const allocator = std.testing.allocator;
     json.setAllocator(allocator);
@@ -1670,7 +1934,7 @@ test "convergeFrom applies and records results once" {
     defer allocator.free(script);
     try session.evalString(script);
 
-    var display = try modern_display.ModernProvisionDisplay.init(allocator, false);
+    var display = try modern_display.ModernProvisionDisplay.init(allocator, .normal);
     defer display.deinit();
     session.runner.attachDisplay(&display);
     defer session.runner.detachDisplay();
@@ -1694,6 +1958,8 @@ test "task prelude supports common Rake task semantics" {
         \\module ZigBackend
         \\  def self.converge; [true, nil]; end
         \\  def self.flush_delayed; [true, nil]; end
+        \\  def self.failure_checkpoint; 0; end
+        \\  def self.handle_failures_since(checkpoint); nil; end
         \\  def self.display_section(name); ($sections ||= []) << name; [true, nil]; end
         \\end
         \\module ENV
@@ -1801,6 +2067,8 @@ test "task prelude immediate wrapper converges resource declarations" {
         \\module ZigBackend
         \\  def self.converge; $converge_calls += 1; [true, nil]; end
         \\  def self.flush_delayed; [true, nil]; end
+        \\  def self.failure_checkpoint; 0; end
+        \\  def self.handle_failures_since(checkpoint); nil; end
         \\  def self.display_section(name); [true, nil]; end
         \\end
         \\def execute(name, &block); name; end
@@ -1819,7 +2087,7 @@ test "task command-line assignments use the environment bridge" {
     defer session.close();
     defer session.evalString("ENV.delete('HOLA_TASK_TEST_ENV')") catch {};
 
-    var display = try modern_display.ModernProvisionDisplay.init(allocator, false);
+    var display = try modern_display.ModernProvisionDisplay.init(allocator, .normal);
     defer display.deinit();
     session.runner.attachDisplay(&display);
     defer session.runner.detachDisplay();
@@ -1845,13 +2113,50 @@ test "task command-line assignments use the environment bridge" {
     try std.testing.expectEqual(@as(usize, 0), session.runner.resources.items.len);
 }
 
+test "task prelude treats rescued resource failures as handled" {
+    const allocator = std.testing.allocator;
+    json.setAllocator(allocator);
+    const session = try Session.open(allocator, .{ .mode = .task });
+    defer session.close();
+
+    var display = try modern_display.ModernProvisionDisplay.init(allocator, .normal);
+    defer display.deinit();
+    session.runner.attachDisplay(&display);
+    defer session.runner.detachDisplay();
+    session.runner.start_time = std.Io.Timestamp.now(global_io.io(), .real).toNanoseconds();
+    try display.startTimer(session.runner.start_time);
+
+    try session.loadTaskPrelude();
+    try session.evalString(
+        \\task :rescued do
+        \\  begin
+        \\    sh 'exit 7'
+        \\  rescue Hola::ResourceError => error
+        \\    $rescued_message = error.message
+        \\  end
+        \\end
+        \\$hola_run_argv = ['rescued']
+        \\Hola::Rake.main
+    );
+
+    const status = session.mrb.getGlobal("$hola_run_status");
+    const message = session.mrb.getGlobal("$rescued_message");
+    try std.testing.expectEqual(@as(mruby.mrb_int, 0), mruby.mrb_fixnum(session.mrb.mrb.?, status));
+    try std.testing.expectEqualStrings(
+        "execute[exit 7]: command exited with status 7",
+        std.mem.span(mruby.mrb_str_to_cstr(session.mrb.mrb.?, message)),
+    );
+    try std.testing.expectEqual(@as(usize, 0), display.failed_count);
+    try std.testing.expectEqual(@as(usize, 1), display.handled_failure_count);
+}
+
 test "protected ruby_block failure returns a converge status and session remains usable" {
     const allocator = std.testing.allocator;
     json.setAllocator(allocator);
     const session = try Session.open(allocator, .{});
     defer session.close();
 
-    var display = try modern_display.ModernProvisionDisplay.init(allocator, false);
+    var display = try modern_display.ModernProvisionDisplay.init(allocator, .normal);
     defer display.deinit();
     session.runner.attachDisplay(&display);
     defer session.runner.detachDisplay();

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -483,15 +483,18 @@ pub const Session = struct {
         try self.mrb.evalString(resources.file_edit.ruby_prelude);
         try self.mrb.evalString(resources.extract.ruby_prelude);
         try self.mrb.evalString(@embedFile("resources/apt_update_resource.rb"));
+        try self.mrb.evalString(@embedFile("ruby_prelude/resources.rb"));
 
-        // `file` and `directory` are standard Rake task constructors. Keep the
-        // provision resource classes available for the explicit
-        // Hola::Resources namespace, but remove their top-level methods before
-        // a task file is evaluated.
+        // A Holafile reserves top-level methods for the task DSL. Provision
+        // scripts retain the legacy top-level resource methods, while both
+        // modes can use the explicit Hola::Resources namespace.
         if (opts.mode == .task) {
             try self.mrb.evalString(
-                \\Object.send(:remove_method, :file)
-                \\Object.send(:remove_method, :directory)
+                \\Hola::Resources::DSL_METHODS.each do |name|
+                \\  method_name = name.to_sym
+                \\  available = Object.private_instance_methods.include?(method_name) || Object.instance_methods.include?(method_name)
+                \\  Object.send(:remove_method, method_name) if available
+                \\end
             );
         }
 
@@ -1613,7 +1616,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     };
 }
 
-test "Session.open collects resources without applying" {
+test "Session.open exposes every resource through Hola::Resources" {
     const allocator = std.testing.allocator;
     json.setAllocator(allocator);
 
@@ -1626,7 +1629,22 @@ test "Session.open collects resources without applying" {
 
     const session = try Session.open(allocator, .{});
     defer session.close();
-    const script = try std.fmt.allocPrint(allocator, "file '{s}' do\n  content 'x'\nend", .{target});
+    try session.evalString(
+        \\$expected_resources = %w[
+        \\  file directory execute remote_file template link route
+        \\  macos_dock macos_defaults apt_repository systemd_unit mount
+        \\  package homebrew_package apt_package ruby_block git user group
+        \\  aws_kms file_edit extract apt_update
+        \\]
+        \\$resource_namespace_complete = $expected_resources.all? { |name| Hola::Resources.respond_to?(name.to_sym) }
+        \\$top_level_resource_compat = Object.private_instance_methods.include?(:execute)
+    );
+    const namespace_complete = session.mrb.getGlobal("$resource_namespace_complete");
+    const top_level_compat = session.mrb.getGlobal("$top_level_resource_compat");
+    try std.testing.expect(mruby.mrb_test(namespace_complete));
+    try std.testing.expect(mruby.mrb_test(top_level_compat));
+
+    const script = try std.fmt.allocPrint(allocator, "Hola::Resources.file '{s}' do\n  content 'x'\nend", .{target});
     defer allocator.free(script);
     try session.evalString(script);
 
@@ -1682,6 +1700,11 @@ test "task prelude supports common Rake task semantics" {
         \\  @values = {}
         \\  def self.[](key); @values[key]; end
         \\  def self.[]=(key, value); @values[key] = value; end
+        \\end
+        \\module Hola
+        \\  module Resources
+        \\    DSL_METHODS = []
+        \\  end
         \\end
     );
     try mrb_state.evalString(@embedFile("ruby_prelude/tasks.rb"));
@@ -1748,6 +1771,8 @@ test "task prelude supports common Rake task semantics" {
         \\$parse_test_result = ($parse_result == [['a', []], ['a', []], ['a', ['1', '2']], ['ns:a', ['x']]])
         \\$tasklib_result = Rake::Task.task_defined?(:from_tasklib) && Rake::Task.task_defined?(:clean) && Rake::Task.task_defined?(:clobber)
         \\$file_dsl_result = Rake::Task[:'standard-file-task'].is_a?(Rake::FileTask) && Rake::Task[:'legacy-file-task'].is_a?(Rake::FileTask) && Rake::Task[:'standard-directory-task'].is_a?(Rake::FileTask)
+        \\$resource_gateway_result = (resources == Hola::Resources)
+        \\resources { $resource_gateway_result = $resource_gateway_result && (self == Hola::Resources) }
     );
 
     const result_names = [_][*:0]const u8{
@@ -1758,6 +1783,7 @@ test "task prelude supports common Rake task semantics" {
         "$parse_test_result",
         "$tasklib_result",
         "$file_dsl_result",
+        "$resource_gateway_result",
     };
     for (result_names) |name| {
         const result = mruby.mrb_gv_get(mrb_ptr, mruby.mrb_intern_cstr(mrb_ptr, name));
@@ -1779,8 +1805,9 @@ test "task prelude immediate wrapper converges resource declarations" {
         \\end
         \\def execute(name, &block); name; end
     );
+    try mrb_state.evalString(@embedFile("ruby_prelude/resources.rb"));
     try mrb_state.evalString(@embedFile("ruby_prelude/tasks.rb"));
-    try mrb_state.evalString("$hola_run_immediate = true; execute('command'); $immediate_result = ($converge_calls == 1)");
+    try mrb_state.evalString("$hola_run_immediate = true; resources.execute('command'); $immediate_result = ($converge_calls == 1)");
     const result = mruby.mrb_gv_get(mrb_ptr, mruby.mrb_intern_cstr(mrb_ptr, "$immediate_result"));
     try std.testing.expect(mruby.mrb_test(result));
 }
@@ -1806,9 +1833,15 @@ test "task command-line assignments use the environment bridge" {
         \\$hola_run_argv = ['HOLA_TASK_TEST_ENV=present', 'check_env']
         \\Hola::Rake.main
         \\$env_bridge_result = ($hola_run_status == 0 && $env_seen == 'present')
+        \\$resource_boundary_result = Hola::Resources.respond_to?(:execute) &&
+        \\  !Object.private_instance_methods.include?(:execute) &&
+        \\  !Object.instance_methods.include?(:execute) &&
+        \\  resources == Hola::Resources
     );
     const result = session.mrb.getGlobal("$env_bridge_result");
+    const boundary_result = session.mrb.getGlobal("$resource_boundary_result");
     try std.testing.expect(mruby.mrb_test(result));
+    try std.testing.expect(mruby.mrb_test(boundary_result));
     try std.testing.expectEqual(@as(usize, 0), session.runner.resources.items.len);
 }
 

--- a/src/resources.zig
+++ b/src/resources.zig
@@ -87,12 +87,30 @@ pub const ResourceId = notification.ResourceId;
 pub const NotificationTiming = notification.Timing;
 pub const ApplyResult = base.ApplyResult;
 
+/// A virtual parent shown by the normal execution formatter for resources
+/// implemented as a composition of other resources (for example apt_update
+/// wrapping execute). Consecutive children sharing a path render the parent
+/// once and remain indented beneath it.
+pub const DisplayScope = struct {
+    type_name: []const u8,
+    name: []const u8,
+    action: []const u8,
+
+    pub fn deinit(self: DisplayScope, allocator: std.mem.Allocator) void {
+        allocator.free(self.type_name);
+        allocator.free(self.name);
+        allocator.free(self.action);
+    }
+};
+
 /// Wrapper for a resource with metadata
 pub const ResourceWithMetadata = struct {
     resource: Resource,
     id: ResourceId,
     notifications: std.ArrayList(Notification),
     was_updated: bool = false, // Track if resource was changed
+    display_depth: usize = 0,
+    display_path: []DisplayScope = &.{},
 
     pub fn deinit(self: *ResourceWithMetadata, allocator: std.mem.Allocator) void {
         self.resource.deinit(allocator);
@@ -101,6 +119,8 @@ pub const ResourceWithMetadata = struct {
             notif.deinit(allocator);
         }
         self.notifications.deinit(allocator);
+        for (self.display_path) |scope| scope.deinit(allocator);
+        if (self.display_path.len > 0) allocator.free(self.display_path);
     }
 };
 
@@ -185,6 +205,31 @@ fn payloadShouldIgnoreFailure(payload: anytype) bool {
     @compileError("Unsupported resource payload for shouldIgnoreFailure");
 }
 
+fn payloadActionName(payload: anytype) []const u8 {
+    const Payload = @TypeOf(payload);
+
+    if (Payload == package.Resource) {
+        if (builtin.os.tag == .macos) {
+            return switch (payload.backend) {
+                .homebrew => |backend| @tagName(backend.action),
+            };
+        } else if (builtin.os.tag == .linux) {
+            return switch (payload.backend) {
+                .apt => |backend| @tagName(backend.action),
+            };
+        }
+        return "apply";
+    }
+    if (@hasField(Payload, "action")) return @tagName(payload.action);
+    return "apply";
+}
+
+fn payloadCommand(payload: anytype) ?[]const u8 {
+    const Payload = @TypeOf(payload);
+    if (Payload == execute.Resource) return payload.command;
+    return null;
+}
+
 fn resourceName(resource: anytype) []const u8 {
     return switch (resource) {
         inline else => |res| payloadName(res),
@@ -200,6 +245,18 @@ fn resourceCommonProps(resource: anytype) *base.CommonProps {
 fn resourceShouldIgnoreFailure(resource: anytype) bool {
     return switch (resource) {
         inline else => |res| payloadShouldIgnoreFailure(res),
+    };
+}
+
+fn resourceActionName(resource: anytype) []const u8 {
+    return switch (resource) {
+        inline else => |res| payloadActionName(res),
+    };
+}
+
+fn resourceCommand(resource: anytype) ?[]const u8 {
+    return switch (resource) {
+        inline else => |res| payloadCommand(res),
     };
 }
 
@@ -242,6 +299,14 @@ const ResourceMacOs = union(enum) {
     pub fn shouldIgnoreFailure(self: ResourceMacOs) bool {
         return resourceShouldIgnoreFailure(self);
     }
+
+    pub fn getActionName(self: ResourceMacOs) []const u8 {
+        return resourceActionName(self);
+    }
+
+    pub fn getCommand(self: ResourceMacOs) ?[]const u8 {
+        return resourceCommand(self);
+    }
 };
 
 const ResourceGeneric = union(enum) {
@@ -283,5 +348,13 @@ const ResourceGeneric = union(enum) {
 
     pub fn shouldIgnoreFailure(self: ResourceGeneric) bool {
         return resourceShouldIgnoreFailure(self);
+    }
+
+    pub fn getActionName(self: ResourceGeneric) []const u8 {
+        return resourceActionName(self);
+    }
+
+    pub fn getCommand(self: ResourceGeneric) ?[]const u8 {
+        return resourceCommand(self);
     }
 };

--- a/src/resources.zig
+++ b/src/resources.zig
@@ -108,6 +108,9 @@ pub const ResourceWithMetadata = struct {
     resource: Resource,
     id: ResourceId,
     notifications: std.ArrayList(Notification),
+    phase: ?[]const u8 = null,
+    converged: bool = false,
+    subscriptions_resolved: bool = false,
     was_updated: bool = false, // Track if resource was changed
     display_depth: usize = 0,
     display_path: []DisplayScope = &.{},
@@ -119,6 +122,7 @@ pub const ResourceWithMetadata = struct {
             notif.deinit(allocator);
         }
         self.notifications.deinit(allocator);
+        if (self.phase) |phase| allocator.free(phase);
         for (self.display_path) |scope| scope.deinit(allocator);
         if (self.display_path.len > 0) allocator.free(self.display_path);
     }

--- a/src/resources/apt_package.zig
+++ b/src/resources/apt_package.zig
@@ -328,6 +328,7 @@ fn runCommand(allocator: std.mem.Allocator, cmd: []const u8, action: common.Acti
                 if (stderr.len > 0) {
                     logger.err("[apt_package] error: {s}", .{stderr});
                 }
+                base.recordCommandFailure(term, stderr);
                 // Map action to corresponding error type
                 return switch (action) {
                     .install => common.PackageError.InstallFailed,
@@ -341,12 +342,14 @@ fn runCommand(allocator: std.mem.Allocator, cmd: []const u8, action: common.Acti
             const pkg_list = std.mem.join(allocator, ", ", packages) catch "unknown";
             defer if (pkg_list.ptr != "unknown".ptr) allocator.free(pkg_list);
             logger.err("[apt_package] command killed by signal {d} for package(s): {s}", .{ @intFromEnum(sig), pkg_list });
+            base.recordCommandFailure(term, stderr);
             return common.PackageError.CommandFailed;
         },
         else => {
             const pkg_list = std.mem.join(allocator, ", ", packages) catch "unknown";
             defer if (pkg_list.ptr != "unknown".ptr) allocator.free(pkg_list);
             logger.err("[apt_package] command failed with unknown status for package(s): {s}", .{pkg_list});
+            base.recordCommandFailure(term, stderr);
             return common.PackageError.CommandFailed;
         },
     }

--- a/src/resources/apt_update_resource.rb
+++ b/src/resources/apt_update_resource.rb
@@ -12,12 +12,15 @@ class AptUpdateResource
 
     instance_eval(&block) if block
 
-    # Execute the actual logic based on action
-    case @action
-    when :periodic
-      apply_periodic
-    when :update
-      apply_update
+    Hola::Resources.with_resource_scope("apt_update", @name, @action) do
+      # apt_update is a composite resource. Children keep this parent in their
+      # display path so normal output mirrors Chef's nested custom resources.
+      case @action
+      when :periodic
+        apply_periodic
+      when :update
+        apply_update
+      end
     end
   end
 

--- a/src/resources/apt_update_resource.rb
+++ b/src/resources/apt_update_resource.rb
@@ -54,7 +54,7 @@ class AptUpdateResource
     command_str = "apt-get update && mkdir -p /var/lib/apt/periodic && touch /var/lib/apt/periodic/update-success-stamp"
     stamp_path = "/var/lib/apt/periodic/update-success-stamp"
 
-    execute @name do
+    Hola::Resources.execute @name do
       command command_str
       action "run"
 
@@ -85,7 +85,7 @@ class AptUpdateResource
     # Always update, no frequency check
     ignore_fail = @ignore_failure
 
-    execute @name do
+    Hola::Resources.execute @name do
       command "apt-get update"
       action "run"
       ignore_failure ignore_fail

--- a/src/resources/execute.zig
+++ b/src/resources/execute.zig
@@ -595,12 +595,21 @@ pub const Resource = struct {
             .sink = sink,
         };
 
-        const result = try AsyncExecutor.executeWithContext(
+        const result = AsyncExecutor.executeWithContext(
             ExecuteContext,
             ExecuteResult,
             ctx,
             executeCommand,
-        );
+        ) catch |err| {
+            if (err == error.CommandOutputTooLarge) {
+                base.recordProvisionErrorDetail("command output exceeded the {d} MiB capture limit", .{MAX_OUTPUT_BYTES / (1024 * 1024)});
+            } else if (self.cwd) |cwd| {
+                base.recordProvisionErrorDetail("could not execute command in {s}: {s}", .{ cwd, base.userFacingError(err) });
+            } else {
+                base.recordProvisionErrorDetail("could not execute command: {s}", .{base.userFacingError(err)});
+            }
+            return err;
+        };
         defer result.deinit();
 
         const term = result.term;
@@ -658,6 +667,7 @@ pub const Resource = struct {
 
         if (result.timed_out) {
             logger.err("[execute] command timed out after {d}s", .{self.timeout_s});
+            base.recordCommandTimeoutOutput(self.timeout_s, stdout, stderr);
             return error.CommandTimedOut;
         }
 
@@ -666,19 +676,23 @@ pub const Resource = struct {
             .exited => |code| {
                 if (code != 0) {
                     logger.err("[execute] command exited with code {d}", .{code});
+                    base.recordCommandFailureOutput(term, stdout, stderr);
                     return error.CommandFailed;
                 }
             },
             .signal => |sig| {
                 logger.err("[execute] command killed by signal {d}", .{@intFromEnum(sig)});
+                base.recordCommandFailureOutput(term, stdout, stderr);
                 return error.CommandKilled;
             },
             .stopped => |sig| {
                 logger.err("[execute] command stopped by signal {d}", .{@intFromEnum(sig)});
+                base.recordCommandFailureOutput(term, stdout, stderr);
                 return error.CommandStopped;
             },
             .unknown => |unknown_status| {
                 logger.err("[execute] command exited with unknown status {d}", .{unknown_status});
+                base.recordCommandFailureOutput(term, stdout, stderr);
                 return error.CommandFailed;
             },
         }
@@ -844,4 +858,38 @@ test "LineSplitter emits complete and trailing partial lines" {
     const second = try channel.take();
     defer allocator.free(second.bytes);
     try std.testing.expectEqualSlices(u8, &.{ 1, 'b', '\n' }, second.bytes);
+}
+
+test "execute failure records exit status and normalized stderr" {
+    base.clearProvisionErrorDetail();
+    defer base.clearProvisionErrorDetail();
+
+    var common = base.CommonProps.init(std.testing.allocator);
+    defer common.deinit(std.testing.allocator);
+    const resource = Resource{
+        .name = "diagnostic failure",
+        .command = "printf 'first line\\nsecond line\\n' >&2; exit 7",
+        .cwd = null,
+        .user = null,
+        .group = null,
+        .environment = null,
+        .live_stream = false,
+        .creates = null,
+        .timeout_s = DEFAULT_TIMEOUT_S,
+        .action = .run,
+        .common = common,
+    };
+
+    try std.testing.expectError(error.CommandFailed, resource.apply());
+    try std.testing.expectEqualStrings(
+        "command exited with status 7; stderr: first line second line",
+        base.getProvisionErrorDetail().?,
+    );
+    const diagnostic = base.getCommandDiagnostic() orelse return error.TestExpectedCommandDiagnostic;
+    switch (diagnostic.term.?) {
+        .exited => |code| try std.testing.expectEqual(@as(u8, 7), code),
+        else => return error.TestExpectedExitStatus,
+    }
+    try std.testing.expect(diagnostic.stdout == null);
+    try std.testing.expectEqualStrings("first line\nsecond line", diagnostic.stderr.?);
 }

--- a/src/resources/execute.zig
+++ b/src/resources/execute.zig
@@ -5,6 +5,7 @@ const ansi = @import("../ansi_constants.zig");
 const logger = @import("../logger.zig");
 const AsyncExecutor = @import("../async_executor.zig").AsyncExecutor;
 const global_io = @import("../global_io.zig");
+const output_channel = @import("../output_channel.zig");
 
 const DEFAULT_TIMEOUT_S: u32 = 3600;
 const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
@@ -14,6 +15,44 @@ const TERM_GRACE_MS: i64 = 2000;
 const PIPE_CLOSE_GRACE_MS: i64 = 5000;
 const POST_EXIT_PIPE_GRACE_MS: i64 = 1000;
 const REAP_GRACE_MS: i64 = 2000;
+
+pub const LineSplitter = struct {
+    allocator: std.mem.Allocator,
+    stream: output_channel.Stream,
+    sink: ?*output_channel.LineChannel,
+    partial: std.ArrayList(u8) = .empty,
+
+    pub fn init(allocator: std.mem.Allocator, stream: output_channel.Stream, sink: ?*output_channel.LineChannel) LineSplitter {
+        return .{ .allocator = allocator, .stream = stream, .sink = sink };
+    }
+
+    pub fn deinit(self: *LineSplitter) void {
+        self.partial.deinit(self.allocator);
+    }
+
+    pub fn feed(self: *LineSplitter, bytes: []const u8) !void {
+        if (self.sink == null) return;
+        for (bytes) |byte| {
+            if (byte == '\n') {
+                self.emit();
+            } else {
+                try self.partial.append(self.allocator, byte);
+            }
+        }
+    }
+
+    pub fn flush(self: *LineSplitter) void {
+        if (self.sink == null or self.partial.items.len == 0) return;
+        self.emit();
+    }
+
+    fn emit(self: *LineSplitter) void {
+        var line = self.partial.items;
+        if (line.len > 0 and line[line.len - 1] == '\r') line = line[0 .. line.len - 1];
+        self.sink.?.push(self.stream, line);
+        self.partial.clearRetainingCapacity();
+    }
+};
 
 /// Execute resource data structure
 pub const Resource = struct {
@@ -139,6 +178,7 @@ pub const Resource = struct {
         group: ?[]const u8,
         environment: ?[]const u8,
         timeout_s: u32,
+        sink: ?*output_channel.LineChannel,
     };
 
     fn termFromStatus(status: u32) std.process.Child.Term {
@@ -216,11 +256,13 @@ pub const Resource = struct {
         allocator: std.mem.Allocator,
         file: std.Io.File,
         output: *std.ArrayList(u8),
+        splitter: *LineSplitter,
     ) !bool {
         var buf: [READ_BUFFER_SIZE]u8 = undefined;
         const n = try std.posix.read(file.handle, &buf);
         if (n == 0) return false;
         try appendOutputBounded(allocator, output, buf[0..n]);
+        try splitter.feed(buf[0..n]);
         return true;
     }
 
@@ -229,6 +271,7 @@ pub const Resource = struct {
         pipe: *?std.Io.File,
         output: *std.ArrayList(u8),
         is_open: *bool,
+        splitter: *LineSplitter,
     ) !void {
         if (!is_open.*) return;
         const file = pipe.* orelse {
@@ -236,7 +279,7 @@ pub const Resource = struct {
             return;
         };
 
-        const still_open = try drainPipe(allocator, file, output);
+        const still_open = try drainPipe(allocator, file, output, splitter);
         if (!still_open) {
             closePipe(pipe);
             is_open.* = false;
@@ -262,6 +305,7 @@ pub const Resource = struct {
         child: *std.process.Child,
         allocator: std.mem.Allocator,
         timeout_s: u32,
+        sink: ?*output_channel.LineChannel,
     ) !ExecuteResult {
         const io = global_io.io();
 
@@ -269,6 +313,10 @@ pub const Resource = struct {
         defer stdout.deinit(allocator);
         var stderr = std.ArrayList(u8).empty;
         defer stderr.deinit(allocator);
+        var stdout_splitter = LineSplitter.init(allocator, .stdout, sink);
+        defer stdout_splitter.deinit();
+        var stderr_splitter = LineSplitter.init(allocator, .stderr, sink);
+        defer stderr_splitter.deinit();
 
         var stdout_open = child.stdout != null;
         var stderr_open = child.stderr != null;
@@ -381,14 +429,14 @@ pub const Resource = struct {
             if (ready == 0) continue;
 
             if (stdout_open and fds[0].revents != 0) {
-                drainReadyPipe(allocator, &child.stdout, &stdout, &stdout_open) catch |err| {
+                drainReadyPipe(allocator, &child.stdout, &stdout, &stdout_open, &stdout_splitter) catch |err| {
                     killAndReap(pid, &child_running);
                     closeChildPipes(child);
                     return err;
                 };
             }
             if (stderr_open and fds[1].revents != 0) {
-                drainReadyPipe(allocator, &child.stderr, &stderr, &stderr_open) catch |err| {
+                drainReadyPipe(allocator, &child.stderr, &stderr, &stderr_open, &stderr_splitter) catch |err| {
                     killAndReap(pid, &child_running);
                     closeChildPipes(child);
                     return err;
@@ -408,6 +456,8 @@ pub const Resource = struct {
         }
 
         closeChildPipes(child);
+        stdout_splitter.flush();
+        stderr_splitter.flush();
 
         const result_allocator = std.heap.page_allocator;
         return ExecuteResult{
@@ -432,7 +482,7 @@ pub const Resource = struct {
         // Note: env_map must live until child.wait() completes
         var env_map_storage: ?std.process.Environ.Map = null;
         defer if (env_map_storage) |*map| map.deinit();
-        var environ_map: ?*const std.process.Environ.Map = null;
+        var environ_map: ?*const std.process.Environ.Map = global_io.environMap();
 
         if (ctx.environment) |env_str| {
             // Parse environment string "KEY=VALUE\0KEY2=VALUE2\0" into a map.
@@ -525,7 +575,7 @@ pub const Resource = struct {
             .pgid = 0,
         });
 
-        return try collectOutputAndWait(&child, temp_allocator, ctx.timeout_s);
+        return try collectOutputAndWait(&child, temp_allocator, ctx.timeout_s, ctx.sink);
     }
 
     fn applyRun(self: Resource) !?[]const u8 {
@@ -534,6 +584,7 @@ pub const Resource = struct {
         const allocator = arena.allocator();
 
         // Execute command asynchronously to allow spinner to continue
+        const sink = if (self.live_stream) output_channel.getCurrent() else null;
         const ctx = ExecuteContext{
             .command = self.command,
             .cwd = self.cwd,
@@ -541,6 +592,7 @@ pub const Resource = struct {
             .group = self.group,
             .environment = self.environment,
             .timeout_s = self.timeout_s,
+            .sink = sink,
         };
 
         const result = try AsyncExecutor.executeWithContext(
@@ -592,7 +644,7 @@ pub const Resource = struct {
         }
 
         // Display command output only if live_stream is enabled
-        if (self.live_stream) {
+        if (self.live_stream and sink == null) {
             if (stdout.len > 0) {
                 showCommandOutput(stdout);
             }
@@ -774,4 +826,22 @@ pub fn zigAddResource(
     }) catch return mruby.mrb_nil_value();
 
     return mruby.mrb_nil_value();
+}
+
+test "LineSplitter emits complete and trailing partial lines" {
+    const allocator = std.testing.allocator;
+    var channel = output_channel.LineChannel.init(allocator);
+    defer channel.deinit();
+    var splitter = LineSplitter.init(allocator, .stdout, &channel);
+    defer splitter.deinit();
+
+    try splitter.feed("a\nb");
+    const first = try channel.take();
+    defer allocator.free(first.bytes);
+    try std.testing.expectEqualSlices(u8, &.{ 1, 'a', '\n' }, first.bytes);
+
+    splitter.flush();
+    const second = try channel.take();
+    defer allocator.free(second.bytes);
+    try std.testing.expectEqualSlices(u8, &.{ 1, 'b', '\n' }, second.bytes);
 }

--- a/src/resources/group.zig
+++ b/src/resources/group.zig
@@ -150,11 +150,15 @@ pub const Resource = struct {
                     if (result.stderr.len > 0) {
                         logger.err("stderr: {s}", .{result.stderr});
                     }
+                    base.recordCommandFailure(result.term, result.stderr);
                     return error.CommandFailed;
                 }
                 return true;
             },
-            else => return error.CommandFailed,
+            else => {
+                base.recordCommandFailure(result.term, result.stderr);
+                return error.CommandFailed;
+            },
         }
     }
 

--- a/src/resources/homebrew_package.zig
+++ b/src/resources/homebrew_package.zig
@@ -314,6 +314,7 @@ fn runCommand(allocator: std.mem.Allocator, cmd: []const u8, action: common.Acti
                 if (stderr.len > 0) {
                     logger.err("[homebrew_package] error: {s}", .{stderr});
                 }
+                base.recordCommandFailure(term, stderr);
                 // Map action to corresponding error type
                 return switch (action) {
                     .install => common.PackageError.InstallFailed,
@@ -327,12 +328,14 @@ fn runCommand(allocator: std.mem.Allocator, cmd: []const u8, action: common.Acti
             const pkg_list = std.mem.join(allocator, ", ", packages) catch "unknown";
             defer if (pkg_list.ptr != "unknown".ptr) allocator.free(pkg_list);
             logger.err("[homebrew_package] command killed by signal {d} for package(s): {s}", .{ @intFromEnum(sig), pkg_list });
+            base.recordCommandFailure(term, stderr);
             return common.PackageError.CommandFailed;
         },
         else => {
             const pkg_list = std.mem.join(allocator, ", ", packages) catch "unknown";
             defer if (pkg_list.ptr != "unknown".ptr) allocator.free(pkg_list);
             logger.err("[homebrew_package] command failed with unknown status for package(s): {s}", .{pkg_list});
+            base.recordCommandFailure(term, stderr);
             return common.PackageError.CommandFailed;
         },
     }

--- a/src/resources/mount.zig
+++ b/src/resources/mount.zig
@@ -423,10 +423,14 @@ fn runCommand(allocator: std.mem.Allocator, argv: []const []const u8) ![]const u
                 if (stderr.len > 0) {
                     logger.err("  stderr: {s}\n", .{stderr});
                 }
+                base.recordCommandFailure(result.term, stderr);
                 return error.CommandFailed;
             }
         },
-        else => return error.CommandFailed,
+        else => {
+            base.recordCommandFailure(result.term, stderr);
+            return error.CommandFailed;
+        },
     }
 
     return stdout;

--- a/src/resources/ruby_block.zig
+++ b/src/resources/ruby_block.zig
@@ -178,8 +178,6 @@ pub const Resource = struct {
                     // of the raw Zig error name.
                     base.recordProvisionException(mrb, exc, "ruby_block raised");
 
-                    // Also print to stderr for consistency
-                    mruby.zig_mrb_print_exc(mrb, exc);
                     return error.RubyBlockFailed;
                 },
             }

--- a/src/resources/ruby_block.zig
+++ b/src/resources/ruby_block.zig
@@ -5,8 +5,6 @@ const logger = @import("../logger.zig");
 
 // External helper for checking nil values and exceptions
 extern fn zig_mrb_nil_p(val: mruby.mrb_value) c_int;
-extern fn zig_mrb_has_exception(mrb: *mruby.mrb_state) c_int;
-
 /// Ruby block resource data structure
 pub const Resource = struct {
     // Resource-specific properties
@@ -164,35 +162,27 @@ pub const Resource = struct {
                 }
             }
 
-            // Call the Ruby proc using mrb_funcall
-            // Proc.call() in Ruby translates to funcall with "call" method
-            const call_sym = mruby.mrb_intern_cstr(mrb, "call");
-            const result = mruby.mrb_funcall_argv(mrb, proc, call_sym, 0, null);
+            switch (mruby.callProtected(mrb, proc, "call", &.{})) {
+                .ok => return true,
+                .raised => |exc| {
+                    const exc_str = mruby.mrb_inspect(mrb, exc);
+                    const err_msg_cstr = mruby.mrb_str_to_cstr(mrb, exc_str);
+                    const err_msg = std.mem.span(err_msg_cstr);
 
-            // Check if an exception occurred
-            if (zig_mrb_has_exception(mrb) != 0) {
-                // Get exception object and convert to string
-                const exc = mruby.mrb_get_exception(mrb);
-                const exc_str = mruby.mrb_inspect(mrb, exc);
-                const err_msg_cstr = mruby.mrb_str_to_cstr(mrb, exc_str);
-                const err_msg = std.mem.span(err_msg_cstr);
+                    // Log the error message
+                    logger.err("Ruby block execution failed: {s}", .{err_msg});
 
-                // Log the error message
-                logger.err("Ruby block execution failed: {s}", .{err_msg});
+                    // Capture a friendly "ruby_block raised: ClassName: message"
+                    // summary into the shared provision error-detail buffer so the
+                    // top-level apply loop / agent callback can surface it instead
+                    // of the raw Zig error name.
+                    base.recordProvisionException(mrb, exc, "ruby_block raised");
 
-                // Capture a friendly "ruby_block raised: ClassName: message"
-                // summary into the shared provision error-detail buffer so the
-                // top-level apply loop / agent callback can surface it instead
-                // of the raw Zig error name.
-                base.recordProvisionException(mrb, exc, "ruby_block raised");
-
-                // Also print to stderr for consistency
-                mruby.mrb_print_error(mrb);
-                return error.RubyBlockFailed;
+                    // Also print to stderr for consistency
+                    mruby.zig_mrb_print_exc(mrb, exc);
+                    return error.RubyBlockFailed;
+                },
             }
-
-            _ = result;
-            return true; // Block was executed
         }
         return false; // No block to execute
     }

--- a/src/resources/template.zig
+++ b/src/resources/template.zig
@@ -89,7 +89,10 @@ pub const Resource = struct {
 
     fn applyCreate(self: Resource) !bool {
         // Read template file
-        const template_content = try readTemplateFile(self.source);
+        const template_content = readTemplateFile(self.source) catch |err| {
+            base.recordProvisionErrorDetail("template source templates/{s}: {s}", .{ self.source, base.userFacingError(err) });
+            return err;
+        };
         defer std.heap.c_allocator.free(template_content);
 
         // Render template using mruby

--- a/src/resources/user.zig
+++ b/src/resources/user.zig
@@ -204,11 +204,15 @@ pub const Resource = struct {
                     if (result.stderr.len > 0) {
                         logger.err("stderr: {s}", .{result.stderr});
                     }
+                    base.recordCommandFailure(result.term, result.stderr);
                     return error.CommandFailed;
                 }
                 return true;
             },
-            else => return error.CommandFailed,
+            else => {
+                base.recordCommandFailure(result.term, result.stderr);
+                return error.CommandFailed;
+            },
         }
     }
 

--- a/src/ruby_prelude/resources.rb
+++ b/src/ruby_prelude/resources.rb
@@ -11,6 +11,18 @@ module Hola
     @receiver = Object.new
 
     class << self
+      # Give Ruby-only composite resources a stable parent row in normal output.
+      # Every resource declared inside the block inherits this display path.
+      def with_resource_scope(type, name, action = :run)
+        ok, message = ZigBackend.begin_resource_scope(type.to_s, name.to_s, action.to_s)
+        raise message unless ok
+        begin
+          yield
+        ensure
+          ZigBackend.end_resource_scope
+        end
+      end
+
       def register(method_name, original_name)
         resources_class = class << self; self; end
         resources_class.send(:define_method, method_name) do |*args, &block|

--- a/src/ruby_prelude/resources.rb
+++ b/src/ruby_prelude/resources.rb
@@ -47,4 +47,74 @@ module Hola
       DSL_METHODS << name
     end
   end
+
+  module Phases
+    @namespace = nil
+    @listener = nil
+
+    class << self
+      def current
+        ZigBackend.current_phase
+      end
+
+      def select(name)
+        value = name.to_s
+        raise ArgumentError, "phase name cannot be empty" if value.empty?
+        qualified = @namespace && !@namespace.empty? ? "#{@namespace}:#{value}" : value
+        set_raw(qualified)
+        @listener.call(qualified) if @listener
+        qualified
+      end
+
+      def restore(name)
+        set_raw(name)
+      end
+
+      def with_import(namespace = nil, listener = nil)
+        previous_current = current
+        previous_namespace = @namespace
+        previous_listener = @listener
+        prefix = []
+        prefix << previous_namespace if previous_namespace && !previous_namespace.empty?
+        prefix << namespace.to_s if namespace && !namespace.to_s.empty?
+        @namespace = prefix.join(":")
+        @listener = listener
+        set_raw(nil)
+        begin
+          yield
+        ensure
+          @namespace = previous_namespace
+          @listener = previous_listener
+          set_raw(previous_current)
+        end
+      end
+
+      private
+
+      def set_raw(name)
+        ok, message = name ? ZigBackend.select_phase(name.to_s) : ZigBackend.clear_phase
+        raise message unless ok
+      end
+    end
+  end
 end
+
+module Hola
+  module PhaseDSL
+    def phase(name, &block)
+      previous = Hola::Phases.current
+      selected = Hola::Phases.select(name)
+      return selected unless block
+      begin
+        block.call
+      ensure
+        Hola::Phases.restore(previous)
+      end
+      selected
+    end
+
+    private :phase
+  end
+end
+
+Object.send(:include, Hola::PhaseDSL)

--- a/src/ruby_prelude/resources.rb
+++ b/src/ruby_prelude/resources.rb
@@ -1,0 +1,38 @@
+module Hola
+  module Resources
+    CANDIDATE_METHODS = %w[
+      file directory execute remote_file template link route
+      macos_dock macos_defaults apt_repository systemd_unit mount
+      package homebrew_package apt_package ruby_block git user group
+      aws_kms file_edit extract apt_update
+    ]
+
+    DSL_METHODS = []
+    @receiver = Object.new
+
+    class << self
+      def register(method_name, original_name)
+        resources_class = class << self; self; end
+        resources_class.send(:define_method, method_name) do |*args, &block|
+          @receiver.send(original_name, *args, &block)
+        end
+      end
+
+      private :register
+    end
+
+    CANDIDATE_METHODS.each do |name|
+      method_name = name.to_sym
+      available = Object.private_instance_methods.include?(method_name) ||
+        Object.instance_methods.include?(method_name)
+      next unless available
+
+      original_name = ("hola_resource_" + name).to_sym
+      installed = Object.private_instance_methods.include?(original_name) ||
+        Object.instance_methods.include?(original_name)
+      Object.send(:alias_method, original_name, method_name) unless installed
+      register(method_name, original_name)
+      DSL_METHODS << name
+    end
+  end
+end

--- a/src/ruby_prelude/tasks.rb
+++ b/src/ruby_prelude/tasks.rb
@@ -138,7 +138,12 @@ module Hola
           return self
         end
         puts "** Execute #{@name}" if Hola::Rake.trace?
-        @actions.each { |action| action.call(self, args) }
+        @actions.each do |action|
+          failure_checkpoint = ZigBackend.failure_checkpoint
+          action.call(self, args)
+          Hola::Rake.converge!
+          ZigBackend.handle_failures_since(failure_checkpoint)
+        end
         Hola::Rake.converge!
         self
       end
@@ -541,6 +546,10 @@ module Hola
           application.run($hola_run_argv || [])
           flush_delayed!
           $hola_run_status = 0
+        rescue Hola::ResourceError => error
+          location = error.backtrace && error.backtrace[0]
+          puts(location ? "Task aborted at #{location}" : "Task aborted")
+          $hola_run_status = 1
         rescue Exception => error
           puts "hola aborted!"
           puts error.message

--- a/src/ruby_prelude/tasks.rb
+++ b/src/ruby_prelude/tasks.rb
@@ -1,0 +1,871 @@
+module Hola
+  class ResourceError < StandardError
+  end
+
+  class LoadError < ScriptError
+  end
+
+  module Rake
+    RESOURCE_DSL = %w[
+      execute remote_file template link route
+      macos_dock macos_defaults apt_repository systemd_unit mount
+      package homebrew_package apt_package ruby_block git user group
+      aws_kms file_edit extract apt_update
+    ]
+
+    class TaskArguments
+      attr_reader :names
+
+      def initialize(names, values)
+        @names = Array(names).map { |name| name.to_sym }
+        @values = Array(values)
+        @hash = {}
+        @names.each_with_index do |name, index|
+          @hash[name] = @values[index]
+        end
+      end
+
+      def [](key)
+        return @values[key] if key.is_a?(Integer)
+        @hash[key.to_sym]
+      end
+
+      def to_hash
+        @hash.dup
+      end
+
+      def with_defaults(defaults)
+        defaults.each do |key, value|
+          symbol = key.to_sym
+          @hash[symbol] = value unless @hash.key?(symbol) && !@hash[symbol].nil?
+        end
+        self
+      end
+
+      def extras
+        @values[@names.length..-1] || []
+      end
+
+      def new_scope(new_names)
+        names = Array(new_names).map { |name| name.to_sym }
+        values = names.map { |name| @hash[name] }
+        TaskArguments.new(names, values)
+      end
+
+      def method_missing(name, *args, &block)
+        return @hash[name] if args.empty? && block.nil? && @hash.key?(name)
+        super
+      end
+
+      def respond_to_missing?(name, include_private = false)
+        @hash.key?(name) || super
+      end
+    end
+
+    class Task
+      attr_reader :name, :prerequisites, :actions, :arg_names, :description, :scope
+      attr_accessor :source
+
+      def self.[](name)
+        Hola::Rake.application.lookup!(name.to_s, Hola::Rake.application.current_scope)
+      end
+
+      def self.tasks
+        Hola::Rake.application.tasks.values
+      end
+
+      def self.task_defined?(name)
+        !Hola::Rake.application.lookup(name.to_s, Hola::Rake.application.current_scope).nil?
+      end
+
+      def self.define_task(*definition, &block)
+        Hola::Rake.application.define_task(self, *definition, &block)
+      end
+
+      def self.clear
+        Hola::Rake.application.clear
+      end
+
+      def initialize(application, name, prerequisites = [], arg_names = [], description = nil, scope = [])
+        @application = application
+        @name = name.to_s
+        @prerequisites = []
+        @actions = []
+        @arg_names = Array(arg_names).map { |item| item.to_sym }
+        @description = description
+        @scope = Array(scope).dup
+        @already_invoked = false
+        @source = nil
+        enhance(prerequisites)
+      end
+
+      def enhance(dependencies = nil, &block)
+        Array(dependencies).flatten.each do |dependency|
+          value = dependency.to_s
+          @prerequisites << value unless @prerequisites.include?(value)
+        end
+        @actions << block if block
+        self
+      end
+
+      def add_description(description)
+        @description = description if description
+        self
+      end
+
+      def invoke(*values)
+        args = TaskArguments.new(@arg_names, values)
+        invoke_with_call_chain(args, [])
+      end
+
+      def invoke_with_call_chain(args, chain)
+        puts "** Invoke #{@name}" if Hola::Rake.trace?
+        if chain.include?(@name)
+          raise "Circular dependency detected: #{(chain + [@name]).join(' => ')}"
+        end
+        return self if @already_invoked
+
+        @already_invoked = true
+        next_chain = chain + [@name]
+        @prerequisites.each do |dependency|
+          task = @application.lookup!(dependency, @scope)
+          task.invoke_with_call_chain(args.new_scope(task.arg_names), next_chain)
+        end
+        execute(args) if needed?
+        self
+      end
+
+      def execute(args = nil)
+        args ||= TaskArguments.new(@arg_names, [])
+        Hola::Rake.begin_task(@name)
+        if Hola::Rake.dry_run?
+          puts "** Execute #{@name} (dry run)"
+          return self
+        end
+        puts "** Execute #{@name}" if Hola::Rake.trace?
+        @actions.each { |action| action.call(self, args) }
+        Hola::Rake.converge!
+        self
+      end
+
+      def reenable
+        @already_invoked = false
+        self
+      end
+
+      def already_invoked
+        @already_invoked
+      end
+
+      def needed?
+        true
+      end
+
+      def timestamp
+        Time.now
+      end
+
+      def clear
+        clear_prerequisites
+        clear_actions
+        self
+      end
+
+      def clear_actions
+        @actions.clear
+        self
+      end
+
+      def clear_prerequisites
+        @prerequisites.clear
+        self
+      end
+
+      def all_prerequisite_tasks
+        result = []
+        @prerequisites.each do |dependency|
+          task = @application.lookup!(dependency, @scope)
+          result << task unless result.include?(task)
+          task.all_prerequisite_tasks.each { |item| result << item unless result.include?(item) }
+        end
+        result
+      end
+
+      def investigation
+        "Task #{@name}: prerequisites=#{@prerequisites.inspect}, already_invoked=#{@already_invoked}"
+      end
+
+      def to_s
+        @name
+      end
+    end
+
+    class FileTask < Task
+      def needed?
+        return true unless File.exist?(@name)
+        own_timestamp = timestamp
+        @prerequisites.any? do |dependency|
+          task = @application.lookup!(dependency, @scope)
+          task.timestamp > own_timestamp
+        end
+      end
+
+      def timestamp
+        File.exist?(@name) ? File.mtime(@name) : Time.at(0)
+      end
+    end
+
+    class Application
+      attr_reader :tasks, :current_scope
+
+      def initialize
+        @tasks = {}
+        @current_scope = []
+        @last_description = nil
+        @rules = []
+        @rule_stack = []
+      end
+
+      def clear
+        @tasks.clear
+        @rules.clear
+        @last_description = nil
+      end
+
+      def [](name)
+        lookup!(name, @current_scope)
+      end
+
+      def task_defined?(name)
+        !lookup(name, @current_scope).nil?
+      end
+
+      def last_description=(description)
+        @last_description = description
+      end
+
+      def define_task(task_class, *definition, &block)
+        parsed = parse_definition(definition)
+        full_name = qualify(parsed[:name])
+        task = @tasks[full_name]
+        unless task
+          task = task_class.new(self, full_name, [], parsed[:arg_names], @last_description, @current_scope)
+          @tasks[full_name] = task
+        end
+        task.add_description(@last_description)
+        task.enhance(parsed[:dependencies], &block)
+        @last_description = nil
+        task
+      end
+
+      def define_rule(*definition, &block)
+        parsed = parse_rule(definition)
+        @rules << {
+          :target => parsed[:target],
+          :source => parsed[:source],
+          :dependencies => parsed[:dependencies],
+          :action => block,
+        }
+        nil
+      end
+
+      def in_namespace(name)
+        @current_scope << name.to_s
+        begin
+          yield
+        ensure
+          @current_scope.pop
+        end
+      end
+
+      def lookup(name, scope = @current_scope)
+        return name if name.is_a?(Task)
+        task_name = name.to_s
+        candidates = []
+
+        if task_name.start_with?("^")
+          candidates << task_name[1..-1]
+        elsif task_name.include?(":")
+          index = scope.length
+          while index > 0
+            candidates << (scope[0...index] + [task_name]).join(":")
+            index -= 1
+          end
+          candidates << task_name
+        else
+          index = scope.length
+          while index >= 0
+            prefix = scope[0...index]
+            candidates << (prefix + [task_name]).join(":")
+            index -= 1
+          end
+        end
+
+        candidates.each do |candidate|
+          return @tasks[candidate] if @tasks.key?(candidate)
+        end
+        nil
+      end
+
+      def lookup!(name, scope = @current_scope)
+        task = lookup(name, scope)
+        return task if task
+
+        task_name = name.to_s
+        return synthesize_file_task(task_name) if File.exist?(task_name)
+        task = synthesize_rule(task_name)
+        return task if task
+        raise "Don't know how to build task '#{task_name}'"
+      end
+
+      def parse_task_string(value)
+        text = value.to_s
+        open_index = text.index("[")
+        return [text, []] unless open_index
+        return [text, []] unless text.end_with?("]")
+
+        name = text[0...open_index]
+        body = text[(open_index + 1)...-1]
+        values = body.empty? ? [] : body.split(",").map { |item| item.strip }
+        [name, values]
+      end
+
+      def run(argv)
+        requested = []
+        Array(argv).each do |argument|
+          if environment_assignment?(argument)
+            separator = argument.index("=")
+            ENV[argument[0...separator]] = argument[(separator + 1)..-1]
+          else
+            requested << argument
+          end
+        end
+        requested = ["default"] if requested.empty?
+        requested.each do |task_string|
+          name, values = parse_task_string(task_string)
+          lookup!(name, @current_scope).invoke(*values)
+        end
+      end
+
+      def list_tasks
+        described = @tasks.values.select { |task| task.description && !task.description.empty? }
+        described.sort_by { |task| task.name }.each do |task|
+          signature = task.name
+          unless task.arg_names.empty?
+            signature += "[#{task.arg_names.join(',')}]"
+          end
+          padding = " " * [1, 28 - signature.length].max
+          puts "hola run #{signature}#{padding}# #{task.description}"
+        end
+      end
+
+      def list_prerequisites
+        @tasks.values.sort_by { |task| task.name }.each do |task|
+          puts "hola run #{task.name}"
+          task.prerequisites.each { |dependency| puts "    #{dependency}" }
+        end
+      end
+
+      private
+
+      def qualify(name)
+        (@current_scope + [name.to_s]).join(":")
+      end
+
+      def parse_definition(definition)
+        name = nil
+        arg_names = []
+        dependencies = []
+        first = definition[0]
+
+        if first.is_a?(Hash)
+          key, value = first.first
+          if key.is_a?(Array)
+            name = key[0]
+            arg_names = key[1] || []
+          else
+            name = key
+          end
+          dependencies = value
+        else
+          name = first
+          second = definition[1]
+          if second.is_a?(Hash)
+            key, value = second.first
+            arg_names = key if key.is_a?(Array)
+            dependencies = value
+          elsif second.is_a?(Array)
+            arg_names = second
+            dependencies = definition[2] || []
+          elsif second
+            dependencies = second
+          end
+        end
+
+        raise "Task name is required" if name.nil?
+        {
+          :name => name.to_s,
+          :arg_names => Array(arg_names),
+          :dependencies => Array(dependencies).flatten,
+        }
+      end
+
+      def parse_rule(definition)
+        first = definition[0]
+        raise "Rule definition must be a Hash" unless first.is_a?(Hash)
+        target, source_spec = first.first
+        sources = Array(source_spec)
+        source = sources.shift
+        raise "Rule source is required" if source.nil?
+        {
+          :target => target.to_s,
+          :source => source.to_s,
+          :dependencies => sources,
+        }
+      end
+
+      def synthesize_file_task(name)
+        @tasks[name] ||= FileTask.new(self, name, [], [], nil, [])
+      end
+
+      def synthesize_rule(name)
+        return nil if @rule_stack.include?(name)
+        @rule_stack << name
+        begin
+          @rules.reverse_each do |rule|
+            target_suffix = rule[:target]
+            next unless name.end_with?(target_suffix)
+            stem = name[0...(name.length - target_suffix.length)]
+            source = stem + rule[:source]
+            next unless File.exist?(source) || lookup(source, []) || matching_rule?(source)
+
+            dependencies = [source] + rule[:dependencies]
+            task = FileTask.new(self, name, dependencies, [], nil, [])
+            task.source = source
+            task.enhance([], &rule[:action]) if rule[:action]
+            @tasks[name] = task
+            return task
+          end
+        ensure
+          @rule_stack.pop
+        end
+        nil
+      end
+
+      def matching_rule?(name)
+        @rules.any? { |rule| name.end_with?(rule[:target]) }
+      end
+
+      def environment_assignment?(argument)
+        separator = argument.index("=")
+        return false unless separator && separator > 0
+        key = argument[0...separator]
+        key.bytes.each_with_index do |byte, index|
+          alpha = (byte >= 65 && byte <= 90) || (byte >= 97 && byte <= 122)
+          digit = byte >= 48 && byte <= 57
+          return false unless alpha || byte == 95 || (index > 0 && digit)
+        end
+        true
+      end
+    end
+
+    class << self
+      attr_writer :application
+
+      def application
+        @application ||= Application.new
+      end
+
+      def immediate?
+        $hola_run_immediate == true
+      end
+
+      def dry_run?
+        $hola_run_dry == true
+      end
+
+      def trace?
+        $hola_run_trace == true
+      end
+
+      def converge!
+        return unless immediate?
+        return if dry_run?
+        ok, message = ZigBackend.converge
+        raise Hola::ResourceError, message unless ok
+      end
+
+      def flush_delayed!
+        ok, message = ZigBackend.flush_delayed
+        raise Hola::ResourceError, message unless ok
+      end
+
+      def begin_task(name)
+        ok, message = ZigBackend.display_section(name.to_s)
+        raise Hola::ResourceError, message unless ok
+      end
+
+      def install_immediate_mode!
+        RESOURCE_DSL.each do |name|
+          method_name = name.to_sym
+          available = Object.private_instance_methods.include?(method_name) || Object.instance_methods.include?(method_name)
+          next unless available
+          original = ("hola_original_" + name).to_sym
+          installed = Object.private_instance_methods.include?(original) || Object.instance_methods.include?(original)
+          next if installed
+          Object.send(:alias_method, original, method_name)
+          Object.send(:define_method, method_name) do |*args, &block|
+            result = send(original, *args, &block)
+            Hola::Rake.converge!
+            result
+          end
+          Object.send(:private, method_name)
+        end
+      end
+
+      def main
+        if $hola_run_list
+          application.list_tasks
+          $hola_run_status = 0
+          return
+        end
+        if $hola_run_prerequisites
+          application.list_prerequisites
+          $hola_run_status = 0
+          return
+        end
+
+        begin
+          $hola_run_immediate = true
+          converge!
+          application.run($hola_run_argv || [])
+          flush_delayed!
+          $hola_run_status = 0
+        rescue Exception => error
+          puts "rake aborted!"
+          puts error.message
+          if error.backtrace
+            error.backtrace[0, 8].each { |line| puts line }
+          end
+          $hola_run_status = 1
+        end
+      end
+    end
+  end
+end
+
+module Rake
+  Task = Hola::Rake::Task
+  FileTask = Hola::Rake::FileTask
+  TaskArguments = Hola::Rake::TaskArguments
+  Application = Hola::Rake::Application
+
+  module DSL
+    def desc(description)
+      Hola::Rake.application.last_description = description.to_s
+    end
+
+    def task(*definition, &block)
+      Hola::Rake.application.define_task(Hola::Rake::Task, *definition, &block)
+    end
+
+    def file(*definition, &block)
+      Hola::Rake.application.define_task(Hola::Rake::FileTask, *definition, &block)
+    end
+
+    def file_task(*definition, &block)
+      file(*definition, &block)
+    end
+
+    def directory(*definition, &block)
+      Hola::Rake.application.define_task(Hola::Rake::FileTask, *definition) do |task, args|
+        mkdir_p(task.name)
+        block.call(task, args) if block
+      end
+    end
+
+    def multitask(*definition, &block)
+      task(*definition, &block)
+    end
+
+    def namespace(name, &block)
+      Hola::Rake.application.in_namespace(name, &block)
+    end
+
+    def default(*dependencies)
+      task({:default => dependencies.flatten})
+    end
+
+    def rule(*definition, &block)
+      Hola::Rake.application.define_rule(*definition, &block)
+    end
+
+    private :desc, :task, :file, :file_task, :directory, :multitask, :namespace, :default, :rule
+  end
+
+  class TaskLib
+    include DSL
+  end
+
+  class << self
+    def application
+      Hola::Rake.application
+    end
+
+    def application=(value)
+      Hola::Rake.application = value
+    end
+  end
+end
+
+module Hola
+  module Resources
+    class << self
+      def file(path, &block)
+        result = FileResource.new(path, &block)
+        Hola::Rake.converge!
+        result
+      end
+
+      def directory(path, &block)
+        result = DirectoryResource.new(path, &block)
+        Hola::Rake.converge!
+        result
+      end
+    end
+  end
+end
+
+class Dir
+  class << self
+    def glob(pattern, *flags, &block)
+      results = ZigBackend.glob(pattern.to_s)
+      if block
+        results.each(&block)
+        nil
+      else
+        results
+      end
+    end
+
+    def [](*patterns)
+      patterns.map { |pattern| glob(pattern) }.flatten
+    end
+  end
+end
+
+class FileList < Array
+  def self.[](*patterns)
+    new(*patterns)
+  end
+
+  def initialize(*patterns)
+    super()
+    include(*patterns)
+  end
+
+  def include(*patterns)
+    patterns.flatten.each do |pattern|
+      values = pattern.to_s.index("*") || pattern.to_s.index("?") || pattern.to_s.index("[")
+      entries = values ? Dir.glob(pattern.to_s) : [pattern.to_s]
+      entries.each { |entry| self << entry unless self.include?(entry) }
+    end
+    self
+  end
+
+  def exclude(*patterns)
+    rejected = patterns.flatten.map do |pattern|
+      value = pattern.to_s
+      wildcard = value.index("*") || value.index("?") || value.index("[")
+      wildcard ? Dir.glob(value) : [value]
+    end.flatten
+    delete_if { |entry| rejected.include?(entry) }
+    self
+  end
+
+  def existing
+    FileList.new.concat(select { |entry| File.exist?(entry) })
+  end
+
+  def ext(new_extension = nil)
+    return map { |entry| File.extname(entry) } if new_extension.nil?
+    map do |entry|
+      extension = File.extname(entry)
+      base = extension.empty? ? entry : entry[0...(entry.length - extension.length)]
+      base + new_extension.to_s
+    end
+  end
+
+  def to_a
+    Array.new(self)
+  end
+end
+
+Rake::FileList = FileList
+CLEAN = FileList.new unless Object.const_defined?(:CLEAN)
+CLOBBER = FileList.new unless Object.const_defined?(:CLOBBER)
+
+module FileUtils
+  def mkdir_p(path)
+    value = path.to_s
+    current = value.start_with?("/") ? "/" : ""
+    value.split("/").each do |part|
+      next if part.empty? || part == "."
+      current = if current == "/"
+        "/#{part}"
+      elsif current.empty?
+        part
+      else
+        "#{current}/#{part}"
+      end
+      Dir.mkdir(current) unless File.directory?(current)
+    end
+    [value]
+  end
+
+  def rm_f(path)
+    File.delete(path.to_s) if File.exist?(path.to_s)
+    nil
+  rescue Exception
+    nil
+  end
+
+  def rm_rf(path)
+    value = path.to_s
+    return nil unless File.exist?(value) || File.directory?(value)
+    if File.directory?(value)
+      Dir.entries(value).each do |entry|
+        next if entry == "." || entry == ".."
+        rm_rf(File.join(value, entry))
+      end
+      Dir.rmdir(value)
+    else
+      File.delete(value)
+    end
+    nil
+  end
+
+  def cp(source, destination)
+    data = File.open(source.to_s, "rb") { |file| file.read }
+    File.open(destination.to_s, "wb") { |file| file.write(data) }
+    destination
+  end
+
+  def mv(source, destination)
+    File.rename(source.to_s, destination.to_s)
+    destination
+  end
+
+  def touch(path)
+    File.open(path.to_s, "a") { |file| file.write("") }
+    path
+  end
+
+  def cd(directory)
+    previous = Dir.pwd
+    Dir.chdir(directory.to_s)
+    return directory unless block_given?
+    begin
+      yield directory
+    ensure
+      Dir.chdir(previous)
+    end
+  end
+
+  module_function :mkdir_p, :rm_f, :rm_rf, :cp, :mv, :touch, :cd
+end
+
+include FileUtils
+Rake::FileUtilsExt = FileUtils
+include Rake::DSL
+
+def sh(command_text, options = {}, &block)
+  if block
+    raise ArgumentError, "sh block form is not supported; use execute with ignore_failure"
+  end
+  options ||= {}
+  if Hola::Rake.dry_run?
+    puts command_text.to_s
+    return true
+  end
+  execute(command_text.to_s) do
+    self.command(command_text.to_s)
+    live_stream(true)
+    cwd(options[:cwd].to_s) if options[:cwd]
+    environment(options[:env] || {})
+  end
+end
+
+def abort(message = "")
+  raise RuntimeError, message.to_s
+end
+
+$hola_required_files ||= []
+$hola_load_stack ||= []
+
+def hola_load_ruby_file(path, once = false)
+  candidate = File.expand_path(path.to_s)
+  candidate += ".rb" if !File.exist?(candidate) && File.exist?(candidate + ".rb")
+  return false if once && $hola_required_files.include?(candidate)
+
+  $hola_load_stack << candidate
+  begin
+    ok, message = ZigBackend.load_file(candidate)
+    raise Hola::LoadError, message unless ok
+    $hola_required_files << candidate if once
+  ensure
+    $hola_load_stack.pop
+  end
+  true
+end
+
+def load(path)
+  hola_load_ruby_file(path, false)
+end
+
+def require(name)
+  known = %w[rake rake/tasklib rake/clean fileutils json time base64 set ostruct]
+  if name.to_s == "rake/clean"
+    unless Hola::Rake.application.lookup("clean", [])
+      Hola::Rake.application.define_task(Hola::Rake::Task, :clean) { CLEAN.each { |path| rm_rf(path) } }
+      Hola::Rake.application.define_task(Hola::Rake::Task, {:clobber => :clean}) { CLOBBER.each { |path| rm_rf(path) } }
+    end
+    return false
+  end
+  return false if known.include?(name.to_s)
+  if name.to_s.start_with?(".") || name.to_s.start_with?("/") || File.exist?(name.to_s) || File.exist?(name.to_s + ".rb")
+    return hola_load_ruby_file(name, true)
+  end
+  raise Hola::LoadError, "cannot load such file -- #{name}"
+end
+
+def require_relative(name)
+  current_file = $hola_load_stack.last || $hola_rakefile
+  base = current_file ? File.dirname(current_file) : Dir.pwd
+  hola_load_ruby_file(File.join(base, name.to_s), true)
+end
+
+def import(*files)
+  files.flatten.each { |path| hola_load_ruby_file(path, false) }
+end
+
+Hola::Rake.install_immediate_mode!
+
+if $hola_run_capture_output
+  unless Object.private_instance_methods.include?(:hola_original_puts) || Object.instance_methods.include?(:hola_original_puts)
+    Object.send(:alias_method, :hola_original_puts, :puts)
+    Object.send(:define_method, :puts) do |*values|
+      values = [""] if values.empty?
+      values.each do |value|
+        if value.is_a?(Array)
+          value.each { |item| puts(item) }
+        else
+          ok, message = ZigBackend.print_line(value.nil? ? "nil" : value.to_s)
+          raise Hola::ResourceError, message unless ok
+        end
+      end
+      nil
+    end
+    Object.send(:private, :puts)
+  end
+end

--- a/src/ruby_prelude/tasks.rb
+++ b/src/ruby_prelude/tasks.rb
@@ -224,11 +224,13 @@ module Hola
         @last_description = nil
         @rules = []
         @rule_stack = []
+        @phase_tasks = {}
       end
 
       def clear
         @tasks.clear
         @rules.clear
+        @phase_tasks.clear
         @last_description = nil
       end
 
@@ -267,6 +269,20 @@ module Hola
           :action => block,
         }
         nil
+      end
+
+      def define_phase_task(name, source = nil)
+        full_name = name.to_s
+        return @tasks[full_name] if @phase_tasks[full_name]
+        raise "Task '#{full_name}' is already defined and cannot also be a phase" if @tasks[full_name]
+
+        scope = full_name.split(":")[0...-1]
+        description = source ? "Run phase from #{source}" : "Run phase #{full_name}"
+        task = Task.new(self, full_name, [], [], description, scope)
+        task.enhance { Hola::Rake.converge_phase!(full_name) }
+        @tasks[full_name] = task
+        @phase_tasks[full_name] = true
+        task
       end
 
       def in_namespace(name)
@@ -493,6 +509,13 @@ module Hola
         return if dry_run?
         ok, message = ZigBackend.converge
         raise Hola::ResourceError, message unless ok
+      end
+
+      def converge_phase!(name)
+        return if dry_run?
+        ok, message = ZigBackend.converge_phase(name.to_s)
+        raise Hola::ResourceError, message unless ok
+        flush_delayed!
       end
 
       def flush_delayed!
@@ -841,8 +864,49 @@ def require_relative(name)
   hola_load_ruby_file(File.join(base, name.to_s), true)
 end
 
+def hola_with_top_level_resource_dsl
+  installed = []
+  Hola::Resources::DSL_METHODS.each do |name|
+    method_name = name.to_sym
+    original = ("hola_resource_" + name).to_sym
+    available = Object.private_instance_methods.include?(original) || Object.instance_methods.include?(original)
+    next unless available
+    Object.send(:alias_method, method_name, original)
+    Object.send(:private, method_name)
+    installed << method_name
+  end
+  begin
+    yield
+  ensure
+    installed.reverse_each do |method_name|
+      begin
+        Object.send(:remove_method, method_name)
+      rescue NameError
+      end
+    end
+  end
+end
+
 def import(*files)
   files.flatten.each { |path| hola_load_ruby_file(path, false) }
+end
+
+def import_phases(path, options = {})
+  options ||= {}
+  namespace = options[:as] || options["as"]
+  source = File.expand_path(path.to_s)
+  phases = []
+  listener = proc do |name|
+    Hola::Rake.application.define_phase_task(name, source)
+    phases << name unless phases.include?(name)
+  end
+
+  Hola::Phases.with_import(namespace, listener) do
+    hola_with_top_level_resource_dsl do
+      hola_load_ruby_file(source, false)
+    end
+  end
+  phases
 end
 
 Hola::Rake.install_immediate_mode!

--- a/src/ruby_prelude/tasks.rb
+++ b/src/ruby_prelude/tasks.rb
@@ -6,12 +6,7 @@ module Hola
   end
 
   module Rake
-    RESOURCE_DSL = %w[
-      execute remote_file template link route
-      macos_dock macos_defaults apt_repository systemd_unit mount
-      package homebrew_package apt_package ruby_block git user group
-      aws_kms file_edit extract apt_update
-    ]
+    RESOURCE_DSL = Hola::Resources::DSL_METHODS
 
     class TaskArguments
       attr_reader :names
@@ -505,21 +500,26 @@ module Hola
         raise Hola::ResourceError, message unless ok
       end
 
+      def install_immediate_resource!(resources_class, method_name, original)
+        resources_class.send(:alias_method, original, method_name)
+        resources_class.send(:private, original)
+        resources_class.send(:define_method, method_name) do |*args, &block|
+          result = send(original, *args, &block)
+          Hola::Rake.converge!
+          result
+        end
+      end
+
       def install_immediate_mode!
+        resources_class = class << Hola::Resources; self; end
         RESOURCE_DSL.each do |name|
           method_name = name.to_sym
-          available = Object.private_instance_methods.include?(method_name) || Object.instance_methods.include?(method_name)
-          next unless available
-          original = ("hola_original_" + name).to_sym
-          installed = Object.private_instance_methods.include?(original) || Object.instance_methods.include?(original)
+          next unless Hola::Resources.respond_to?(method_name)
+          original = ("hola_deferred_resource_" + name).to_sym
+          installed = resources_class.private_instance_methods.include?(original) ||
+            resources_class.instance_methods.include?(original)
           next if installed
-          Object.send(:alias_method, original, method_name)
-          Object.send(:define_method, method_name) do |*args, &block|
-            result = send(original, *args, &block)
-            Hola::Rake.converge!
-            result
-          end
-          Object.send(:private, method_name)
+          install_immediate_resource!(resources_class, method_name, original)
         end
       end
 
@@ -600,7 +600,12 @@ module Rake
       Hola::Rake.application.define_rule(*definition, &block)
     end
 
-    private :desc, :task, :file, :file_task, :directory, :multitask, :namespace, :default, :rule
+    def resources(&block)
+      return Hola::Resources unless block
+      Hola::Resources.instance_eval(&block)
+    end
+
+    private :desc, :task, :file, :file_task, :directory, :multitask, :namespace, :default, :rule, :resources
   end
 
   class TaskLib
@@ -614,24 +619,6 @@ module Rake
 
     def application=(value)
       Hola::Rake.application = value
-    end
-  end
-end
-
-module Hola
-  module Resources
-    class << self
-      def file(path, &block)
-        result = FileResource.new(path, &block)
-        Hola::Rake.converge!
-        result
-      end
-
-      def directory(path, &block)
-        result = DirectoryResource.new(path, &block)
-        Hola::Rake.converge!
-        result
-      end
     end
   end
 end
@@ -781,14 +768,14 @@ include Rake::DSL
 
 def sh(command_text, options = {}, &block)
   if block
-    raise ArgumentError, "sh block form is not supported; use execute with ignore_failure"
+    raise ArgumentError, "sh block form is not supported; use resources.execute with ignore_failure"
   end
   options ||= {}
   if Hola::Rake.dry_run?
     puts command_text.to_s
     return true
   end
-  execute(command_text.to_s) do
+  Hola::Resources.execute(command_text.to_s) do
     self.command(command_text.to_s)
     live_stream(true)
     cwd(options[:cwd].to_s) if options[:cwd]

--- a/src/ruby_prelude/tasks.rb
+++ b/src/ruby_prelude/tasks.rb
@@ -542,7 +542,7 @@ module Hola
           flush_delayed!
           $hola_run_status = 0
         rescue Exception => error
-          puts "rake aborted!"
+          puts "hola aborted!"
           puts error.message
           if error.backtrace
             error.backtrace[0, 8].each { |line| puts line }
@@ -840,7 +840,7 @@ def require(name)
 end
 
 def require_relative(name)
-  current_file = $hola_load_stack.last || $hola_rakefile
+  current_file = $hola_load_stack.last || $hola_taskfile
   base = current_file ? File.dirname(current_file) : Dir.pwd
   hola_load_ruby_file(File.join(base, name.to_s), true)
 end

--- a/src/ruby_prelude/test_helper.rb
+++ b/src/ruby_prelude/test_helper.rb
@@ -114,14 +114,14 @@ class TestCase
 end
 
 def test(name, &block)
-  ruby_block "test: #{name}" do
+  Hola::Resources.ruby_block "test: #{name}" do
     block_proc = proc { TestCase.new(name, &block) }
     self.block(&block_proc)
   end
 end
 
 def skip_test(name, reason = "skipped")
-  ruby_block "test: #{name}" do
+  Hola::Resources.ruby_block "test: #{name}" do
     block do
       Hola::Test.test_count += 1
       puts "○ #{name} (#{reason})"
@@ -150,7 +150,7 @@ def systemd?
 end
 
 def test_summary
-  ruby_block "test summary" do
+  Hola::Resources.ruby_block "test summary" do
     block { Hola::Test.summary }
   end
 end

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -6,12 +6,14 @@ OUTPUT = "#{ROOT}/out.txt"
 
 desc "Prepare the fixture directory"
 task :prepare do
-  Hola::Resources.directory ROOT
-  Hola::Resources.file CONFIG do
-    content "configured\n"
-  end
-  Hola::Resources.file "#{ROOT}/generated.in" do
-    content "rule input\n"
+  resources do
+    directory ROOT
+    file CONFIG do
+      content "configured\n"
+    end
+    file "#{ROOT}/generated.in" do
+      content "rule input\n"
+    end
   end
   raise "resources were not applied immediately" unless File.exist?(CONFIG)
 end

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -1,0 +1,97 @@
+require_relative "rake_helpers"
+
+ROOT = "/tmp/hola_rake_test"
+CONFIG = "#{ROOT}/config.txt"
+OUTPUT = "#{ROOT}/out.txt"
+
+desc "Prepare the fixture directory"
+task :prepare do
+  Hola::Resources.directory ROOT
+  Hola::Resources.file CONFIG do
+    content "configured\n"
+  end
+  Hola::Resources.file "#{ROOT}/generated.in" do
+    content "rule input\n"
+  end
+  raise "resources were not applied immediately" unless File.exist?(CONFIG)
+end
+
+desc "Build the fixture"
+task :build => :prepare do
+  sh "echo compiling"
+  sh "echo built > #{OUTPUT}"
+end
+
+desc "Build an output only when its input is newer"
+file OUTPUT => [CONFIG] do
+  sh "cp #{CONFIG} #{OUTPUT}"
+end
+
+rule ".out" => ".in" do |task|
+  sh "cp #{task.source} #{task.name}"
+end
+
+desc "Build a target using a suffix rule"
+task :rule_demo => [:prepare, "#{ROOT}/generated.out"]
+
+desc "Expand files with Dir.glob and FileList"
+task :glob_demo do
+  files = FileList["*.rb"]
+  raise "glob did not find Ruby fixtures" if files.empty?
+  puts files.join(",")
+end
+
+desc "Load a helper with require_relative"
+task :helper_demo do
+  puts rake_helper_message
+end
+
+namespace :db do
+  desc "Run a database migration"
+  task :migrate, [:env] do |task, args|
+    args.with_defaults :env => "development"
+    puts "migrating #{args.env}"
+  end
+end
+
+desc "Demonstrate task enhancement"
+task :enhanced do
+  puts "first action"
+end
+
+task :enhanced do
+  puts "second action"
+end
+
+desc "Use command-line environment assignments"
+task :env_demo do
+  raise "missing task environment" unless ENV["HOLA_TASK_ENV"] == "assigned"
+  sh 'test "$HOLA_TASK_ENV" = assigned'
+end
+
+desc "Fail with a non-zero shell exit"
+task :fails do
+  sh "exit 3"
+  puts "never"
+end
+
+desc "Stream stdout and stderr while a command runs"
+task :stream do
+  sh "for i in 1 2 3; do echo out-$i; echo err-$i >&2; sleep 1; done"
+end
+
+desc "Rescue a failed resource and continue"
+task :rescued do
+  begin
+    sh "exit 3"
+  rescue Hola::ResourceError
+    puts "rescued"
+  end
+end
+
+desc "Remove fixture output"
+task :clean do
+  rm_rf ROOT
+end
+
+task :default => :build

--- a/test/output_failures/Holafile
+++ b/test/output_failures/Holafile
@@ -1,0 +1,109 @@
+ROOT = "/tmp/hola-output-failures/task"
+READ_ONLY_DIR = "#{ROOT}/read-only"
+PARENT_FILE = "#{ROOT}/parent-is-a-file"
+
+desc "Run the complete handled-error diagnostic flow"
+task :diagnostics do
+  rm_rf ROOT
+
+  resources.directory ROOT do
+    recursive true
+    mode "0755"
+  end
+
+  resources.file PARENT_FILE do
+    content "this path is intentionally a regular file\n"
+  end
+
+  resources.directory READ_ONLY_DIR do
+    recursive true
+    mode "0555"
+  end
+
+  resources.execute "non-zero command with captured output" do
+    command "printf 'compile started\\n'; printf 'main.c:42:7: error: expected semicolon\\n' >&2; exit 7"
+    live_stream true
+    ignore_failure true
+  end
+
+  resources.execute "missing command" do
+    command "/definitely/missing/hola-command --version"
+    ignore_failure true
+  end
+
+  resources.execute "timed out command" do
+    command "printf 'starting slow step\\n'; sleep 3"
+    live_stream true
+    timeout 1
+    ignore_failure true
+  end
+
+  resources.execute "missing parent working directory" do
+    command "pwd"
+    cwd "#{ROOT}/missing-parent/worktree"
+    ignore_failure true
+  end
+
+  resources.template "#{ROOT}/rendered.conf" do
+    source "definitely-missing-template.erb"
+    variables "environment" => "test"
+    ignore_failure true
+  end
+
+  resources.file "#{PARENT_FILE}/child.txt" do
+    content "cannot be created\n"
+    ignore_failure true
+  end
+
+  resources.file "#{READ_ONLY_DIR}/cannot-write.txt" do
+    content "cannot be written\n"
+    ignore_failure true
+  end
+
+  # Restore permissions so the fixture can always be removed by the next run.
+  resources.directory READ_ONLY_DIR do
+    mode "0755"
+  end
+
+  resources.ruby_block "raise from authoring code" do
+    block do
+      raise "simulated Ruby failure from Holafile"
+    end
+    ignore_failure true
+  end
+
+  Hola::Resources.with_resource_scope "build_bundle", "demo application", :create do
+    Hola::Resources.execute "nested compilation failure" do
+      command "printf 'nested stdout\\n'; printf 'nested stderr\\n' >&2; exit 23"
+      live_stream true
+      ignore_failure true
+    end
+  end
+
+  begin
+    sh "printf 'rescued failure\\n' >&2; exit 11"
+  rescue Hola::ResourceError => error
+    puts "rescued by task: #{error.message}"
+  end
+
+  resources.execute "guarded command" do
+    command "exit 99"
+    only_if { false }
+  end
+
+  resources.file PARENT_FILE do
+    content "this path is intentionally a regular file\n"
+  end
+end
+
+desc "Abort on an unhandled nested resource failure"
+task :abort do
+  Hola::Resources.with_resource_scope "build_bundle", "fatal demo application", :create do
+    Hola::Resources.execute "fatal nested packaging step" do
+      command "printf 'packaging started\\n'; printf 'package input is missing\\n' >&2; exit 29"
+      live_stream true
+    end
+  end
+end
+
+task :default => :diagnostics

--- a/test/output_failures/README.md
+++ b/test/output_failures/README.md
@@ -1,0 +1,39 @@
+# Output failure fixtures
+
+These fixtures exercise four focused execution flows in each output mode:
+
+- `hola run diagnostics`: one task containing handled command, filesystem,
+  rescue, guard, and nested-resource failures.
+- `hola run abort`: one unhandled nested-resource failure.
+- `hola provision provision.rb`: one converge containing handled failures.
+- `hola provision provision_abort.rb`: one fatal converge.
+
+Build Hola, then run one mode at a time:
+
+```bash
+zig build
+./test/output_failures/run.sh normal
+./test/output_failures/run.sh compact
+```
+
+Run both modes with:
+
+```bash
+./test/output_failures/run.sh both
+```
+
+The driver verifies exit statuses silently and reports only mismatches. It uses
+only `/tmp/hola-output-failures` and removes that directory between flows.
+Run it as a normal user so the permission-denied case remains meaningful. Set
+`HOLA_BIN=/absolute/path/to/hola` to test a different binary.
+
+Individual cases can also be run directly:
+
+```bash
+./zig-out/bin/hola-macos-aarch64 run \
+  --holafile test/output_failures/Holafile \
+  --output normal diagnostics
+
+./zig-out/bin/hola-macos-aarch64 provision \
+  --output compact test/output_failures/provision.rb
+```

--- a/test/output_failures/provision.rb
+++ b/test/output_failures/provision.rb
@@ -1,0 +1,82 @@
+ROOT = "/tmp/hola-output-failures/provision"
+READ_ONLY_DIR = "#{ROOT}/read-only"
+PARENT_FILE = "#{ROOT}/parent-is-a-file"
+
+directory ROOT do
+  recursive true
+  mode "0755"
+end
+
+file PARENT_FILE do
+  content "this path is intentionally a regular file\n"
+end
+
+directory READ_ONLY_DIR do
+  recursive true
+  mode "0555"
+end
+
+execute "non-zero command with captured output" do
+  command "printf 'compile started\\n'; printf 'main.c:42:7: error: expected semicolon\\n' >&2; exit 7"
+  live_stream true
+  ignore_failure true
+end
+
+execute "missing command" do
+  command "/definitely/missing/hola-command --version"
+  ignore_failure true
+end
+
+execute "timed out command" do
+  command "printf 'starting slow step\\n'; sleep 3"
+  live_stream true
+  timeout 1
+  ignore_failure true
+end
+
+execute "missing parent working directory" do
+  command "pwd"
+  cwd "#{ROOT}/missing-parent/worktree"
+  ignore_failure true
+end
+
+template "#{ROOT}/rendered.conf" do
+  source "definitely-missing-template.erb"
+  variables "environment" => "test"
+  ignore_failure true
+end
+
+file "#{PARENT_FILE}/child.txt" do
+  content "cannot be created\n"
+  ignore_failure true
+end
+
+file "#{READ_ONLY_DIR}/cannot-write.txt" do
+  content "cannot be written\n"
+  ignore_failure true
+end
+
+# Restore permissions so the fixture can always be removed by the next run.
+directory READ_ONLY_DIR do
+  mode "0755"
+end
+
+ruby_block "raise from provision code" do
+  block do
+    raise "simulated Ruby failure from provision.rb"
+  end
+  ignore_failure true
+end
+
+Hola::Resources.with_resource_scope "release_bundle", "demo application", :create do
+  execute "nested signing failure" do
+    command "printf 'sign stdout\\n'; printf 'codesign: invalid identity\\n' >&2; exit 17"
+    live_stream true
+    ignore_failure true
+  end
+end
+
+execute "guarded command" do
+  command "exit 99"
+  only_if { false }
+end

--- a/test/output_failures/provision_abort.rb
+++ b/test/output_failures/provision_abort.rb
@@ -1,0 +1,6 @@
+Hola::Resources.with_resource_scope "release_bundle", "fatal demo application", :create do
+  execute "fatal nested packaging step" do
+    command "printf 'packaging started\\n'; printf 'package input is missing\\n' >&2; exit 29"
+    live_stream true
+  end
+end

--- a/test/output_failures/run.sh
+++ b/test/output_failures/run.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd "$SCRIPT_DIR/../.." && pwd)
+
+if [ -n "${HOLA_BIN:-}" ]; then
+  HOLA=$HOLA_BIN
+else
+  case "$(uname -s)-$(uname -m)" in
+    Darwin-arm64) HOLA="$REPO_ROOT/zig-out/bin/hola-macos-aarch64" ;;
+    Linux-aarch64|Linux-arm64) HOLA="$REPO_ROOT/zig-out/bin/hola-linux-aarch64" ;;
+    Linux-x86_64) HOLA="$REPO_ROOT/zig-out/bin/hola-linux-x86_64" ;;
+    *)
+      echo "Unsupported platform; set HOLA_BIN to the hola executable." >&2
+      exit 2
+      ;;
+  esac
+fi
+
+if [ ! -x "$HOLA" ]; then
+  echo "Hola executable not found: $HOLA" >&2
+  echo "Run 'zig build' first, or set HOLA_BIN explicitly." >&2
+  exit 2
+fi
+
+cd "$SCRIPT_DIR"
+
+unexpected=0
+
+reset_fixture() {
+  rm -rf /tmp/hola-output-failures
+}
+
+expect_failure() {
+  label=$1
+  shift
+  reset_fixture
+  printf '\n%s\n' "$label"
+  "$@"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    echo "ERROR: expected a non-zero exit status" >&2
+    unexpected=$((unexpected + 1))
+  fi
+}
+
+expect_success() {
+  label=$1
+  shift
+  reset_fixture
+  printf '\n%s\n' "$label"
+  "$@"
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    printf 'ERROR: expected exit status 0, got %s\n' "$status" >&2
+    unexpected=$((unexpected + 1))
+  fi
+}
+
+run_mode() {
+  mode=$1
+  printf '\nOutput mode: %s\n' "$mode"
+
+  expect_success "run: handled diagnostics" \
+    "$HOLA" run --output "$mode" diagnostics
+
+  expect_failure "run: fatal diagnostic" \
+    "$HOLA" run --output "$mode" abort
+
+  expect_success "provision: handled diagnostics" \
+    "$HOLA" provision --output "$mode" provision.rb
+
+  expect_failure "provision: fatal diagnostic" \
+    "$HOLA" provision --output "$mode" provision_abort.rb
+}
+
+case "${1:-both}" in
+  normal|compact)
+    run_mode "$1"
+    ;;
+  both)
+    run_mode normal
+    run_mode compact
+    ;;
+  *)
+    echo "Usage: $0 [normal|compact|both]" >&2
+    exit 2
+    ;;
+esac
+
+reset_fixture
+
+if [ "$unexpected" -ne 0 ]; then
+  printf '\n%s scenario(s) returned an unexpected exit status.\n' "$unexpected" >&2
+  exit 1
+fi
+
+printf '\nAll scenarios returned the expected exit status.\n'

--- a/test/rake_helpers.rb
+++ b/test/rake_helpers.rb
@@ -1,0 +1,3 @@
+def rake_helper_message
+  "helper loaded"
+end


### PR DESCRIPTION
## What

Adds `hola run` — a Rake-inspired task runner backed by hola's resources and the embedded mruby — plus a `phase` mechanism that lets one provision recipe be executed whole, by stage, or as imported tasks.

### Task runner (`hola run`)

- Task DSL: `task`/`desc`, dependencies, task arguments (`db:migrate[production]`), `namespace`, string-suffix `rule`, `file`/`directory` file tasks, `Rake::Task[]`, `invoke`/`execute`/`reenable`, `import`, `require`/`require_relative`/`load`, `Dir.glob`/`FileList`, `rake/clean`.
- File discovery: `Holafile`/`holafile.rb` preferred, legacy `Rakefile` names accepted with a migration warning; upward search with chdir; `-f/--holafile` to pin.
- Implicit fallback: `hola <task>` runs a task when it isn't a builtin command.
- `-T`/`-P`/`-n` (dry-run)/`-t` (trace), plus the same data/secrets-bag flags as `provision`.
- Resource DSL gateway: `resources.<name>` / `resources do ... end` inside tasks applies resources immediately (imperative semantics); `sh` is an `execute` resource with live streaming.
- mruby safety: converge and the other new bindings return `[ok, message]` and raise on the Ruby side; `only_if`/`not_if`/`ruby_block` procs run through an `mrb_protect_error` shim so exceptions can't longjmp across Zig frames.

### Reusable phases

- `phase :name` markers split a flat recipe into stages; recipes without markers keep the existing behavior.
- `hola provision --phase NAME` runs a single stage; unknown names fail with the available list.
- `import_phases "recipe.rb", :as => :app` exposes stages as namespaced tasks (`hola run app:deploy`), composable with plain tasks.
- Agent tasks accept an optional `"phase"` field; per-resource callback results include their phase.

### Output

- Output modes reworked into `normal` (plain, default) and `compact` (progress UI); `plain`/`pretty` kept as aliases.
- Streaming command output, richer failure diagnostics with backtraces, per-task sections.

## Tests

Zig test blocks for the task DSL semantics, discovery, glob, streaming splitter, display formatting, and provision phase selection; runnable fixtures under `test/` including an exit-status driver for failure scenarios (`test/output_failures/run.sh`).

## Known follow-ups

- `template` inside immediate mode still evaluates ERB via an unprotected `mrb_load_string`; a raise there can skip Zig cleanup and leave the converge guard stuck. Fix is to route it through the protected loader.
- `sh "cmd", "arg"` (splat form) and old-style `task :name, :arg` are not yet supported.
- `phase` used inside a task body is currently inert; nested phases are intentionally not selected by `--phase`.