### PR TITLE
fix(file): report deletions as updates

### DIFF
--- a/src/resources/file.zig
+++ b/src/resources/file.zig
@@ -64,11 +64,11 @@ pub const Resource = struct {
                 };
             },
             .delete => {
-                try applyDelete(self);
+                const was_deleted = try applyDelete(self);
                 return base.ApplyResult{
-                    .was_updated = false,
+                    .was_updated = was_deleted,
                     .action = action_name,
-                    .skip_reason = "up to date",
+                    .skip_reason = if (was_deleted) null else "up to date",
                 };
             },
             .touch => {
@@ -283,20 +283,21 @@ pub const Resource = struct {
         return true;
     }
 
-    fn applyDelete(self: Resource) !void {
+    fn applyDelete(self: Resource) !bool {
         const io = global_io.io();
         const is_abs = std.fs.path.isAbsolute(self.path);
         if (is_abs) {
             std.Io.Dir.deleteFileAbsolute(io, self.path) catch |err| switch (err) {
-                error.FileNotFound => return,
+                error.FileNotFound => return false,
                 else => return err,
             };
         } else {
             std.Io.Dir.cwd().deleteFile(io, self.path) catch |err| switch (err) {
-                error.FileNotFound => return,
+                error.FileNotFound => return false,
                 else => return err,
             };
         }
+        return true;
     }
 };
 

--- a/src/resources/remote_file.zig
+++ b/src/resources/remote_file.zig
@@ -146,11 +146,11 @@ pub const Resource = struct {
                 };
             },
             .delete => {
-                try applyDelete(self);
+                const was_deleted = try applyDelete(self);
                 return base.ApplyResult{
-                    .was_updated = false,
+                    .was_updated = was_deleted,
                     .action = action_name,
-                    .skip_reason = "up to date",
+                    .skip_reason = if (was_deleted) null else "up to date",
                 };
             },
             .touch => {
@@ -369,20 +369,21 @@ pub const Resource = struct {
         return false; // File was up to date
     }
 
-    fn applyDelete(self: Resource) !void {
+    fn applyDelete(self: Resource) !bool {
         const io = global_io.io();
         const is_abs = std.fs.path.isAbsolute(self.path);
         if (is_abs) {
             std.Io.Dir.deleteFileAbsolute(io, self.path) catch |err| switch (err) {
-                error.FileNotFound => return, // Already deleted, that's fine
+                error.FileNotFound => return false,
                 else => return err,
             };
         } else {
             std.Io.Dir.cwd().deleteFile(io, self.path) catch |err| switch (err) {
-                error.FileNotFound => return, // Already deleted, that's fine
+                error.FileNotFound => return false,
                 else => return err,
             };
         }
+        return true;
     }
 
     fn applyTouch(self: Resource) !void {

--- a/src/resources/template.zig
+++ b/src/resources/template.zig
@@ -77,11 +77,11 @@ pub const Resource = struct {
                 };
             },
             .delete => {
-                try applyDelete(self);
+                const was_deleted = try applyDelete(self);
                 return base.ApplyResult{
-                    .was_updated = false,
+                    .was_updated = was_deleted,
                     .action = action_name,
-                    .skip_reason = "up to date",
+                    .skip_reason = if (was_deleted) null else "up to date",
                 };
             },
         }
@@ -172,20 +172,21 @@ pub const Resource = struct {
         return true; // File was created or updated
     }
 
-    fn applyDelete(self: Resource) !void {
+    fn applyDelete(self: Resource) !bool {
         const io = global_io.io();
         const is_abs = std.fs.path.isAbsolute(self.path);
         if (is_abs) {
             std.Io.Dir.deleteFileAbsolute(io, self.path) catch |err| switch (err) {
-                error.FileNotFound => return,
+                error.FileNotFound => return false,
                 else => return err,
             };
         } else {
             std.Io.Dir.cwd().deleteFile(io, self.path) catch |err| switch (err) {
-                error.FileNotFound => return,
+                error.FileNotFound => return false,
                 else => return err,
             };
         }
+        return true;
     }
 
     fn readTemplateFile(source: []const u8) ![]u8 {


### PR DESCRIPTION
The delete action of file, template and remote_file always returned
was_updated = false with skip_reason "up to date", even when it had just
removed the file. Converge output claimed nothing happened, and the
notification gate in provision.zig — which skips resources whose
skip_reason is "up to date" — never fired for a deletion.

applyDelete now reports whether it removed anything.