### PR TITLE
fix(remote_file): validate the predownload cache before using it

### DIFF
--- a/src/provision.zig
+++ b/src/provision.zig
@@ -261,6 +261,10 @@ pub const ProvisionRunner = struct {
             base.recordProvisionErrorDetailSlice(msg);
             return error.DownloadFailed;
         }
+        if (task.status.load(.acquire) != .completed) {
+            base.recordProvisionErrorDetail("Download timed out for {s}", .{resource_id});
+            return error.DownloadTimeout;
+        }
     }
 
     fn applyOne(self: *ProvisionRunner, index: usize, immediate: *std.ArrayList(PendingNotification)) !void {
@@ -1774,6 +1778,8 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
     };
     var download_mgr = try http.download.Manager.init(allocator, download_config);
     defer download_mgr.deinit();
+    download_mgr.setCurrent();
+    defer http.download.Manager.clearCurrent();
 
     // Set up progress callback for display
     const ProgressContext = struct {
@@ -1862,6 +1868,7 @@ pub fn run(allocator: std.mem.Allocator, opts: Options) !ProvisionResult {
             const xdg_instance = @import("xdg.zig").XDG.init(allocator);
             const temp_dir = try xdg_instance.getDownloadsDir();
             defer allocator.free(temp_dir);
+            try std.Io.Dir.cwd().createDirPath(global_io.io(), temp_dir);
 
             // Generate temporary file path with slugified path
             const temp_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ temp_dir, path_slug });

--- a/src/resources/remote_file.zig
+++ b/src/resources/remote_file.zig
@@ -4,7 +4,6 @@ const base = @import("../base_resource.zig");
 const http = @import("../http.zig");
 const logger = @import("../logger.zig");
 const json_helpers = @import("../json.zig");
-const xdg_mod = @import("../xdg.zig");
 const AsyncExecutor = @import("../async_executor.zig").AsyncExecutor;
 const global_io = @import("../global_io.zig");
 
@@ -203,12 +202,17 @@ pub const Resource = struct {
         const predownloaded_path = if (self.use_etag)
             null
         else
-            findPreDownloadedFile(self.path, allocator) catch |err| switch (err) {
+            self.findPreDownloadedFile(allocator) catch |err| switch (err) {
                 error.FileNotFound => null,
                 else => return err,
             };
 
         if (predownloaded_path) |temp_path| {
+            defer allocator.free(temp_path);
+            // A cache entry is not proof that the requested content is valid.
+            if (self.checksum) |expected_checksum| {
+                try http.download.downloader.verifyChecksum(allocator, temp_path, expected_checksum);
+            }
             // Use pre-downloaded file
             // Create backup if specified
             if (self.backup) |backup_ext| {
@@ -226,9 +230,6 @@ pub const Resource = struct {
             base.applyFileAttributes(self.path, self.attrs) catch |err| {
                 logger.warn("Failed to apply file attributes for {s}: {}", .{ self.path, err });
             };
-
-            // Clean up the temp path string
-            allocator.free(temp_path);
         } else {
             // File not pre-downloaded (likely has conditions)
             // Download directly (conditional downloads are not batched)
@@ -324,20 +325,15 @@ pub const Resource = struct {
         return true; // File was downloaded/updated
     }
 
-    /// Find a pre-downloaded file by matching the slugified final path
-    fn findPreDownloadedFile(final_path: []const u8, allocator: std.mem.Allocator) !?[]const u8 {
+    /// Only consume completed downloads belonging to this provisioning run.
+    fn findPreDownloadedFile(self: Resource, allocator: std.mem.Allocator) !?[]const u8 {
         const io = global_io.io();
-        // Get the download temp directory
-        const xdg_instance = xdg_mod.XDG.init(allocator);
-        const temp_dir = try xdg_instance.getDownloadsDir();
-        defer allocator.free(temp_dir);
-
-        // Slugify the final path to match the naming scheme in provision.zig
-        const path_slug = try http.slugifyPath(allocator, final_path);
-        defer allocator.free(path_slug);
-
-        // Expected filename is just the slugified path (no prefix needed)
-        const file_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ temp_dir, path_slug });
+        const manager = http.download.Manager.getCurrent() orelse return null;
+        const resource_id = try std.fmt.allocPrint(allocator, "remote_file[{s}]", .{self.path});
+        defer allocator.free(resource_id);
+        const task = manager.getTask(resource_id) orelse return null;
+        if (task.status.load(.acquire) != .completed or !std.mem.eql(u8, task.url, self.source)) return null;
+        const file_path = try allocator.dupe(u8, task.temp_path);
 
         // Check if file exists
         std.Io.Dir.cwd().access(io, file_path, .{}) catch |err| switch (err) {


### PR DESCRIPTION
findPreDownloadedFile located a batch download by slugifying the
destination path and probing the shared downloads directory. Any file
left there by an earlier run matched, so a resource could install
content it never downloaded — stale content for a source URL that had
since changed, or the partial output of a download that failed or was
still in flight.

Look the task up in the download manager instead, and use its temp file
only when the task has completed and its URL still matches the
resource's source. Verify the checksum on this path too; it previously
ran only for direct downloads.

Along the way: create the downloads directory before writing into it,
free the temp path on every exit rather than only on the success path,
and fail waitForDownload when a task is neither failed nor completed
instead of treating a timeout as success.