### PR TITLE
feat(macos_defaults): add current_host option and fix global/delete handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,20 @@ macos_defaults 'show all file extensions' do
   key 'AppleShowAllExtensions'
   value true
 end
+
+# Per-host keys (`defaults -currentHost write ...`)
+macos_defaults 'menu bar item spacing' do
+  global true
+  current_host true
+  key 'NSStatusItemSpacing'
+  value 6
+end
 ```
 
 **Features:**
 - ✅ **Type-safe**: Boolean, Integer, Float, String - automatically handled
 - ✅ **Idempotent**: Only updates when values differ
+- ✅ **Per-host domain**: `current_host true` targets `defaults -currentHost`
 - ✅ **Auto-restart**: Automatically restarts Finder/Dock/SystemUIServer when needed
 - ✅ **No manual `defaults` commands**: Just declare what you want
 

--- a/src/cfprefs_wrapper.c
+++ b/src/cfprefs_wrapper.c
@@ -3,13 +3,27 @@
 #include <string.h>
 
 // ============================================================================
+// Helpers
+// ============================================================================
+
+// Map the `defaults` global domain name to CFPreferences' any-application
+// domain (.GlobalPreferences). Without this, "NSGlobalDomain" would be treated
+// as a literal application id and end up in ~/Library/Preferences/NSGlobalDomain.plist.
+static CFStringRef domain_ref(const char *domain) {
+    if (strcmp(domain, "NSGlobalDomain") == 0 || strcmp(domain, "-g") == 0) {
+        return (CFStringRef)CFRetain(kCFPreferencesAnyApplication);
+    }
+    return CFStringCreateWithCString(NULL, domain, kCFStringEncodingUTF8);
+}
+
+// ============================================================================
 // Write operations
 // ============================================================================
 
 // Write boolean value
 // Returns 1 on success, 0 on failure
 int cfpreferences_write_boolean(const char *domain, const char *key, int value) {
-    CFStringRef domain_cf = CFStringCreateWithCString(NULL, domain, kCFStringEncodingUTF8);
+    CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
     CFBooleanRef bool_val = value ? kCFBooleanTrue : kCFBooleanFalse;
@@ -26,7 +40,7 @@ int cfpreferences_write_boolean(const char *domain, const char *key, int value) 
 // Write integer value
 // Returns 1 on success, 0 on failure
 int cfpreferences_write_integer(const char *domain, const char *key, long long value) {
-    CFStringRef domain_cf = CFStringCreateWithCString(NULL, domain, kCFStringEncodingUTF8);
+    CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
     CFNumberRef num = CFNumberCreate(NULL, kCFNumberLongLongType, &value);
@@ -49,7 +63,7 @@ int cfpreferences_write_integer(const char *domain, const char *key, long long v
 // Write float value
 // Returns 1 on success, 0 on failure
 int cfpreferences_write_float(const char *domain, const char *key, double value) {
-    CFStringRef domain_cf = CFStringCreateWithCString(NULL, domain, kCFStringEncodingUTF8);
+    CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
     CFNumberRef num = CFNumberCreate(NULL, kCFNumberDoubleType, &value);
@@ -72,7 +86,7 @@ int cfpreferences_write_float(const char *domain, const char *key, double value)
 // Write string value
 // Returns 1 on success, 0 on failure
 int cfpreferences_write_string(const char *domain, const char *key, const char *value) {
-    CFStringRef domain_cf = CFStringCreateWithCString(NULL, domain, kCFStringEncodingUTF8);
+    CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
     CFStringRef value_cf = CFStringCreateWithCString(NULL, value, kCFStringEncodingUTF8);
 
@@ -100,7 +114,7 @@ int cfpreferences_write_string(const char *domain, const char *key, const char *
 // Returns: 1 if value exists and is boolean, 0 otherwise
 // out_value: pointer to store the boolean value (0 or 1)
 int cfpreferences_read_boolean(const char *domain, const char *key, int *out_value) {
-    CFStringRef domain_cf = CFStringCreateWithCString(NULL, domain, kCFStringEncodingUTF8);
+    CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
     CFTypeRef value = CFPreferencesCopyAppValue(key_cf, domain_cf);
@@ -126,7 +140,7 @@ int cfpreferences_read_boolean(const char *domain, const char *key, int *out_val
 // Returns: 1 if value exists and is number, 0 otherwise
 // out_value: pointer to store the integer value
 int cfpreferences_read_integer(const char *domain, const char *key, long long *out_value) {
-    CFStringRef domain_cf = CFStringCreateWithCString(NULL, domain, kCFStringEncodingUTF8);
+    CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
     CFTypeRef value = CFPreferencesCopyAppValue(key_cf, domain_cf);
@@ -152,7 +166,7 @@ int cfpreferences_read_integer(const char *domain, const char *key, long long *o
 // Returns: 1 if value exists and is number, 0 otherwise
 // out_value: pointer to store the float value
 int cfpreferences_read_float(const char *domain, const char *key, double *out_value) {
-    CFStringRef domain_cf = CFStringCreateWithCString(NULL, domain, kCFStringEncodingUTF8);
+    CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
     CFTypeRef value = CFPreferencesCopyAppValue(key_cf, domain_cf);
@@ -179,7 +193,7 @@ int cfpreferences_read_float(const char *domain, const char *key, double *out_va
 // buffer: buffer to store the string (must be pre-allocated)
 // buffer_size: size of the buffer
 int cfpreferences_read_string(const char *domain, const char *key, char *buffer, int buffer_size) {
-    CFStringRef domain_cf = CFStringCreateWithCString(NULL, domain, kCFStringEncodingUTF8);
+    CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
     CFTypeRef value = CFPreferencesCopyAppValue(key_cf, domain_cf);
@@ -208,7 +222,7 @@ int cfpreferences_read_string(const char *domain, const char *key, char *buffer,
 // Check if a key exists
 // Returns: 1 if exists, 0 if not
 int cfpreferences_key_exists(const char *domain, const char *key) {
-    CFStringRef domain_cf = CFStringCreateWithCString(NULL, domain, kCFStringEncodingUTF8);
+    CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
     CFTypeRef value = CFPreferencesCopyAppValue(key_cf, domain_cf);
@@ -226,7 +240,7 @@ int cfpreferences_key_exists(const char *domain, const char *key) {
 // Delete a key
 // Returns: 1 on success, 0 on failure
 int cfpreferences_delete_key(const char *domain, const char *key) {
-    CFStringRef domain_cf = CFStringCreateWithCString(NULL, domain, kCFStringEncodingUTF8);
+    CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
     CFPreferencesSetAppValue(key_cf, NULL, domain_cf);

--- a/src/cfprefs_wrapper.c
+++ b/src/cfprefs_wrapper.c
@@ -16,20 +16,35 @@ static CFStringRef domain_ref(const char *domain) {
     return CFStringCreateWithCString(NULL, domain, kCFStringEncodingUTF8);
 }
 
+// current_host != 0 selects the per-host domain (`defaults -currentHost`),
+// otherwise the any-host domain that `defaults` uses by default.
+static CFStringRef host_ref(int current_host) {
+    return current_host ? kCFPreferencesCurrentHost : kCFPreferencesAnyHost;
+}
+
+static CFPropertyListRef copy_value(CFStringRef key, CFStringRef domain, int current_host) {
+    return CFPreferencesCopyValue(key, domain, kCFPreferencesCurrentUser, host_ref(current_host));
+}
+
+// Returns 1 on success, 0 on failure
+static int set_value(CFStringRef key, CFPropertyListRef value, CFStringRef domain, int current_host) {
+    CFPreferencesSetValue(key, value, domain, kCFPreferencesCurrentUser, host_ref(current_host));
+    return CFPreferencesSynchronize(domain, kCFPreferencesCurrentUser, host_ref(current_host)) ? 1 : 0;
+}
+
 // ============================================================================
 // Write operations
 // ============================================================================
 
 // Write boolean value
 // Returns 1 on success, 0 on failure
-int cfpreferences_write_boolean(const char *domain, const char *key, int value) {
+int cfpreferences_write_boolean(const char *domain, const char *key, int value, int current_host) {
     CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
     CFBooleanRef bool_val = value ? kCFBooleanTrue : kCFBooleanFalse;
 
-    CFPreferencesSetAppValue(key_cf, bool_val, domain_cf);
-    Boolean sync_result = CFPreferencesAppSynchronize(domain_cf);
+    Boolean sync_result = set_value(key_cf, bool_val, domain_cf, current_host);
 
     CFRelease(key_cf);
     CFRelease(domain_cf);
@@ -39,7 +54,7 @@ int cfpreferences_write_boolean(const char *domain, const char *key, int value) 
 
 // Write integer value
 // Returns 1 on success, 0 on failure
-int cfpreferences_write_integer(const char *domain, const char *key, long long value) {
+int cfpreferences_write_integer(const char *domain, const char *key, long long value, int current_host) {
     CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
@@ -50,8 +65,7 @@ int cfpreferences_write_integer(const char *domain, const char *key, long long v
         return 0;
     }
 
-    CFPreferencesSetAppValue(key_cf, num, domain_cf);
-    Boolean sync_result = CFPreferencesAppSynchronize(domain_cf);
+    Boolean sync_result = set_value(key_cf, num, domain_cf, current_host);
 
     CFRelease(num);
     CFRelease(key_cf);
@@ -62,7 +76,7 @@ int cfpreferences_write_integer(const char *domain, const char *key, long long v
 
 // Write float value
 // Returns 1 on success, 0 on failure
-int cfpreferences_write_float(const char *domain, const char *key, double value) {
+int cfpreferences_write_float(const char *domain, const char *key, double value, int current_host) {
     CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
@@ -73,8 +87,7 @@ int cfpreferences_write_float(const char *domain, const char *key, double value)
         return 0;
     }
 
-    CFPreferencesSetAppValue(key_cf, num, domain_cf);
-    Boolean sync_result = CFPreferencesAppSynchronize(domain_cf);
+    Boolean sync_result = set_value(key_cf, num, domain_cf, current_host);
 
     CFRelease(num);
     CFRelease(key_cf);
@@ -85,7 +98,7 @@ int cfpreferences_write_float(const char *domain, const char *key, double value)
 
 // Write string value
 // Returns 1 on success, 0 on failure
-int cfpreferences_write_string(const char *domain, const char *key, const char *value) {
+int cfpreferences_write_string(const char *domain, const char *key, const char *value, int current_host) {
     CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
     CFStringRef value_cf = CFStringCreateWithCString(NULL, value, kCFStringEncodingUTF8);
@@ -96,8 +109,7 @@ int cfpreferences_write_string(const char *domain, const char *key, const char *
         return 0;
     }
 
-    CFPreferencesSetAppValue(key_cf, value_cf, domain_cf);
-    Boolean sync_result = CFPreferencesAppSynchronize(domain_cf);
+    Boolean sync_result = set_value(key_cf, value_cf, domain_cf, current_host);
 
     CFRelease(value_cf);
     CFRelease(key_cf);
@@ -113,11 +125,11 @@ int cfpreferences_write_string(const char *domain, const char *key, const char *
 // Read boolean value
 // Returns: 1 if value exists and is boolean, 0 otherwise
 // out_value: pointer to store the boolean value (0 or 1)
-int cfpreferences_read_boolean(const char *domain, const char *key, int *out_value) {
+int cfpreferences_read_boolean(const char *domain, const char *key, int *out_value, int current_host) {
     CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
-    CFTypeRef value = CFPreferencesCopyAppValue(key_cf, domain_cf);
+    CFTypeRef value = copy_value(key_cf, domain_cf, current_host);
 
     CFRelease(key_cf);
     CFRelease(domain_cf);
@@ -139,11 +151,11 @@ int cfpreferences_read_boolean(const char *domain, const char *key, int *out_val
 // Read integer value
 // Returns: 1 if value exists and is number, 0 otherwise
 // out_value: pointer to store the integer value
-int cfpreferences_read_integer(const char *domain, const char *key, long long *out_value) {
+int cfpreferences_read_integer(const char *domain, const char *key, long long *out_value, int current_host) {
     CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
-    CFTypeRef value = CFPreferencesCopyAppValue(key_cf, domain_cf);
+    CFTypeRef value = copy_value(key_cf, domain_cf, current_host);
 
     CFRelease(key_cf);
     CFRelease(domain_cf);
@@ -165,11 +177,11 @@ int cfpreferences_read_integer(const char *domain, const char *key, long long *o
 // Read float value
 // Returns: 1 if value exists and is number, 0 otherwise
 // out_value: pointer to store the float value
-int cfpreferences_read_float(const char *domain, const char *key, double *out_value) {
+int cfpreferences_read_float(const char *domain, const char *key, double *out_value, int current_host) {
     CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
-    CFTypeRef value = CFPreferencesCopyAppValue(key_cf, domain_cf);
+    CFTypeRef value = copy_value(key_cf, domain_cf, current_host);
 
     CFRelease(key_cf);
     CFRelease(domain_cf);
@@ -192,11 +204,11 @@ int cfpreferences_read_float(const char *domain, const char *key, double *out_va
 // Returns: 1 if value exists and is string, 0 otherwise
 // buffer: buffer to store the string (must be pre-allocated)
 // buffer_size: size of the buffer
-int cfpreferences_read_string(const char *domain, const char *key, char *buffer, int buffer_size) {
+int cfpreferences_read_string(const char *domain, const char *key, char *buffer, int buffer_size, int current_host) {
     CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
-    CFTypeRef value = CFPreferencesCopyAppValue(key_cf, domain_cf);
+    CFTypeRef value = copy_value(key_cf, domain_cf, current_host);
 
     CFRelease(key_cf);
     CFRelease(domain_cf);
@@ -221,11 +233,11 @@ int cfpreferences_read_string(const char *domain, const char *key, char *buffer,
 
 // Check if a key exists
 // Returns: 1 if exists, 0 if not
-int cfpreferences_key_exists(const char *domain, const char *key) {
+int cfpreferences_key_exists(const char *domain, const char *key, int current_host) {
     CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
-    CFTypeRef value = CFPreferencesCopyAppValue(key_cf, domain_cf);
+    CFTypeRef value = copy_value(key_cf, domain_cf, current_host);
 
     CFRelease(key_cf);
     CFRelease(domain_cf);
@@ -239,12 +251,11 @@ int cfpreferences_key_exists(const char *domain, const char *key) {
 
 // Delete a key
 // Returns: 1 on success, 0 on failure
-int cfpreferences_delete_key(const char *domain, const char *key) {
+int cfpreferences_delete_key(const char *domain, const char *key, int current_host) {
     CFStringRef domain_cf = domain_ref(domain);
     CFStringRef key_cf = CFStringCreateWithCString(NULL, key, kCFStringEncodingUTF8);
 
-    CFPreferencesSetAppValue(key_cf, NULL, domain_cf);
-    Boolean sync_result = CFPreferencesAppSynchronize(domain_cf);
+    Boolean sync_result = set_value(key_cf, NULL, domain_cf, current_host);
 
     CFRelease(key_cf);
     CFRelease(domain_cf);

--- a/src/resources/macos_defaults.zig
+++ b/src/resources/macos_defaults.zig
@@ -20,21 +20,24 @@ const global_io = @import("../global_io.zig");
 // These functions bypass Zig's @cImport issues with CFPreferences API
 // ============================================================================
 
+// All wrappers take a trailing `current_host` flag: non-zero targets the
+// per-host domain (`defaults -currentHost`), zero the any-host domain.
+
 // Write operations
-extern "c" fn cfpreferences_write_boolean(domain: [*:0]const u8, key: [*:0]const u8, value: c_int) c_int;
-extern "c" fn cfpreferences_write_integer(domain: [*:0]const u8, key: [*:0]const u8, value: c_longlong) c_int;
-extern "c" fn cfpreferences_write_float(domain: [*:0]const u8, key: [*:0]const u8, value: f64) c_int;
-extern "c" fn cfpreferences_write_string(domain: [*:0]const u8, key: [*:0]const u8, value: [*:0]const u8) c_int;
+extern "c" fn cfpreferences_write_boolean(domain: [*:0]const u8, key: [*:0]const u8, value: c_int, current_host: c_int) c_int;
+extern "c" fn cfpreferences_write_integer(domain: [*:0]const u8, key: [*:0]const u8, value: c_longlong, current_host: c_int) c_int;
+extern "c" fn cfpreferences_write_float(domain: [*:0]const u8, key: [*:0]const u8, value: f64, current_host: c_int) c_int;
+extern "c" fn cfpreferences_write_string(domain: [*:0]const u8, key: [*:0]const u8, value: [*:0]const u8, current_host: c_int) c_int;
 
 // Read operations
-extern "c" fn cfpreferences_read_boolean(domain: [*:0]const u8, key: [*:0]const u8, out_value: *c_int) c_int;
-extern "c" fn cfpreferences_read_integer(domain: [*:0]const u8, key: [*:0]const u8, out_value: *c_longlong) c_int;
-extern "c" fn cfpreferences_read_float(domain: [*:0]const u8, key: [*:0]const u8, out_value: *f64) c_int;
-extern "c" fn cfpreferences_read_string(domain: [*:0]const u8, key: [*:0]const u8, buffer: [*]u8, buffer_size: c_int) c_int;
+extern "c" fn cfpreferences_read_boolean(domain: [*:0]const u8, key: [*:0]const u8, out_value: *c_int, current_host: c_int) c_int;
+extern "c" fn cfpreferences_read_integer(domain: [*:0]const u8, key: [*:0]const u8, out_value: *c_longlong, current_host: c_int) c_int;
+extern "c" fn cfpreferences_read_float(domain: [*:0]const u8, key: [*:0]const u8, out_value: *f64, current_host: c_int) c_int;
+extern "c" fn cfpreferences_read_string(domain: [*:0]const u8, key: [*:0]const u8, buffer: [*]u8, buffer_size: c_int, current_host: c_int) c_int;
 
 // Utility operations
-extern "c" fn cfpreferences_key_exists(domain: [*:0]const u8, key: [*:0]const u8) c_int;
-extern "c" fn cfpreferences_delete_key(domain: [*:0]const u8, key: [*:0]const u8) c_int;
+extern "c" fn cfpreferences_key_exists(domain: [*:0]const u8, key: [*:0]const u8, current_host: c_int) c_int;
+extern "c" fn cfpreferences_delete_key(domain: [*:0]const u8, key: [*:0]const u8, current_host: c_int) c_int;
 
 /// macOS defaults resource data structure
 pub const Resource = struct {
@@ -42,6 +45,8 @@ pub const Resource = struct {
     key: []const u8,
     value: Value,
     action: Action,
+    /// Target the per-host domain (`defaults -currentHost`) instead of the any-host domain
+    current_host: bool = false,
 
     // Common properties (guards, notifications, etc.)
     common: base.CommonProps,
@@ -93,7 +98,7 @@ pub const Resource = struct {
     }
 
     pub fn apply(self: Resource) !base.ApplyResult {
-        logger.debug("macos_defaults apply: domain={s}, key={s}, action={}", .{ self.domain, self.key, self.action });
+        logger.debug("macos_defaults apply: domain={s}, key={s}, action={}, current_host={}", .{ self.domain, self.key, self.action, self.current_host });
 
         // Log the desired value stored in the resource
         switch (self.value) {
@@ -134,11 +139,11 @@ pub const Resource = struct {
                 };
             },
             .delete => {
-                try applyDelete(self);
+                const was_updated = try applyDelete(self);
                 return base.ApplyResult{
-                    .was_updated = false,
+                    .was_updated = was_updated,
                     .action = action_name,
-                    .skip_reason = "up to date",
+                    .skip_reason = if (was_updated) null else "up to date",
                 };
             },
         }
@@ -151,7 +156,7 @@ pub const Resource = struct {
 
         // Step 1: Read current value
         const value_type = std.meta.activeTag(self.value);
-        const current_value = try readDefaultWithCWrapper(allocator, self.domain, self.key, value_type);
+        const current_value = try readDefaultWithCWrapper(allocator, self.domain, self.key, value_type, self.current_host);
         defer if (current_value) |val| {
             if (val == .string) allocator.free(val.string);
         };
@@ -173,7 +178,7 @@ pub const Resource = struct {
         }
 
         // Step 3: Write new value
-        try writeDefault(allocator, self.domain, self.key, self.value);
+        try writeDefault(allocator, self.domain, self.key, self.value, self.current_host);
 
         // Step 4: Restart application if needed
         try restartApplicationIfNeeded(allocator, self.domain);
@@ -234,21 +239,22 @@ pub const Resource = struct {
         io.sleep(.fromNanoseconds(500_000_000), .awake) catch {}; // 0.5 seconds
     }
 
-    fn applyDelete(self: Resource) !void {
-        var gpa = std.heap.DebugAllocator(.{}){};
-        defer _ = gpa.deinit();
-        const allocator = gpa.allocator();
+    /// Returns true when the key existed and was deleted
+    fn applyDelete(self: Resource) !bool {
+        var domain_buf: [256]u8 = undefined;
+        var key_buf: [256]u8 = undefined;
+        const domain_z = try std.fmt.bufPrintZ(&domain_buf, "{s}", .{self.domain});
+        const key_z = try std.fmt.bufPrintZ(&key_buf, "{s}", .{self.key});
+        const host: c_int = @intFromBool(self.current_host);
 
-        // Check if key exists
-        var current_value = readDefault(allocator, self.domain, self.key) catch null;
-        defer if (current_value) |*val| val.deinit(allocator);
-
-        if (current_value == null) {
-            return; // Already deleted
+        if (cfpreferences_key_exists(domain_z.ptr, key_z.ptr, host) == 0) {
+            return false; // Already deleted
         }
 
-        // Delete the key
-        try deleteDefault(allocator, self.domain, self.key);
+        if (cfpreferences_delete_key(domain_z.ptr, key_z.ptr, host) == 0) {
+            return error.PreferencesSyncFailed;
+        }
+        return true;
     }
 
     fn valuesEqual(allocator: std.mem.Allocator, a: *const Value, b: Value) bool {
@@ -399,36 +405,37 @@ pub const Resource = struct {
     }
 
     /// Read a preference value using C wrapper (bypasses Zig @cImport issues)
-    fn readDefaultWithCWrapper(allocator: std.mem.Allocator, domain: []const u8, key: []const u8, expected_type: std.meta.Tag(Value)) !?Value {
+    fn readDefaultWithCWrapper(allocator: std.mem.Allocator, domain: []const u8, key: []const u8, expected_type: std.meta.Tag(Value), current_host: bool) !?Value {
         // Create null-terminated strings for C
         var domain_buf: [256]u8 = undefined;
         var key_buf: [256]u8 = undefined;
         const domain_z = try std.fmt.bufPrintZ(&domain_buf, "{s}", .{domain});
         const key_z = try std.fmt.bufPrintZ(&key_buf, "{s}", .{key});
+        const host: c_int = @intFromBool(current_host);
 
         // Try to read based on expected type
         switch (expected_type) {
             .boolean => {
                 var out_value: c_int = 0;
-                const result = cfpreferences_read_boolean(domain_z.ptr, key_z.ptr, &out_value);
+                const result = cfpreferences_read_boolean(domain_z.ptr, key_z.ptr, &out_value, host);
                 if (result == 0) return null; // Key doesn't exist or wrong type
                 return Value{ .boolean = out_value != 0 };
             },
             .integer => {
                 var out_value: c_longlong = 0;
-                const result = cfpreferences_read_integer(domain_z.ptr, key_z.ptr, &out_value);
+                const result = cfpreferences_read_integer(domain_z.ptr, key_z.ptr, &out_value, host);
                 if (result == 0) return null;
                 return Value{ .integer = @intCast(out_value) };
             },
             .float => {
                 var out_value: f64 = 0;
-                const result = cfpreferences_read_float(domain_z.ptr, key_z.ptr, &out_value);
+                const result = cfpreferences_read_float(domain_z.ptr, key_z.ptr, &out_value, host);
                 if (result == 0) return null;
                 return Value{ .float = out_value };
             },
             .string => {
                 var buffer: [1024]u8 = undefined;
-                const result = cfpreferences_read_string(domain_z.ptr, key_z.ptr, &buffer, buffer.len);
+                const result = cfpreferences_read_string(domain_z.ptr, key_z.ptr, &buffer, buffer.len, host);
                 if (result == 0) return null;
                 const len = std.mem.indexOfScalar(u8, &buffer, 0) orelse buffer.len;
                 const str = try allocator.dupe(u8, buffer[0..len]);
@@ -438,22 +445,23 @@ pub const Resource = struct {
         }
     }
 
-    fn writeDefault(_: std.mem.Allocator, domain: []const u8, key: []const u8, value: Value) !void {
+    fn writeDefault(_: std.mem.Allocator, domain: []const u8, key: []const u8, value: Value, current_host: bool) !void {
         // Create null-terminated strings for C
         var domain_buf: [256]u8 = undefined;
         var key_buf: [256]u8 = undefined;
         const domain_z = try std.fmt.bufPrintZ(&domain_buf, "{s}", .{domain});
         const key_z = try std.fmt.bufPrintZ(&key_buf, "{s}", .{key});
+        const host: c_int = @intFromBool(current_host);
 
         // Call appropriate C wrapper based on value type
         const result = switch (value) {
-            .boolean => |b| cfpreferences_write_boolean(domain_z.ptr, key_z.ptr, if (b) 1 else 0),
-            .integer => |i| cfpreferences_write_integer(domain_z.ptr, key_z.ptr, @intCast(i)),
-            .float => |f| cfpreferences_write_float(domain_z.ptr, key_z.ptr, f),
+            .boolean => |b| cfpreferences_write_boolean(domain_z.ptr, key_z.ptr, if (b) 1 else 0, host),
+            .integer => |i| cfpreferences_write_integer(domain_z.ptr, key_z.ptr, @intCast(i), host),
+            .float => |f| cfpreferences_write_float(domain_z.ptr, key_z.ptr, f, host),
             .string => |s| blk: {
                 var value_buf: [1024]u8 = undefined;
                 const value_z = try std.fmt.bufPrintZ(&value_buf, "{s}", .{s});
-                break :blk cfpreferences_write_string(domain_z.ptr, key_z.ptr, value_z.ptr);
+                break :blk cfpreferences_write_string(domain_z.ptr, key_z.ptr, value_z.ptr, host);
             },
             else => return error.UnsupportedValueType,
         };
@@ -714,8 +722,9 @@ pub fn zigAddResource(
     var ignore_failure_val: mruby.mrb_value = undefined;
     var notifications_val: mruby.mrb_value = undefined;
     var subscriptions_val: mruby.mrb_value = undefined;
+    var current_host_val: mruby.mrb_value = mruby.mrb_nil_value();
 
-    // Format: SS|oooooAA
+    // Format: SS|oooooAAo
     // S: required string (domain)
     // S: required string (key)
     // |: optional args start
@@ -726,7 +735,9 @@ pub fn zigAddResource(
     // o: optional object (ignore_failure)
     // A: optional array (notifications)
     // A: optional array (subscriptions)
-    _ = mruby.mrb_get_args(mrb, "SS|oooooAA", &domain_val, &key_val, &value_val, &action_val, &only_if_val, &not_if_val, &ignore_failure_val, &notifications_val, &subscriptions_val);
+    // o: optional object (current_host)
+    _ = mruby.mrb_get_args(mrb, "SS|oooooAAo", &domain_val, &key_val, &value_val, &action_val, &only_if_val, &not_if_val, &ignore_failure_val, &notifications_val, &subscriptions_val, &current_host_val);
+    const current_host = mruby.mrb_test(current_host_val);
 
     // Extract domain and key
     const domain_cstr = mruby.mrb_str_to_cstr(mrb, domain_val);
@@ -785,6 +796,7 @@ pub fn zigAddResource(
         .key = key,
         .value = value,
         .action = action,
+        .current_host = current_host,
         .common = common,
     }) catch {
         allocator.free(domain);

--- a/src/resources/macos_defaults.zig
+++ b/src/resources/macos_defaults.zig
@@ -715,19 +715,18 @@ pub fn zigAddResource(
     var notifications_val: mruby.mrb_value = undefined;
     var subscriptions_val: mruby.mrb_value = undefined;
 
-    // Format: SS|Aoo|oooAA
+    // Format: SS|oooooAA
     // S: required string (domain)
     // S: required string (key)
     // |: optional args start
-    // A: optional array (value: [type, value])
+    // o: optional object (value: [type, value] array, or nil for delete)
     // o: optional object (action)
-    // |: optional args start
     // o: optional object (only_if)
     // o: optional object (not_if)
     // o: optional object (ignore_failure)
     // A: optional array (notifications)
     // A: optional array (subscriptions)
-    _ = mruby.mrb_get_args(mrb, "SS|Aoo|oooAA", &domain_val, &key_val, &value_val, &action_val, &only_if_val, &not_if_val, &ignore_failure_val, &notifications_val, &subscriptions_val);
+    _ = mruby.mrb_get_args(mrb, "SS|oooooAA", &domain_val, &key_val, &value_val, &action_val, &only_if_val, &not_if_val, &ignore_failure_val, &notifications_val, &subscriptions_val);
 
     // Extract domain and key
     const domain_cstr = mruby.mrb_str_to_cstr(mrb, domain_val);

--- a/src/resources/macos_defaults_resource.rb
+++ b/src/resources/macos_defaults_resource.rb
@@ -9,6 +9,7 @@ class MacOSDefaultsResource
     @value = nil
     @type = nil
     @global = false
+    @current_host = false
     @action = :write
     @only_if_proc = nil
     @not_if_proc = nil
@@ -72,7 +73,7 @@ class MacOSDefaultsResource
 
     action_arg = @action.to_s
 
-    ZigBackend.add_macos_defaults(@domain, @key, value_arg, action_arg, only_if_arg, not_if_arg, @ignore_failure, notifications_arg, subscriptions_arg)
+    ZigBackend.add_macos_defaults(@domain, @key, value_arg, action_arg, only_if_arg, not_if_arg, @ignore_failure, notifications_arg, subscriptions_arg, @current_host)
   end
 
   def domain(val)
@@ -81,6 +82,12 @@ class MacOSDefaultsResource
 
   def global(val)
     @global = val
+  end
+
+  # Write to the per-host domain (`defaults -currentHost`). Some keys, such as
+  # NSStatusItemSpacing on macOS 14+, are only honoured from there.
+  def current_host(val)
+    @current_host = val
   end
 
   def key(val)

--- a/src/resources/macos_defaults_resource.rb
+++ b/src/resources/macos_defaults_resource.rb
@@ -30,6 +30,11 @@ class MacOSDefaultsResource
       @domain = "NSGlobalDomain"
     end
 
+    # The write action needs something to write; only delete may omit value
+    if @action == :write && @value.nil?
+      raise "macos_defaults: 'value' is required for write action"
+    end
+
     # If the Zig backend for macos_defaults is not available (non-macOS build),
     # act as a no-op so DSL usage like `macos_defaults` does not crash.
     return unless ZigBackend.respond_to?(:add_macos_defaults)


### PR DESCRIPTION
## Summary

- **`current_host true`** on `macos_defaults` writes/reads/deletes the per-host domain (what `defaults -currentHost` targets). Keys such as `NSStatusItemSpacing` / `NSStatusItemSelectionPadding` are only honoured from there on macOS 14+.
- **Fix `global true`**: the literal string `NSGlobalDomain` was passed to CFPreferences as an application id, so every global setting landed in `~/Library/Preferences/NSGlobalDomain.plist` and never took effect. It is now mapped to `kCFPreferencesAnyApplication` (`.GlobalPreferences`) like the `defaults` tool does.
- **Fix `action :delete`**: the `mrb_get_args` spec declared the value argument as an Array, so passing `nil` for delete raised `nil cannot be converted to Array` before the resource was registered. Delete now goes through the same CFPreferences wrapper as write (previously it always used the current-host domain while writes used any-host) and reports `(updated)` when a key was actually removed.

```ruby
macos_defaults 'menu bar item spacing' do
  global true
  current_host true
  key 'NSStatusItemSpacing'
  value 6
end
```

## Test plan

- [x] `zig build`, `zig fmt --check src/`, `zig build test`
- [x] Provision script writing integer / string / boolean keys to `com.hola.test` (any-host and `current_host true`) and to `NSGlobalDomain` (both hosts); verified with `defaults read`, `defaults -currentHost read`, `defaults read -g` that each value landed only in the intended domain and nothing was written to `NSGlobalDomain.plist`
- [x] Re-run reports all resources `up to date`
- [x] Changed values (42→43, 7→8, string, true→false) are applied and read back
- [x] `action :delete` removes all four keys and reports `(updated)`, second run reports `up to date`

Note for existing users: a stray `~/Library/Preferences/NSGlobalDomain.plist` created by the old behaviour can be removed by hand.