### PR TITLE
fix(notify): accept :immediately as a timing alias

### DIFF
--- a/src/base_resource.zig
+++ b/src/base_resource.zig
@@ -669,7 +669,7 @@ pub fn fillCommonFromRuby(
             };
             const timing_str = std.mem.span(timing_cstr);
 
-            const timing: notification.Timing = if (std.mem.eql(u8, timing_str, "immediate"))
+            const timing: notification.Timing = if (std.mem.eql(u8, timing_str, "immediate") or std.mem.eql(u8, timing_str, "immediately"))
                 .immediate
             else
                 .delayed;
@@ -715,7 +715,7 @@ pub fn fillCommonFromRuby(
             };
             const timing_str = std.mem.span(timing_cstr);
 
-            const timing: notification.Timing = if (std.mem.eql(u8, timing_str, "immediate"))
+            const timing: notification.Timing = if (std.mem.eql(u8, timing_str, "immediate") or std.mem.eql(u8, timing_str, "immediately"))
                 .immediate
             else
                 .delayed;

--- a/src/provision.zig
+++ b/src/provision.zig
@@ -2309,6 +2309,35 @@ test "convergeFrom applies and records results once" {
     try std.testing.expectEqual(@as(usize, 1), session.runner.resource_results.items.len);
 }
 
+test "notifies accepts both spellings of the immediate timing" {
+    const allocator = std.testing.allocator;
+    json.setAllocator(allocator);
+    const session = try Session.open(allocator, .{});
+    defer session.close();
+    try session.evalString(
+        \\ruby_block 'immediately' do
+        \\  block {}
+        \\  notifies :run, 'ruby_block[target]', :immediately
+        \\end
+        \\ruby_block 'immediate' do
+        \\  block {}
+        \\  notifies :run, 'ruby_block[target]', :immediate
+        \\end
+        \\ruby_block 'default' do
+        \\  block {}
+        \\  notifies :run, 'ruby_block[target]'
+        \\end
+    );
+
+    try std.testing.expectEqual(@as(usize, 3), session.runner.resources.items.len);
+    const timings = [_]resources.NotificationTiming{ .immediate, .immediate, .delayed };
+    for (timings, 0..) |expected, index| {
+        const notifications = session.runner.resources.items[index].notifications;
+        try std.testing.expectEqual(@as(usize, 1), notifications.items.len);
+        try std.testing.expectEqual(expected, notifications.items[0].timing);
+    }
+}
+
 test "task prelude supports common Rake task semantics" {
     var mrb_state = try mruby.State.init();
     defer mrb_state.deinit();


### PR DESCRIPTION
Chef spells the immediate timing `:immediately`; hola only matched
"immediate", so `notifies :restart, 'service[x]', :immediately` was
silently downgraded to a delayed notification. Accept both spellings in
the notifies and subscribes parsers.